### PR TITLE
Feature: Added runtime editable script fields to editor

### DIFF
--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -24,25 +24,45 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <sstream>
+#include <vector>
 
 namespace {
     template<typename Owner, typename T>
     bool DrawField(const NE::Core::FieldDescriptor<Owner, T>& desc, T& value) {
         if constexpr (std::is_same_v<T, bool>) {
             return ImGui::Checkbox(desc.name.data(), &value);
-        } else if constexpr (std::is_same_v<T, int>) {
+        }
+        else if constexpr (std::is_same_v<T, int>) {
             return ImGui::DragInt(desc.name.data(), &value);
-        } else if constexpr (std::is_same_v<T, float>) {
+        }
+        else if constexpr (std::is_same_v<T, float>) {
             return ImGui::DragFloat(desc.name.data(), &value, 0.1f);
-        } else if constexpr (std::is_same_v<T, NE::Math::Vec3>) {
+        }
+        else if constexpr (std::is_same_v<T, NE::Math::Vec3>) {
             ImGui::BeginGroup();
             bool changed = Editor::DrawVec3Control(desc.name.data(), value, 0.0f, 75.0f);
             ImGui::EndGroup();
             return changed;
-        } else {
+        }
+        else {
             ImGui::Text("%s (unsupported)", desc.name.data());
             return false;
         }
+    }
+
+    // Helpers for scripting field parsing/formatting
+    static NE::Math::Vec3 Vec3FromString(const std::string& s) {
+        NE::Math::Vec3 v{ 0.f,0.f,0.f };
+        std::istringstream iss(s);
+        iss >> v.x >> v.y >> v.z;
+        return v;
+    }
+    static std::string Vec3ToString(const NE::Math::Vec3& v) {
+        std::ostringstream oss;
+        oss << v.x << ' ' << v.y << ' ' << v.z;
+        return oss.str();
     }
 
     template <typename Owner, typename T>
@@ -55,18 +75,23 @@ namespace {
         auto getter = [=](uint32_t e) -> Owner& {
             if constexpr (std::is_same_v<Owner, NE::ECS::Component::Transform>) {
                 return NE::ECS::Command::GetEntityTransform(e);
-            } else if constexpr (std::is_same_v<Owner, NE::ECS::Component::Collider>) {
+            }
+            else if constexpr (std::is_same_v<Owner, NE::ECS::Component::Collider>) {
                 return NE::ECS::Command::GetEntityCollider(e);
-            } else if constexpr (std::is_same_v<Owner, NE::ECS::Component::Rigidbody>) {
+            }
+            else if constexpr (std::is_same_v<Owner, NE::ECS::Component::Rigidbody>) {
                 return NE::ECS::Command::GetEntityRigidbody(e);
-            } else if constexpr (std::is_same_v<Owner, NE::ECS::Component::Renderer>) {
+            }
+            else if constexpr (std::is_same_v<Owner, NE::ECS::Component::Renderer>) {
                 return NE::ECS::Command::GetEntityRenderer(e);
-            } else if constexpr (std::is_same_v<Owner, NE::ECS::Component::Light>) {
+            }
+            else if constexpr (std::is_same_v<Owner, NE::ECS::Component::Light>) {
                 return NE::ECS::Command::GetEntityLight(e);
-            } else {
+            }
+            else {
                 static_assert(sizeof(Owner) == 0, "No getter defined for this component type.");
             }
-        };
+            };
 
         auto cmd = std::make_unique<Cmd>(entity,
             std::string(desc.name),
@@ -114,7 +139,8 @@ namespace {
     static bool Equal(const T& a, const T& b) {
         if constexpr (std::is_floating_point_v<T>) {
             return std::fabs(a - b) <= 1e-6f;
-        } else {
+        }
+        else {
             return a == b;
         }
     }
@@ -308,7 +334,8 @@ namespace Editor {
                                     auto* asSet = dynamic_cast<Editor::SetFieldCommand<Owner, FieldT>*>(it->second.get());
                                     if (asSet && Equal(asSet->Before(), asSet->After())) {
                                         g_activeCommands.erase(it);
-                                    } else {
+                                    }
+                                    else {
                                         Editor::CommandHistory::GetInstance()
                                             .ExecuteCommand(std::move(it->second));
                                         g_activeCommands.erase(it);
@@ -317,7 +344,8 @@ namespace Editor {
                             }
                         });
 
-                } else if (typeIdx == typeid(NE::ECS::Component::Renderer)) {
+                }
+                else if (typeIdx == typeid(NE::ECS::Component::Renderer)) {
                     auto& comp = NE::ECS::Query::GetEntityRenderer(entity);
                     ImGui::SeparatorText("Renderer");
                     //char buf[256]; 
@@ -328,15 +356,15 @@ namespace Editor {
                     DrawAssetField("Model", comp.modelPath.string(), "+", 0.f, &openPopup);
                     if (openPopup) {
                         ImGui::OpenPopup("AssetPicker_Model");
-					}
+                    }
 
                     if (ImGui::BeginDragDropTarget()) {
                         if (const ImGuiPayload* p = ImGui::AcceptDragDropPayload("ASSET_PATH")) {
                             std::string dropped((const char*)p->Data, p->DataSize - 1);
 
-							if (comp.materialPath.empty()) { // If material is not set, assign a default one
+                            if (comp.materialPath.empty()) { // If material is not set, assign a default one
                                 //AssignRendererMaterial(comp, "Assets/Basic.nanomat");
-							} // done for rapid prototyping, should be removed later
+                            } // done for rapid prototyping, should be removed later
 
                             //AssignRendererModel(comp, dropped);
                         }
@@ -359,7 +387,7 @@ namespace Editor {
                                             NE::Renderer::Command::AssignModel(entity, name); // need to add undo redo
                                             ImGui::CloseCurrentPopup();
                                         }
-									});
+                                    });
                             }
 
                             ImSearch::EndSearch();
@@ -367,7 +395,7 @@ namespace Editor {
                         ImGui::EndPopup();
                     }
 
-                    char bufMat[256]; 
+                    char bufMat[256];
                     strncpy_s(bufMat, comp.materialPath.string().c_str(), sizeof(bufMat));
                     ImGui::InputText("Material", bufMat, sizeof(bufMat));
 
@@ -379,7 +407,8 @@ namespace Editor {
                         }
                         ImGui::EndDragDropTarget();
                     }
-                } else if (typeIdx == typeid(NE::ECS::Component::Light)) {
+                }
+                else if (typeIdx == typeid(NE::ECS::Component::Light)) {
                     auto& comp = NE::ECS::Query::GetEntityLight(entity);
                     ImGui::SeparatorText("Light");
 
@@ -392,7 +421,8 @@ namespace Editor {
                     //NE::Core::ForEachFieldView<NE::ECS::Component::Light>(comp, [](auto&& desc, auto& field) {
                     //    DrawField(desc, field);
                     //    });
-                } else if (typeIdx == typeid(NE::ECS::Component::Collider)) {
+                }
+                else if (typeIdx == typeid(NE::ECS::Component::Collider)) {
                     auto& comp = NE::ECS::Query::GetEntityCollider(entity);
                     ImGui::SeparatorText("Collider");
                     NE::Core::ForEachFieldView<NE::ECS::Component::Collider>(comp,
@@ -408,7 +438,8 @@ namespace Editor {
                                 //SubmitSetFieldCommand(entity, desc, edited);
                             }
                         });
-                } else if (typeIdx == typeid(NE::ECS::Component::Rigidbody)) {
+                }
+                else if (typeIdx == typeid(NE::ECS::Component::Rigidbody)) {
                     auto& comp = NE::ECS::Query::GetEntityRigidbody(entity);
                     ImGui::SeparatorText("Rigidbody");
                     NE::Core::ForEachFieldView<NE::ECS::Component::Rigidbody>(comp,
@@ -424,22 +455,23 @@ namespace Editor {
                                 //SubmitSetFieldCommand(entity, desc, edited);
                             }
                         });
-                } else if (typeIdx == typeid(NE::ECS::Component::NativeScript)) {
+                }
+                else if (typeIdx == typeid(NE::ECS::Component::NativeScript)) {
                     auto& comp = NE::ECS::Query::GetEntityScript(entity);
                     ImGui::SeparatorText("Script");
 
                     // Display current script name or "None"
                     std::string currentScript = comp.ScriptName.empty() ? "None" : comp.ScriptName;
-                    
+
                     ImGui::Text("Current Script: %s", currentScript.c_str());
-                    
+
                     // Script selection dropdown
                     if (ImGui::BeginCombo("Script Type", currentScript.c_str())) {
                         // "None" option to remove script
                         if (ImGui::Selectable("None", comp.ScriptName.empty())) {
                             NE::ECS::Command::RemoveEntityScript(entity);
                         }
-                        
+
                         // List all registered scripts
                         auto scriptNames = NE::ECS::Command::GetRegisteredScriptNames();
                         for (const auto& scriptName : scriptNames) {
@@ -457,20 +489,68 @@ namespace Editor {
                     // Display script status
                     if (!comp.ScriptName.empty()) {
                         ImGui::Separator();
-                        
+
                         // Script enabled/disabled checkbox
                         if (comp.Instance) {
                             bool enabled = comp.Instance->IsEnabled();
                             if (ImGui::Checkbox("Enabled", &enabled)) {
                                 comp.Instance->SetEnabled(enabled);
                             }
-                            
+
                             ImGui::Text("Status: Active");
                             ImGui::Text("Entity ID: %u", comp.Instance->GetEntity());
-                        } else {
+
+                            // --- Scripting Fields UI ---
+                            auto fieldNames = comp.Instance->GetExposedFieldNames();
+                            if (!fieldNames.empty()) {
+                                ImGui::SeparatorText("Script Fields");
+                                for (const auto& fname : fieldNames) {
+                                    std::string ftype = comp.Instance->GetFieldType(fname);
+                                    std::string fval = comp.Instance->GetFieldValueAsString(fname);
+
+                                    ImGui::PushID(fname.c_str());
+
+                                    if (ftype == "bool") {
+                                        bool v = (fval == "1" || fval == "true");
+                                        if (ImGui::Checkbox(fname.c_str(), &v)) {
+                                            comp.Instance->SetFieldValueFromString(fname, v ? "1" : "0");
+                                        }
+                                    }
+                                    else if (ftype == "int") {
+                                        int v = 0; if (!fval.empty()) v = std::stoi(fval);
+                                        if (ImGui::DragInt(fname.c_str(), &v)) {
+                                            comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
+                                        }
+                                    }
+                                    else if (ftype == "float") {
+                                        float v = 0.f; if (!fval.empty()) v = std::stof(fval);
+                                        if (ImGui::DragFloat(fname.c_str(), &v, 0.01f)) {
+                                            comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
+                                        }
+                                    }
+                                    else if (ftype == "vec3") {
+                                        NE::Math::Vec3 vv = Vec3FromString(fval);
+                                        if (Editor::DrawVec3Control(fname.c_str(), vv, 0.0f, 100.0f)) {
+                                            comp.Instance->SetFieldValueFromString(fname, Vec3ToString(vv));
+                                        }
+                                    }
+                                    else { // treat as string
+                                        char buf[256];
+                                        strncpy_s(buf, fval.c_str(), sizeof(buf));
+                                        if (ImGui::InputText(fname.c_str(), buf, sizeof(buf))) {
+                                            comp.Instance->SetFieldValueFromString(fname, std::string(buf));
+                                        }
+                                    }
+
+                                    ImGui::PopID();
+                                }
+                            }
+
+                        }
+                        else {
                             ImGui::Text("Status: Not Instantiated");
                         }
-                        
+
                         // Show if script is properly registered
                         bool isRegistered = NE::ECS::Command::IsScriptRegistered(comp.ScriptName);
                         if (!isRegistered) {
@@ -504,12 +584,14 @@ namespace Editor {
                 ImGui::EndPopup();
             }
 
-        } else if (EditorScene::selectedMaterial != "") {
+        }
+        else if (EditorScene::selectedMaterial != "") {
             if (m_loadedPath != EditorScene::selectedMaterial) {
                 try {
-					//m_loadedMaterial = GetMaterial(EditorScene::selectedMaterial);
+                    //m_loadedMaterial = GetMaterial(EditorScene::selectedMaterial);
                     m_loadedPath = EditorScene::selectedMaterial;
-                } catch (...) {
+                }
+                catch (...) {
                     m_loadedMaterial.reset();
                     m_loadedPath.clear();
                 }
@@ -534,7 +616,7 @@ namespace Editor {
 
                 for (auto& [name, val] : m_loadedMaterial->GetIntUniforms()) {
                     int i = val;
-					Editor::DrawIntControl(name.c_str(), i);
+                    Editor::DrawIntControl(name.c_str(), i);
                     if (ImGui::DragInt(name.c_str(), &i)) {
                         m_loadedMaterial->SetUniformInt(name, i);
                     }

--- a/GameCode/ExposedFieldRegistry.hpp
+++ b/GameCode/ExposedFieldRegistry.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <functional>
+#include <sstream>
+#include <Math/Vec3.hpp>
+#include <type_traits>
+
+// Lightweight helper to register exposed fields in game scripts and
+// provide string-based get/set that the Editor uses.
+struct ExposedFieldRegistry {
+    struct Entry {
+        std::string typeToken;
+        std::function<std::string()> getStr;
+        std::function<bool(const std::string&)> setStr;
+    };
+
+    // Register helpers - accept any callable for getter/setter and wrap conversions
+    template<typename Getter, typename Setter>
+    void RegisterFloat(const std::string& name, Getter getter, Setter setter) {
+        Entry e;
+        e.typeToken = "float";
+        e.getStr = [getter]() { return std::to_string(getter()); };
+        e.setStr = [setter](const std::string& s) {
+            try { setter(std::stof(s)); return true; }
+            catch (...) { return false; }
+            };
+        m_entries[name] = std::move(e);
+    }
+
+    template<typename Getter, typename Setter>
+    void RegisterInt(const std::string& name, Getter getter, Setter setter) {
+        Entry e;
+        e.typeToken = "int";
+        e.getStr = [getter]() { return std::to_string(getter()); };
+        e.setStr = [setter](const std::string& s) {
+            try { setter(std::stoi(s)); return true; }
+            catch (...) { return false; }
+            };
+        m_entries[name] = std::move(e);
+    }
+
+    template<typename Getter, typename Setter>
+    void RegisterBool(const std::string& name, Getter getter, Setter setter) {
+        Entry e;
+        e.typeToken = "bool";
+        e.getStr = [getter]() { return getter() ? std::string("1") : std::string("0"); };
+        e.setStr = [setter](const std::string& s) {
+            if (s == "1" || s == "true") { setter(true); return true; }
+            if (s == "0" || s == "false") { setter(false); return true; }
+            return false;
+            };
+        m_entries[name] = std::move(e);
+    }
+
+    template<typename Getter, typename Setter>
+    void RegisterVec3(const std::string& name, Getter getter, Setter setter) {
+        Entry e;
+        e.typeToken = "vec3";
+        e.getStr = [getter]() {
+            auto v = getter();
+            std::ostringstream oss; oss << v.x << ' ' << v.y << ' ' << v.z; return oss.str();
+            };
+        e.setStr = [setter](const std::string& s) {
+            try {
+                std::istringstream iss(s);
+                NE::Math::Vec3 v; if (!(iss >> v.x >> v.y >> v.z)) return false; setter(v); return true;
+            }
+            catch (...) { return false; }
+            };
+        m_entries[name] = std::move(e);
+    }
+
+    template<typename Getter, typename Setter>
+    void RegisterString(const std::string& name, Getter getter, Setter setter) {
+        Entry e;
+        e.typeToken = "string";
+        e.getStr = [getter]() { return getter(); };
+        e.setStr = [setter](const std::string& s) { try { setter(s); return true; } catch (...) { return false; } };
+        m_entries[name] = std::move(e);
+    }
+
+    // Convenience overloads: register a member pointer directly (no lambdas required)
+    template<typename Owner>
+    void RegisterMember(const std::string& name, Owner* obj, float Owner::* member) {
+        RegisterFloat(name,
+            [obj, member]() -> float { return obj->*member; },
+            [obj, member](float v) { obj->*member = v; });
+    }
+
+    template<typename Owner>
+    void RegisterMember(const std::string& name, Owner* obj, int Owner::* member) {
+        RegisterInt(name,
+            [obj, member]() -> int { return obj->*member; },
+            [obj, member](int v) { obj->*member = v; });
+    }
+
+    template<typename Owner>
+    void RegisterMember(const std::string& name, Owner* obj, bool Owner::* member) {
+        RegisterBool(name,
+            [obj, member]() -> bool { return obj->*member; },
+            [obj, member](bool v) { obj->*member = v; });
+    }
+
+    template<typename Owner>
+    void RegisterMember(const std::string& name, Owner* obj, std::string Owner::* member) {
+        RegisterString(name,
+            [obj, member]() -> std::string { return obj->*member; },
+            [obj, member](const std::string& s) { obj->*member = s; });
+    }
+
+    template<typename Owner>
+    void RegisterMember(const std::string& name, Owner* obj, NE::Math::Vec3 Owner::* member) {
+        RegisterVec3(name,
+            [obj, member]() -> NE::Math::Vec3 { return obj->*member; },
+            [obj, member](NE::Math::Vec3 v) { obj->*member = v; });
+    }
+
+    std::vector<std::string> GetNames() const {
+        std::vector<std::string> out; out.reserve(m_entries.size());
+        for (auto const& kv : m_entries) out.push_back(kv.first);
+        return out;
+    }
+
+    std::string GetType(const std::string& name) const {
+        auto it = m_entries.find(name);
+        return it != m_entries.end() ? it->second.typeToken : std::string();
+    }
+
+    std::string GetValue(const std::string& name) const {
+        auto it = m_entries.find(name);
+        return it != m_entries.end() ? it->second.getStr() : std::string();
+    }
+
+    bool SetValue(const std::string& name, const std::string& s) {
+        auto it = m_entries.find(name);
+        return it != m_entries.end() ? it->second.setStr(s) : false;
+    }
+
+private:
+    std::unordered_map<std::string, Entry> m_entries;
+};
+
+// Macro to auto-register a member within a script's constructor
+#ifndef REGISTER_FIELD
+#define REGISTER_FIELD(member) m_fields.RegisterMember(#member, this, &std::remove_reference_t<decltype(*this)>::member)
+#endif

--- a/GameCode/PlayerScript.hpp
+++ b/GameCode/PlayerScript.hpp
@@ -1,16 +1,30 @@
 #pragma once
 
 #include "Scripting/IScript.hpp"
+#include "ExposedFieldRegistry.hpp"
 #include <iostream>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <Math/Vec3.hpp>
 
 /**
  * Example player script demonstrating how to implement IScript.
  * This would be part of your Game DLL project.
+ * Example player script demonstrating how to implement IScript and expose editable fields
+ * to the editor via ExposedFieldRegistry helper.
  */
 class PlayerScript : public IScript {
 
 public:
     PlayerScript() {
+        // register fields with the helper (macro convenience)
+        REGISTER_FIELD(speed);
+        REGISTER_FIELD(color);
+        REGISTER_FIELD(lives);
+        REGISTER_FIELD(godMode);
+        REGISTER_FIELD(label);
+
         LogMessage("PlayerScript created");
     }
     
@@ -80,9 +94,25 @@ public:
         LogMessage("PlayerScript trigger exit with entity " + std::to_string(other));
     }
 
+    // === Exposed editable fields via registry ===
+    std::vector<std::string> GetExposedFieldNames() const override { return m_fields.GetNames(); }
+    std::string GetFieldType(const std::string& name) const override { return m_fields.GetType(name); }
+    std::string GetFieldValueAsString(const std::string& name) const override { return m_fields.GetValue(name); }
+    bool SetFieldValueFromString(const std::string& name, const std::string& value) override { return m_fields.SetValue(name, value); }
+
 private:
     double m_timeSinceLastLog = 0.0;
     static constexpr double LOG_INTERVAL = 2.0; // Log every 2 seconds
+
+    // Editable fields
+    float speed = 5.0f;
+    NE::Math::Vec3 color{1.0f, 0.5f, 0.25f};
+    int lives = 3;
+    bool godMode = false;
+    std::string label = "Player";
+
+    // Field registry
+    ExposedFieldRegistry m_fields;
 
     // Helper methods
     void LogMessage(const std::string& message) const {

--- a/NANOEngine/src/Scripting/IScript.hpp
+++ b/NANOEngine/src/Scripting/IScript.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 // Export macros for when Engine is built as DLL
 #ifdef NANOENGINE_EXPORTS
 #define ENGINE_API __declspec(dllexport)
@@ -125,6 +128,31 @@ public:
      * @param entity The entity ID
      */
     void SetEntity(NE::ECS::Entity entity) { m_entity = entity; }
+
+    // === Runtime editable scripting fields support ===
+    // Scripts that want to expose editable fields to the editor can override
+    // these methods. We keep the API string-based to avoid reflection across DLLs.
+
+    /**
+     * Return a list of exposed field names.
+     */
+    virtual std::vector<std::string> GetExposedFieldNames() const { return {}; }
+
+    /**
+     * Return the type token for a named field. Example tokens: "bool","int","float","vec3","string"
+     */
+    virtual std::string GetFieldType(const std::string& name) const { (void)name; return std::string(); }
+
+    /**
+     * Get the current field value as a string. The format for complex types (eg vec3) is up to the script,
+     * but the Editor will use a simple whitespace-separated list for vec3: "x y z".
+     */
+    virtual std::string GetFieldValueAsString(const std::string& name) const { (void)name; return std::string(); }
+
+    /**
+     * Set the field value from a string. Return true if successful.
+     */
+    virtual bool SetFieldValueFromString(const std::string& name, const std::string& value) { (void)name; (void)value; return false; }
 
 private:
     NE::ECS::Entity m_entity = 0;


### PR DESCRIPTION
Introduces ExposedFieldRegistry for registering and managing editable script fields. Updates IScript interface to support string-based field get/set for editor integration. PlayerScript now demonstrates field exposure and registration. InspectorPanel updated to display and edit script fields in the editor UI.

Note: Spdlogger still not done?