### PR TITLE
Add Unity-style helper functions to IScript

### DIFF
--- a/GameCode/PlayerScript.hpp
+++ b/GameCode/PlayerScript.hpp
@@ -53,20 +53,17 @@ public:
             m_timeSinceLastLog = 0.0;
         }
 
-		// Example movement logic:
-		auto transform = GetComponent<NE::ECS::Component::Transform>();
-        if (transform) {
-
-            if(NE::InputManager::IsKeyDown('D'))
-			    transform->position.x += 0.2f * (float)deltaTime;
-			else if (NE::InputManager::IsKeyDown('A'))
-				transform->position.x -= 0.2f * (float)deltaTime;
-			else if (NE::InputManager::IsKeyDown('W'))
-				transform->position.y += 0.2f * (float)deltaTime;
-			else if (NE::InputManager::IsKeyDown('S'))
-				transform->position.y -= 0.2f * (float)deltaTime;
+        // Unity-style movement with helper functions
+        float moveSpeed = speed * (float)deltaTime;
         
-        }
+        if(NE::InputManager::IsKeyDown('D'))
+            Translate(moveSpeed, 0, 0);
+        else if (NE::InputManager::IsKeyDown('A'))
+            Translate(-moveSpeed, 0, 0);
+        else if (NE::InputManager::IsKeyDown('W'))
+            Translate(0, moveSpeed, 0);
+        else if (NE::InputManager::IsKeyDown('S'))
+            Translate(0, -moveSpeed, 0);
     }
 
     void OnDestroy() override {

--- a/NANOEngine/src/Scripting/IScript.cpp
+++ b/NANOEngine/src/Scripting/IScript.cpp
@@ -1,4 +1,7 @@
 #include "IScript.hpp" 
+#include "../ECS/Components/Transform.hpp"
+#include "../ECS/Components/Rigidbody.hpp"
+#include "../ECS/Components/AudioSource.hpp"
 
 NE::ECS::Entity IScript::GetEntity() const {
     return m_entity;
@@ -8,4 +11,287 @@ IScript::~IScript() = default;
 
 void IScript::LinkToEngine(NE::ECS::ComponentManager* componentManager) {
     m_componentManager = componentManager;
+}
+
+// === Transform Helper Functions ===
+
+NE::Math::Vec3 IScript::GetPosition() const {
+    if (!m_componentManager) return NE::Math::Vec3{0, 0, 0};
+    
+  if (!m_componentManager->HasComponent<NE::ECS::Component::Transform>(m_entity))
+        return NE::Math::Vec3{0, 0, 0};
+    
+    return m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity).position;
+}
+
+void IScript::SetPosition(const NE::Math::Vec3& pos) {
+    if (!m_componentManager) return;
+    
+  if (m_componentManager->HasComponent<NE::ECS::Component::Transform>(m_entity)) {
+     auto& transform = m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity);
+        transform.position = pos;
+      transform.isDirty = true;
+    }
+}
+
+void IScript::SetPosition(float x, float y, float z) {
+    SetPosition(NE::Math::Vec3{x, y, z});
+}
+
+NE::Math::Vec3 IScript::GetRotation() const {
+    if (!m_componentManager) return NE::Math::Vec3{0, 0, 0};
+    
+    if (!m_componentManager->HasComponent<NE::ECS::Component::Transform>(m_entity))
+        return NE::Math::Vec3{0, 0, 0};
+    
+    return m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity).rotation;
+}
+
+void IScript::SetRotation(const NE::Math::Vec3& rot) {
+ if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::Transform>(m_entity)) {
+        auto& transform = m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity);
+   transform.rotation = rot;
+ transform.isDirty = true;
+    }
+}
+
+void IScript::SetRotation(float x, float y, float z) {
+    SetRotation(NE::Math::Vec3{x, y, z});
+}
+
+NE::Math::Vec3 IScript::GetScale() const {
+    if (!m_componentManager) return NE::Math::Vec3{1, 1, 1};
+    
+  if (!m_componentManager->HasComponent<NE::ECS::Component::Transform>(m_entity))
+      return NE::Math::Vec3{1, 1, 1};
+    
+    return m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity).scale;
+}
+
+void IScript::SetScale(const NE::Math::Vec3& scale) {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::Transform>(m_entity)) {
+  auto& transform = m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity);
+     transform.scale = scale;
+        transform.isDirty = true;
+    }
+}
+
+void IScript::SetScale(float x, float y, float z) {
+    SetScale(NE::Math::Vec3{x, y, z});
+}
+
+void IScript::SetScale(float uniformScale) {
+    SetScale(NE::Math::Vec3{uniformScale, uniformScale, uniformScale});
+}
+
+void IScript::Translate(const NE::Math::Vec3& translation) {
+    SetPosition(GetPosition() + translation);
+}
+
+void IScript::Translate(float x, float y, float z) {
+    Translate(NE::Math::Vec3{x, y, z});
+}
+
+void IScript::Rotate(const NE::Math::Vec3& rotation) {
+    SetRotation(GetRotation() + rotation);
+}
+
+void IScript::Rotate(float x, float y, float z) {
+    Rotate(NE::Math::Vec3{x, y, z});
+}
+
+// === Rigidbody Helper Functions ===
+
+bool IScript::HasRigidbody() const {
+    if (!m_componentManager) return false;
+    return m_componentManager->HasComponent<NE::ECS::Component::Rigidbody>(m_entity);
+}
+
+float IScript::GetMass() const {
+    if (!m_componentManager) return 0.0f;
+    
+    if (!m_componentManager->HasComponent<NE::ECS::Component::Rigidbody>(m_entity))
+        return 0.0f;
+    
+ return m_componentManager->GetComponent<NE::ECS::Component::Rigidbody>(m_entity).mass;
+}
+
+void IScript::SetMass(float mass) {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::Rigidbody>(m_entity)) {
+ auto& rigidbody = m_componentManager->GetComponent<NE::ECS::Component::Rigidbody>(m_entity);
+        rigidbody.mass = mass;
+    }
+}
+
+bool IScript::GetUseGravity() const {
+    if (!m_componentManager) return false;
+    
+    if (!m_componentManager->HasComponent<NE::ECS::Component::Rigidbody>(m_entity))
+        return false;
+    
+    return m_componentManager->GetComponent<NE::ECS::Component::Rigidbody>(m_entity).useGravity;
+}
+
+void IScript::SetUseGravity(bool use) {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::Rigidbody>(m_entity)) {
+     auto& rigidbody = m_componentManager->GetComponent<NE::ECS::Component::Rigidbody>(m_entity);
+rigidbody.useGravity = use;
+    }
+}
+
+bool IScript::IsStatic() const {
+    if (!m_componentManager) return false;
+    
+    if (!m_componentManager->HasComponent<NE::ECS::Component::Rigidbody>(m_entity))
+        return false;
+    
+    return m_componentManager->GetComponent<NE::ECS::Component::Rigidbody>(m_entity).isStatic;
+}
+
+void IScript::SetStatic(bool isStatic) {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::Rigidbody>(m_entity)) {
+        auto& rigidbody = m_componentManager->GetComponent<NE::ECS::Component::Rigidbody>(m_entity);
+        rigidbody.isStatic = isStatic;
+    }
+}
+
+// === AudioSource Helper Functions ===
+
+bool IScript::HasAudioSource() const {
+    if (!m_componentManager) return false;
+    return m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity);
+}
+
+void IScript::PlayAudio() {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity)) {
+auto& audioSource = m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity);
+        
+        // If already playing and not paused, stop first
+  if (audioSource.m_channel && audioSource.isPlaying && !audioSource.isPaused) {
+     audioSource.m_channel->stop();
+     }
+        
+        // Reset state - AudioSystem will handle actual playback
+        audioSource.isPlaying = true;
+        audioSource.isPaused = false;
+        audioSource.m_hasPlayed = false; // Trigger playback in AudioSystem
+    }
+}
+
+void IScript::StopAudio() {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity)) {
+        auto& audioSource = m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity);
+        
+        if (audioSource.m_channel) {
+       audioSource.m_channel->stop();
+ }
+        
+        audioSource.isPlaying = false;
+   audioSource.isPaused = false;
+    }
+}
+
+void IScript::PauseAudio() {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity)) {
+        auto& audioSource = m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity);
+        
+        if (audioSource.m_channel && audioSource.isPlaying) {
+      audioSource.m_channel->setPaused(true);
+            audioSource.isPaused = true;
+        }
+    }
+}
+
+void IScript::ResumeAudio() {
+ if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity)) {
+        auto& audioSource = m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity);
+   
+        if (audioSource.m_channel && audioSource.isPaused) {
+      audioSource.m_channel->setPaused(false);
+            audioSource.isPaused = false;
+        }
+    }
+}
+
+bool IScript::IsAudioPlaying() const {
+    if (!m_componentManager) return false;
+    
+  if (!m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity))
+  return false;
+    
+    const auto& audioSource = m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity);
+    return audioSource.isPlaying && !audioSource.isPaused;
+}
+
+float IScript::GetVolume() const {
+    if (!m_componentManager) return 0.0f;
+  
+    if (!m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity))
+        return 0.0f;
+    
+    return m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity).volume;
+}
+
+void IScript::SetVolume(float volume) {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity)) {
+        auto& audioSource = m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity);
+      audioSource.volume = volume;
+        
+     // Apply immediately if playing
+        if (audioSource.m_channel) {
+     audioSource.m_channel->setVolume(volume);
+}
+    }
+}
+
+float IScript::GetPitch() const {
+    if (!m_componentManager) return 1.0f;
+  
+    if (!m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity))
+    return 1.0f;
+    
+    return m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity).pitch;
+}
+
+void IScript::SetPitch(float pitch) {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity)) {
+        auto& audioSource = m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity);
+     audioSource.pitch = pitch;
+        
+        // Apply immediately if playing
+     if (audioSource.m_channel) {
+        audioSource.m_channel->setPitch(pitch);
+  }
+    }
+}
+
+void IScript::SetAudioLoop(bool loop) {
+    if (!m_componentManager) return;
+    
+    if (m_componentManager->HasComponent<NE::ECS::Component::AudioSource>(m_entity)) {
+     auto& audioSource = m_componentManager->GetComponent<NE::ECS::Component::AudioSource>(m_entity);
+     audioSource.loop = loop;
+    }
 }

--- a/NANOEngine/src/Scripting/IScript.hpp
+++ b/NANOEngine/src/Scripting/IScript.hpp
@@ -16,6 +16,10 @@ namespace NE::ECS {
     using Entity = unsigned int;
 }
 
+namespace NE::Math {
+  struct Vec3;
+}
+
 //namespace NE::Core {
 //    class Transform;
 //    class GameObject;
@@ -143,6 +147,217 @@ public:
     template<typename T>
     T* GetComponent() const;
 
+    /**
+     * Check if the entity has a specific component.
+     * @return true if the component exists, false otherwise
+     */
+    template<typename T>
+    bool HasComponent() const;
+
+    // === Unity-Style Transform Helper Functions ===
+
+    /**
+     * Get the current position of the entity.
+     * @return Position as Vec3, or (0,0,0) if no Transform component
+     */
+    NE::Math::Vec3 GetPosition() const;
+
+    /**
+     * Set the position of the entity.
+     * @param pos New position
+     */
+    void SetPosition(const NE::Math::Vec3& pos);
+
+    /**
+     * Set the position of the entity.
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     */
+    void SetPosition(float x, float y, float z);
+
+    /**
+     * Get the current rotation of the entity.
+     * @return Rotation as Vec3 (euler angles), or (0,0,0) if no Transform component
+     */
+    NE::Math::Vec3 GetRotation() const;
+
+    /**
+     * Set the rotation of the entity.
+     * @param rot New rotation (euler angles)
+     */
+    void SetRotation(const NE::Math::Vec3& rot);
+
+    /**
+     * Set the rotation of the entity.
+     * @param x X rotation (pitch)
+     * @param y Y rotation (yaw)
+     * @param z Z rotation (roll)
+     */
+    void SetRotation(float x, float y, float z);
+
+    /**
+     * Get the current scale of the entity.
+     * @return Scale as Vec3, or (1,1,1) if no Transform component
+     */
+    NE::Math::Vec3 GetScale() const;
+
+    /**
+     * Set the scale of the entity.
+     * @param scale New scale
+     */
+    void SetScale(const NE::Math::Vec3& scale);
+
+    /**
+     * Set the scale of the entity.
+     * @param x X scale
+     * @param y Y scale
+     * @param z Z scale
+     */
+    void SetScale(float x, float y, float z);
+
+    /**
+     * Set uniform scale on all axes.
+     * @param uniformScale Scale value for all axes
+     */
+    void SetScale(float uniformScale);
+
+    /**
+     * Move the entity by a translation vector.
+     * @param translation Movement vector
+     */
+    void Translate(const NE::Math::Vec3& translation);
+
+    /**
+     * Move the entity by specified amounts on each axis.
+     * @param x X movement
+     * @param y Y movement
+     * @param z Z movement
+     */
+    void Translate(float x, float y, float z);
+
+    /**
+     * Rotate the entity by euler angles.
+     * @param rotation Rotation to apply (euler angles)
+     */
+    void Rotate(const NE::Math::Vec3& rotation);
+
+    /**
+     * Rotate the entity by specified amounts on each axis.
+     * @param x X rotation
+     * @param y Y rotation
+     * @param z Z rotation
+     */
+    void Rotate(float x, float y, float z);
+
+    // === Unity-Style Rigidbody Helper Functions ===
+
+    /**
+     * Check if the entity has a Rigidbody component.
+     * @return true if Rigidbody exists, false otherwise
+     */
+    bool HasRigidbody() const;
+
+    /**
+     * Get the mass of the rigidbody.
+     * @return Mass value, or 0 if no Rigidbody component
+     */
+    float GetMass() const;
+
+    /**
+     * Set the mass of the rigidbody.
+     * @param mass New mass value
+     */
+    void SetMass(float mass);
+
+    /**
+     * Check if the rigidbody uses gravity.
+     * @return true if gravity enabled, false otherwise
+     */
+    bool GetUseGravity() const;
+
+    /**
+     * Enable or disable gravity for the rigidbody.
+     * @param use Whether to use gravity
+     */
+    void SetUseGravity(bool use);
+
+    /**
+     * Check if the rigidbody is static.
+     * @return true if static, false otherwise
+     */
+    bool IsStatic() const;
+
+    /**
+     * Set whether the rigidbody is static.
+     * @param isStatic Whether the body should be static
+     */
+    void SetStatic(bool isStatic);
+
+    // === Unity-Style AudioSource Helper Functions ===
+
+    /**
+     * Check if the entity has an AudioSource component.
+   * @return true if AudioSource exists, false otherwise
+     */
+  bool HasAudioSource() const;
+
+    /**
+     * Play the audio clip attached to this entity's AudioSource.
+     */
+    void PlayAudio();
+
+    /**
+     * Stop the audio playing on this entity's AudioSource.
+     */
+    void StopAudio();
+
+    /**
+     * Pause the audio playing on this entity's AudioSource.
+     */
+    void PauseAudio();
+
+    /**
+ * Resume the audio playing on this entity's AudioSource.
+     */
+    void ResumeAudio();
+
+    /**
+     * Check if the AudioSource is currently playing.
+     * @return true if playing, false otherwise
+     */
+    bool IsAudioPlaying() const;
+
+    /**
+     * Get the volume of the AudioSource.
+     * @return Volume (0.0 to 1.0), or 0 if no AudioSource
+     */
+    float GetVolume() const;
+
+    /**
+     * Set the volume of the AudioSource.
+ * @param volume Volume (0.0 to 1.0)
+     */
+  void SetVolume(float volume);
+
+    /**
+     * Get the pitch of the AudioSource.
+     * @return Pitch multiplier, or 1.0 if no AudioSource
+     */
+    float GetPitch() const;
+
+    /**
+     * Set the pitch of the AudioSource.
+     * @param pitch Pitch multiplier
+ */
+    void SetPitch(float pitch);
+
+    /**
+     * Set whether the audio should loop.
+     * @param loop Whether to loop
+     */
+    void SetAudioLoop(bool loop);
+
     // === Runtime editable scripting fields support ===
     // Scripts that want to expose editable fields to the editor can override
     // these methods. We keep the API string-based to avoid reflection across DLLs.
@@ -184,5 +399,13 @@ T* IScript::GetComponent() const {
     }
     // Assumes ComponentManager has a method like this
     return &m_componentManager->GetComponent<T>(m_entity);
+}
+
+template<typename T>
+bool IScript::HasComponent() const {
+    if (!m_componentManager) {
+        return false;
+    }
+    return m_componentManager->HasComponent<T>(m_entity);
 }
 


### PR DESCRIPTION
Introduces Unity-style helper methods for Transform, Rigidbody, and AudioSource components in IScript, including position, rotation, scale, movement, physics, and audio control. Updates PlayerScript to use new movement helpers for cleaner logic.