### PR TITLE
Trigger hierarchy rebuild on entity create/delete

### DIFF
--- a/Editor/src/Command/EditorCommands.cpp
+++ b/Editor/src/Command/EditorCommands.cpp
@@ -45,7 +45,7 @@ namespace Editor {
 		if (it != EditorScene::s_entities.end()) {
 			EditorScene::s_entities.erase(it);
 		}
-
+		Editor::EditorScene::BuildFlatHierarchy();
 
 		NE::ECS::Command::DestroyEntity(m_entity);
 	}
@@ -54,6 +54,7 @@ namespace Editor {
 	{
 		m_entity = NE::ECS::Command::CreateEntity();
 		EditorScene::s_entities.push_back(EditorEntity{ m_entity });
+		Editor::EditorScene::BuildFlatHierarchy();
 	}
 
 }

--- a/Editor/src/Panels/HierarchyPanel.cpp
+++ b/Editor/src/Panels/HierarchyPanel.cpp
@@ -54,7 +54,7 @@ namespace Editor {
 
             }
             if (ImGui::MenuItem("Delete", "Del", false, EditorScene::s_selectedEntity)) {
-
+                NANOEngine::Events::EventBus::Get().Dispatch(NANOEngine::Events::EventDomain::Editor, DeleteEntityEvent{ EditorScene::s_selectedEntity->linkedEntity });
             }
             ImGui::Separator();
             if (ImGui::MenuItem("Select All", "", false, false)) {
@@ -82,7 +82,7 @@ namespace Editor {
             if (ImGui::MenuItem("Create Entity")) {
                 NANOEngine::Events::EventBus::Get().Dispatch(NANOEngine::Events::EventDomain::Editor, CreateEntityEvent{});
                 //NE::
-                Editor::EditorScene::BuildFlatHierarchy();
+                //Editor::EditorScene::BuildFlatHierarchy();
                 // need to add into display list also currently creates but not shown in hierarchy
             }
             if (ImGui::BeginMenu("3D Object")) { // Creates a submenu with an arrow


### PR DESCRIPTION
Calls EditorScene::BuildFlatHierarchy after creating or deleting entities in EditorCommands.cpp to ensure the hierarchy stays updated. Removes redundant manual hierarchy rebuild from HierarchyPanel.cpp, relying on event-driven updates instead.