### PR TITLE
Add scene dirty flag tracking and status bar to editor

### DIFF
--- a/Editor/src/Command/EditorSetFieldCommand.hpp
+++ b/Editor/src/Command/EditorSetFieldCommand.hpp
@@ -7,70 +7,84 @@
 #include <functional>
 #include "ICommand.hpp"
 #include <Core/Reflection.hpp>
+#include <Engine.hpp>  // For MarkSceneDirty
+#include <EngineState.hpp>  // For GetEngineState
+#include <Core/SpdLogger.hpp>  // For SPD_DEBUG logging
 
 namespace Editor {
 
-    // Minimal, type-safe command that knows how to set one field on a component.
-    template <typename Owner, typename T>
-    class SetFieldCommand final : public ICommand {
-    public:
-        using MemberPtr = T Owner::*;
+	// Minimal, type-safe command that knows how to set one field on a component.
+	template <typename Owner, typename T>
+	class SetFieldCommand final : public ICommand {
+	public:
+		using MemberPtr = T Owner::*;
 
-        SetFieldCommand(uint32_t entity,
-            std::string name,
-            MemberPtr member,
-            T before,
-            T after,
-            std::function<Owner& (uint32_t)> getter)
-            : m_entity(entity),
-            m_name(std::move(name)),
-            m_member(member),
-            m_before(std::move(before)),
-            m_after(std::move(after)),
-            m_getter(std::move(getter)) {
-        }
+		SetFieldCommand(uint32_t entity,
+			std::string name,
+			MemberPtr member,
+			T before,
+			T after,
+			std::function<Owner& (uint32_t)> getter)
+			: m_entity(entity),
+			m_name(std::move(name)),
+			m_member(member),
+			m_before(std::move(before)),
+			m_after(std::move(after)),
+			m_getter(std::move(getter)) {
+		}
 
-        void Execute() override {
-            auto& c = m_getter(m_entity);
-            c.*m_member = m_after;
-            MarkDirtyIfPresent(c);
-        }
+		void Execute() override {
+			auto& c = m_getter(m_entity);
+			c.*m_member = m_after;
+			MarkDirtyIfPresent(c);
 
-        void Undo() override {
-            auto& c = m_getter(m_entity);
-            c.*m_member = m_before;
-            MarkDirtyIfPresent(c);
-        }
+			// Mark scene dirty for serialization (Edit mode only)
+			if (NE::GetEngineState() == NE::EngineState::Edit) {
+				NE::MarkSceneDirty();
+				//SPD_DEBUG("[DirtyFlag] Component changed via Inspector - Scene marked DIRTY");
+			}
+		}
 
-        const char* GetName() const override { return m_name.c_str(); }
+		void Undo() override {
+			auto& c = m_getter(m_entity);
+			c.*m_member = m_before;
+			MarkDirtyIfPresent(c);
 
-        bool CanCoalesceWith(const ICommand& next) const override {
-            auto* other = dynamic_cast<const SetFieldCommand*>(&next);
-            return other &&
-                other->m_entity == m_entity &&
-                other->m_member == m_member;
-        }
+			// Mark scene dirty for serialization (Edit mode only)
+			if (NE::GetEngineState() == NE::EngineState::Edit) {
+				NE::MarkSceneDirty();
+				//SPD_DEBUG("[DirtyFlag] Undo operation - Scene marked DIRTY");
+			}
+		}
 
-        void CoalesceFrom(const ICommand& next) override {
-            auto const& other = static_cast<const SetFieldCommand&>(next);
-            m_after = other.m_after;
-            Execute();
-        }
+		const char* GetName() const override { return m_name.c_str(); }
 
-        const T& Before() const { return m_before; }
-        const T& After()  const { return m_after; }
+		bool CanCoalesceWith(const ICommand& next) const override {
+			auto* other = dynamic_cast<const SetFieldCommand*>(&next);
+			return other &&
+				other->m_entity == m_entity &&
+				other->m_member == m_member;
+		}
 
-    private:
-        template <typename C>
-        static void MarkDirtyIfPresent(C& comp) {
-            if constexpr (requires(C x) { x.isDirty; }) comp.isDirty = true;
-        }
+		void CoalesceFrom(const ICommand& next) override {
+			auto const& other = static_cast<const SetFieldCommand&>(next);
+			m_after = other.m_after;
+			Execute();
+		}
 
-        uint32_t m_entity;
-        std::string m_name;
-        MemberPtr m_member;
-        T m_before, m_after;
-        std::function<Owner& (uint32_t)> m_getter;
-    };
+		const T& Before() const { return m_before; }
+		const T& After()  const { return m_after; }
 
+	private:
+		template <typename C>
+		static void MarkDirtyIfPresent(C& comp) {
+			if constexpr (requires(C x) { x.isDirty; }) comp.isDirty = true;
+		}
+
+		uint32_t m_entity;
+		std::string m_name;
+		MemberPtr m_member;
+		T m_before, m_after;
+		std::function<Owner& (uint32_t)> m_getter;
+	};
 }

--- a/Editor/src/Command/EditorSetTransformCommand.hpp
+++ b/Editor/src/Command/EditorSetTransformCommand.hpp
@@ -2,6 +2,9 @@
 #include <string>
 #include <memory>
 #include "ICommand.hpp"
+#include <Engine.hpp>  // For MarkSceneDirty
+#include <EngineState.hpp>  // For GetEngineState
+#include <Core/SpdLogger.hpp>  
 
 namespace Editor {
 
@@ -42,6 +45,12 @@ namespace Editor {
             if (m_mask & Scl) t.scale = v.scale;
 
             if constexpr (requires(Owner x) { x.isDirty; }) t.isDirty = true;
+     
+            // Mark scene dirty for serialization (Edit mode only)
+            if (NE::GetEngineState() == NE::EngineState::Edit) {
+                NE::MarkSceneDirty();
+                //SPD_DEBUG("[DirtyFlag] Transform changed via Gizmo - Scene marked DIRTY");
+            }
         }
 
         uint32_t    m_entity;

--- a/Editor/src/EditorLayer.cpp
+++ b/Editor/src/EditorLayer.cpp
@@ -5,6 +5,7 @@
 #include "Panels/AssetBrowserPanel.hpp"
 #include "Engine.hpp"
 #include "../src/EditorScene.hpp"
+#include "EditorScene.hpp"
 #include <glfw/glfw3.h>
 #include "Command/CommandHistory.hpp"
 #include "Panels/InspectorPanel.hpp"
@@ -12,27 +13,27 @@
 #include "Panels/AnimationRuntimePanel.hpp"
 #include "Panels/AnimationGraphPanel.hpp"
 #include "Panels/ProfilerPanel.hpp"
+#include <Core/SpdLogger.hpp>  // For SPD_INFO, SPD_DEBUG logging
 
 namespace Editor {
-	void EditorLayer::OnImGuiRender() {
+    void EditorLayer::OnImGuiRender() {
         static bool dockspaceOpen = true;
         static bool opt_fullscreen_persistent = true;
         bool opt_fullscreen = opt_fullscreen_persistent;
-        //static ImGuiDockNodeFlags dockspace_flags = ImGuiDockNodeFlags_None;
-        
-        // Honestly have no clue what are some of these flags do but documentation says need so :/
+
         static ImGuiDockNodeFlags dockspace_flags = ImGuiDockNodeFlags_PassthruCentralNode;
 
-        ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar;
+        ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar |
+            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
 
         if (opt_fullscreen) {
             const ImGuiViewport* viewport = ImGui::GetMainViewport();
             ImGui::SetNextWindowPos(viewport->Pos);
             ImGui::SetNextWindowSize(viewport->Size);
             ImGui::SetNextWindowViewport(viewport->ID);
-            window_flags |= ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse |
-                ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove;
-            window_flags |= ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
+            window_flags |= ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+                ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus |
+                ImGuiWindowFlags_NoNavFocus;
         }
 
         ImGui::Begin("Editor DockSpace", &dockspaceOpen, window_flags);
@@ -40,22 +41,66 @@ namespace Editor {
         float titleBarHeight = 0.0f;
         DrawCustomTitleBar("NANOEngine", titleBarHeight, IM_COL32(25, 25, 25, 255));
 
-        //const ImGuiViewport* viewport = ImGui::GetMainViewport();
-        //float menuBarHeight = ImGui::GetFrameHeight();
-        //float totalTopBarHeight = titleBarHeight + menuBarHeight;
+        // Calculate dockspace size to leave room for status bar at bottom
+        ImVec2 dockspaceSize = ImGui::GetContentRegionAvail();
+        dockspaceSize.y -= 25.0f; // Reserve 25px for status bar
 
-        //ImGui::SetNextWindowPos(ImVec2(viewport->Pos.x, viewport->Pos.y + totalTopBarHeight));
-        //ImGui::SetNextWindowSize(ImVec2(viewport->Size.x, viewport->Size.y - totalTopBarHeight));
-
+        // SINGLE DockSpace call
         ImGuiID dockspace_id = ImGui::GetID("EditorDockspace");
-        ImGui::DockSpace(dockspace_id, ImVec2(0.0f, 0.0f), dockspace_flags);
+        ImGui::DockSpace(dockspace_id, dockspaceSize, dockspace_flags);
+
+        // === SHORTCUTS (Must be at window level to work) ===
+        // Save shortcut (Ctrl+S) - Check globally, not just when window focused
+        if (ImGui::IsKeyPressed(ImGuiKey_S, false) && (ImGui::GetIO().KeyCtrl && !ImGui::GetIO().KeyShift && !ImGui::GetIO().KeyAlt)) {
+            if (NE::IsSceneDirty()) {
+                SPD_INFO("[DirtyFlag] Ctrl+S pressed - Saving scene");
+                NE::SaveCurrentScene(EditorScene::currentScenePath);
+            }
+            else {
+                SPD_DEBUG("[DirtyFlag] Ctrl+S pressed - No changes to save");
+            }
+        }
 
         for (auto& panel : m_panels) {
             panel->OnImGuiRender();
         }
 
-        ImGui::End();
-	}
+        // === STATUS BAR (Integrated at bottom of main window) ===
+        ImGui::Separator();
+
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.12f, 0.12f, 0.12f, 1.0f));
+
+        if (ImGui::BeginChild("##StatusBar", ImVec2(0, 25.0f), false, ImGuiWindowFlags_NoScrollbar)) {
+            ImGui::SetCursorPosY(4.0f); // Center text vertically
+
+            // Scene path on the left
+            ImGui::Text("  %s", EditorScene::currentScenePath.c_str());
+
+            // Dirty indicator on the right
+            ImGui::SameLine();
+            float rightOffset = ImGui::GetWindowWidth() - 120.0f;
+            if (rightOffset > ImGui::GetCursorPosX()) {
+                ImGui::SetCursorPosX(rightOffset);
+            }
+
+            bool isSceneDirty = NE::IsSceneDirty();
+            if (isSceneDirty) {
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.6f, 0.0f, 1.0f)); // Orange
+                ImGui::Text("* UNSAVED");
+                ImGui::PopStyleColor();
+            }
+            else {
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.3f, 0.8f, 0.3f, 1.0f)); // Green
+                ImGui::Text("Saved");
+                ImGui::PopStyleColor();
+            }
+        }
+        ImGui::EndChild();
+
+        ImGui::PopStyleColor();
+
+        ImGui::End();  // End main dockspace window
+    }
 
     void EditorLayer::SetIcon(unsigned int _iconID) {
         icon = reinterpret_cast<ImTextureID>(reinterpret_cast<void*>((uintptr_t)_iconID));
@@ -69,7 +114,7 @@ namespace Editor {
         ImVec2 menuBarSize = ImVec2(ImGui::GetWindowWidth(), barHeight);
 
         HWND hwnd = static_cast<HWND>(ImGui::GetMainViewport()->PlatformHandleRaw);
-        hwnd;
+
         // Background
         drawList->AddRectFilled(winPos, ImVec2(winPos.x + menuBarSize.x, winPos.y + menuBarSize.y), bgColor);
 
@@ -79,19 +124,19 @@ namespace Editor {
 
         // --- Logo (Left) ---
         ImGui::SetCursorPos(ImVec2(0.f, 2.f));
-        ImGui::Image(icon, ImVec2(18.f,18.f));
+        ImGui::Image(icon, ImVec2(18.f, 18.f));
         ImGui::SameLine();
 
         // --- Menus (Next to logo) ---
-        float logoSpace = 20.f; // logo width + padding
+        float logoSpace = 20.f;
         ImGui::SetCursorPosX(logoSpace);
 
         ImGuiStyle& style = ImGui::GetStyle();
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.f, style.ItemSpacing.y));
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(6.f, 2.f));
-        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));             // idle: fully transparent
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1, 1, 1, 0.10f));  // hover: light wash
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1, 1, 1, 0.20f));   // active: slightly stronger
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1, 1, 1, 0.10f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1, 1, 1, 0.20f));
 
         bool openFile = ImGui::Button("File");
         ImVec2 fileMin = ImGui::GetItemRectMin();
@@ -107,7 +152,6 @@ namespace Editor {
         ImVec2 winMin = ImGui::GetItemRectMin();
         ImVec2 winMax = ImGui::GetItemRectMax();
 
-        // Open the popups when clicked (don’t set pos here)
         if (openFile)   ImGui::OpenPopup("FileMenu");
         if (openEdit)   ImGui::OpenPopup("EditMenu");
         if (openWindow) ImGui::OpenPopup("WindowMenu");
@@ -117,42 +161,54 @@ namespace Editor {
         ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_PopupBorderSize, 1.0f);
 
-        // FILE – set pos right before BeginPopup for THIS popup
+        // FILE MENU
         ImGui::SetNextWindowPos(ImVec2(fileMin.x, fileMax.y), ImGuiCond_Appearing);
         if (ImGui::BeginPopup("FileMenu")) {
             if (ImGui::MenuItem("New Scene")) {}
             if (ImGui::MenuItem("Open Scene")) {}
             ImGui::Separator();
-            if (ImGui::MenuItem("Save", "Ctrl+S")) {}
+
+            // FIXED: Single Save menu item with proper dirty check
+            bool isSceneDirty = NE::IsSceneDirty();
+            if (isSceneDirty) {
+                if (ImGui::MenuItem("Save", "Ctrl+S")) {
+                    SPD_INFO("[DirtyFlag] Save menu clicked - Saving scene");
+                    NE::SaveCurrentScene(EditorScene::currentScenePath);
+                }
+            }
+            else {
+                ImGui::BeginDisabled();
+                ImGui::MenuItem("Save", "Ctrl+S");
+                ImGui::EndDisabled();
+            }
+
+            if (ImGui::MenuItem("Save As...")) {
+                NE::SaveCurrentScene(EditorScene::currentScenePath);
+            }
+
             ImGui::Separator();
             if (ImGui::MenuItem("Exit")) {}
             ImGui::EndPopup();
         }
 
-        // EDIT
+        // EDIT MENU
         ImGui::SetNextWindowPos(ImVec2(editMin.x, editMax.y), ImGuiCond_Appearing);
         if (ImGui::BeginPopup("EditMenu")) {
             if (ImGui::MenuItem("Undo", "Ctrl+Z")) CommandHistory::GetInstance().Undo();
             if (ImGui::MenuItem("Redo", "Ctrl+Y")) CommandHistory::GetInstance().Redo();
             ImGui::Separator();
-            if (ImGui::MenuItem("Cut", "Ctrl+X")){}
-            if (ImGui::MenuItem("Copy", "Ctrl+C")){}
-            if (ImGui::MenuItem("Paste", "Ctrl+V")){}
+            if (ImGui::MenuItem("Cut", "Ctrl+X")) {}
+            if (ImGui::MenuItem("Copy", "Ctrl+C")) {}
+            if (ImGui::MenuItem("Paste", "Ctrl+V")) {}
             ImGui::EndPopup();
         }
 
-        // WINDOW
+        // WINDOW MENU
         ImGui::SetNextWindowPos(ImVec2(winMin.x, winMax.y), ImGuiCond_Appearing);
         if (ImGui::BeginPopup("WindowMenu")) {
-
-
             if (ImGui::BeginMenu("General")) {
-                if (ImGui::MenuItem("Scene", nullptr, false)) {
-
-                }
-                if (ImGui::MenuItem("Game", nullptr, false)) {
-
-                }
+                if (ImGui::MenuItem("Scene", nullptr, false)) {}
+                if (ImGui::MenuItem("Game", nullptr, false)) {}
                 if (ImGui::MenuItem("Inspector", nullptr, false)) {
                     AddPanel<InspectorPanel>();
                 }
@@ -180,49 +236,35 @@ namespace Editor {
         }
 
         ImGui::PopStyleVar(3);
-
         ImGui::PopStyleColor(3);
         ImGui::PopStyleVar(2);
 
-        // TEST SHORTCUTS
-        //if (ImGui::Shortcut(ImGuiMod_Ctrl | ImGuiKey_Z)) {
-        //    CommandHistory::GetInstance().Undo();
-        //}
-
-        //if (ImGui::Shortcut(ImGuiMod_Ctrl | ImGuiKey_Y)) {
-        //    CommandHistory::GetInstance().Redo();
-        //}
-
-        // --- History button (top-right), before the window controls ---
-        // Reserve width for the three window buttons you already place on the far right
+        // --- History button (top-right), before window controls ---
         float buttonSize = 20.0f;
         float spacing = 0.0f;
         float totalButtonsWidth = 3 * (buttonSize + spacing);
 
         ImVec2 historySize = ImVec2(140.0f, 20.0f);
 
-        float rightEdge = menuBarSize.x - totalButtonsWidth - 8.0f; // 8px padding
+        float rightEdge = menuBarSize.x - totalButtonsWidth - 8.0f;
         ImVec2 pos = ImVec2(rightEdge - historySize.x, (menuBarSize.y - historySize.y) * 0.5f);
         ImGui::SetCursorPos(pos);
 
-        // show the latest undo label as preview text
         auto& history = CommandHistory::GetInstance();
         const auto& undo = history.GetUndoList();
-        const char* preview =
-            undo.empty() ? "History" : undo.back()->GetName();
+        const char* preview = undo.empty() ? "History" : undo.back()->GetName();
 
-        // Style it to feel like a button (no arrow, we draw "▾" ourselves in the label)
         ImGui::SetNextItemWidth(historySize.x);
         ImGuiComboFlags comboFlags = ImGuiComboFlags_NoArrowButton | ImGuiComboFlags_HeightLarge;
 
         if (ImGui::BeginCombo("##history_dropdown", preview, comboFlags)) {
-            // Optional header
             ImGui::TextUnformatted("Undo Stack");
             ImGui::Separator();
 
             if (undo.empty()) {
                 ImGui::TextDisabled("  <empty>");
-            } else {
+            }
+            else {
                 for (int i = static_cast<int>(undo.size()) - 1; i >= 0; --i)
                     ImGui::BulletText("#%d - %s", i + 1, undo[i]->GetName());
             }
@@ -234,7 +276,8 @@ namespace Editor {
             const auto& redo = history.GetRedoList();
             if (redo.empty()) {
                 ImGui::TextDisabled("  <empty>");
-            } else {
+            }
+            else {
                 for (int i = static_cast<int>(redo.size()) - 1; i >= 0; --i)
                     ImGui::BulletText("#%d - %s", i + 1, redo[i]->GetName());
             }
@@ -248,13 +291,7 @@ namespace Editor {
         }
 
         // --- Window Controls (Far right) ---
-        //float buttonSize = 32.0f; // Slightly smaller for style
-        //float spacing = 0.0f;
-        //float totalButtonsWidth = 3 * (buttonSize + spacing);
-
-        // Move cursor to the far right, but centered in the bar
         ImGui::SetCursorPos(ImVec2(menuBarSize.x - totalButtonsWidth, 0.f));
-
         ImVec2 btnPos = ImGui::GetCursorScreenPos();
 
         // Minimize
@@ -264,7 +301,8 @@ namespace Editor {
         if (ImGui::IsItemHovered()) {
             drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
             drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "-");
-        } else {
+        }
+        else {
             drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "-");
         }
 
@@ -282,7 +320,8 @@ namespace Editor {
         if (ImGui::IsItemHovered()) {
             drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
             drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "O");
-        } else {
+        }
+        else {
             drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "O");
         }
 
@@ -296,11 +335,12 @@ namespace Editor {
         if (ImGui::IsItemHovered()) {
             drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
             drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "X");
-        } else {
+        }
+        else {
             drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 60, 60, 255), "X");
         }
 
-		// For dragging of OS window
+        // For dragging of OS window
         ImGui::SetCursorScreenPos(winPos);
         ImGui::InvisibleButton("##drag_window", menuBarSize);
         if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
@@ -309,21 +349,19 @@ namespace Editor {
             if (isMaximized && !restoringFromMaximized) {
                 restoringFromMaximized = true;
 
-                // Save cursor offset from top-left
                 POINT cursor;
                 GetCursorPos(&cursor);
 
                 int restoreWidth = placement.rcNormalPosition.right - placement.rcNormalPosition.left;
-                //int restoreHeight = placement.rcNormalPosition.bottom - placement.rcNormalPosition.top;
 
                 ShowWindow(hwnd, SW_RESTORE);
 
-                // Adjust window position so cursor remains at same relative offset
                 SetWindowPos(hwnd, nullptr,
                     cursor.x - restoreWidth / 2,
                     cursor.y - 8, 0, 0,
                     SWP_NOSIZE | SWP_NOZORDER);
-            } else {
+            }
+            else {
                 restoringFromMaximized = false;
 
                 ImVec2 dragDelta = ImGui::GetMouseDragDelta();
@@ -341,5 +379,4 @@ namespace Editor {
 
         ImGui::EndChild();
     }
-
 }

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -327,6 +327,7 @@ namespace Editor {
 					//            SubmitSetFieldCommand(entity, desc, currentValue, edited);
 					//        }
 					//    });
+
 					NE::Core::ForEachFieldView<NE::ECS::Component::Transform>(comp,
 						[&](auto const& desc, auto const& currentValue) {
 							using Owner = NE::ECS::Component::Transform;
@@ -395,7 +396,7 @@ namespace Editor {
 				else if (typeIdx == typeid(NE::ECS::Component::Renderer)) {
 					auto& comp = NE::ECS::Query::GetEntityRenderer(entity);
 					ImGui::SeparatorText("Renderer");
-
+					// Model field
 					bool openPopup = false;
 					DrawAssetField("Model", AssetManager::GetInstance().RetrieveFileName(comp.modelUUID), "+", 0.f, &openPopup);
 					if (openPopup) {
@@ -415,7 +416,8 @@ namespace Editor {
 					if (ImGui::BeginPopup("AssetPicker_Model")) {
 						ImGui::Text("Select a Model");
 						ImGui::Separator();
-						auto& modelList = AssetManager::GetInstance().GetInstance().GetAssetsOfType<AssetType::Mesh>();
+						//auto& modelList = AssetManager::GetInstance().GetInstance().GetAssetsOfType<AssetType::Mesh>();
+						auto& modelList = AssetManager::GetInstance().GetAssetsOfType<AssetType::Mesh>();
 
 						if (ImSearch::BeginSearch()) {
 							ImSearch::SearchBar();
@@ -433,6 +435,7 @@ namespace Editor {
 						ImGui::EndPopup();
 					}
 
+					// Material field
 					char bufMat[256];
 					strncpy_s(bufMat, comp.materialUUID.c_str(), sizeof(bufMat));
 					ImGui::InputText("Material", bufMat, sizeof(bufMat));
@@ -453,10 +456,12 @@ namespace Editor {
 					static const char* LightTypeNames[] = { "Directional", "Point", "Spot" };
 					int currentType = static_cast<int>(comp.type);
 					if (ImGui::Combo("Type", &currentType, LightTypeNames, IM_ARRAYSIZE(LightTypeNames))) {
-						//comp.type = static_cast<NE::ECS::Component::Light::Type>(currentType);
-						// temp
 						auto& tempLight = NE::ECS::Command::GetEntityLight(entity);
 						tempLight.type = static_cast<NE::ECS::Component::Light::Type>(currentType);
+						
+						// Mark scene dirty when light type changes
+						NE::MarkSceneDirty();
+						SPD_DEBUG("[DirtyFlag] Light type changed - Scene marked DIRTY");
 					}
 
 					NE::Core::ForEachFieldView<NE::ECS::Component::Light>(comp,
@@ -496,6 +501,8 @@ namespace Editor {
 
 						// Also mark the collider as dirty
 						comp.isShapeDirty = true;
+						
+						// NOTE: SubmitSetFieldCommand already marks scene dirty via SetFieldCommand
 					}
 
 					// Collider fields - shape properties
@@ -541,6 +548,10 @@ namespace Editor {
 						SPD_DEBUG("  Updated: motionType={}, isStatic={}",
 							static_cast<int>(tempRb.motionType),
 							tempRb.isStatic);
+						
+						// Mark scene dirty when motion type changes
+						NE::MarkSceneDirty();
+						SPD_DEBUG("[DirtyFlag] Rigidbody motion type changed - Scene marked DIRTY");
 					}
 
 					// Help text
@@ -636,6 +647,8 @@ namespace Editor {
 						// "None" option to remove script
 						if (ImGui::Selectable("None", comp.ScriptName.empty())) {
 							NE::ECS::Command::RemoveEntityScript(entity);
+							NE::MarkSceneDirty();
+							SPD_DEBUG("[DirtyFlag] Script removed - Scene marked DIRTY");
 						}
 
 						// List all registered scripts
@@ -644,6 +657,8 @@ namespace Editor {
 							bool isSelected = (comp.ScriptName == scriptName);
 							if (ImGui::Selectable(scriptName.c_str(), isSelected)) {
 								NE::ECS::Command::SetEntityScript(entity, scriptName);
+								NE::MarkSceneDirty();
+								SPD_DEBUG("[DirtyFlag] Script changed - Scene marked DIRTY");
 							}
 							if (isSelected) {
 								ImGui::SetItemDefaultFocus();
@@ -661,309 +676,371 @@ namespace Editor {
 							bool enabled = comp.Instance->IsEnabled();
 							if (ImGui::Checkbox("Enabled", &enabled)) {
 								comp.Instance->SetEnabled(enabled);
+								NE::MarkSceneDirty();
+								SPD_DEBUG("[DirtyFlag] Script enabled/disabled - Scene marked DIRTY");
+							}
+						}
+
+						ImGui::Text("Status: Active");
+						ImGui::Text("Entity ID: %u", comp.Instance->GetEntity());
+
+						// --- Scripting Fields UI ---
+						auto fieldNames = comp.Instance->GetExposedFieldNames();
+						if (!fieldNames.empty()) {
+							ImGui::SeparatorText("Script Fields");
+
+							// ? NEW: Group struct fields under collapsible headers
+							std::unordered_map<std::string, std::vector<std::string>> structGroups;
+							std::vector<std::string> normalFields;
+
+							// Separate struct fields (contain '.') from normal fields
+							for (const auto& fname : fieldNames) {
+								if (fname.find('.') != std::string::npos) {
+									// Extract struct name (e.g., "stats" from "stats.health")
+									size_t dotPos = fname.find('.');
+									std::string structName = fname.substr(0, dotPos);
+									structGroups[structName].push_back(fname);
+								}
+								else {
+									normalFields.push_back(fname);
+								}
 							}
 
-							ImGui::Text("Status: Active");
-							ImGui::Text("Entity ID: %u", comp.Instance->GetEntity());
+							// Render normal fields first
+							for (const auto& fname : normalFields) {
+								std::string ftype = comp.Instance->GetFieldType(fname);
+								std::string fval = comp.Instance->GetFieldValueAsString(fname);
 
-							// --- Scripting Fields UI ---
-							auto fieldNames = comp.Instance->GetExposedFieldNames();
-							if (!fieldNames.empty()) {
-								ImGui::SeparatorText("Script Fields");
+								ImGui::PushID(fname.c_str());
 
-								// ? NEW: Group struct fields under collapsible headers
-								std::unordered_map<std::string, std::vector<std::string>> structGroups;
-								std::vector<std::string> normalFields;
+								bool fieldChanged = false;
 
-								// Separate struct fields (contain '.') from normal fields
-								for (const auto& fname : fieldNames) {
-									if (fname.find('.') != std::string::npos) {
-										// Extract struct name (e.g., "stats" from "stats.health")
-										size_t dotPos = fname.find('.');
-										std::string structName = fname.substr(0, dotPos);
-										structGroups[structName].push_back(fname);
-									}
-									else {
-										normalFields.push_back(fname);
+								if (ftype == "bool") {
+									bool v = (fval == "1" || fval == "true");
+									if (ImGui::Checkbox(fname.c_str(), &v)) {
+										comp.Instance->SetFieldValueFromString(fname, v ? "1" : "0");
+										fieldChanged = true;
 									}
 								}
+								else if (ftype == "int") {
+									int v = 0; if (!fval.empty()) v = std::stoi(fval);
+									if (ImGui::DragInt(fname.c_str(), &v)) {
+										comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
+										fieldChanged = true;
+									}
+								}
+								else if (ftype == "float") {
+									float v = 0.f; if (!fval.empty()) v = std::stof(fval);
+									if (ImGui::DragFloat(fname.c_str(), &v, 0.01f)) {
+										comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
+										fieldChanged = true;
+									}
+								}
+								else if (ftype == "vec3") {
+									NE::Math::Vec3 vv = Vec3FromString(fval);
+									if (Editor::DrawVec3Control(fname.c_str(), vv, 0.0f, 100.0f)) {
+										comp.Instance->SetFieldValueFromString(fname, Vec3ToString(vv));
+										fieldChanged = true;
+									}
+								}
+								else if (ftype == "enum") {
+									// Enum dropdown support
+									auto enumOptions = comp.Instance->GetEnumOptions(fname);
+									if (!enumOptions.empty()) {
+										int currentValue = 0;
+										if (!fval.empty()) {
+											try {
+												currentValue = std::stoi(fval);
+											}
+											catch (...) {
+												currentValue = 0;
+											}
+										}
 
-								// Render normal fields first
-								for (const auto& fname : normalFields) {
-									std::string ftype = comp.Instance->GetFieldType(fname);
-									std::string fval = comp.Instance->GetFieldValueAsString(fname);
+										// Clamp to valid range
+										if (currentValue < 0 || currentValue >= static_cast<int>(enumOptions.size())) {
+											currentValue = 0;
+										}
 
-									ImGui::PushID(fname.c_str());
-
-									bool fieldChanged = false;
-
-									if (ftype == "bool") {
-										bool v = (fval == "1" || fval == "true");
-										if (ImGui::Checkbox(fname.c_str(), &v)) {
-											comp.Instance->SetFieldValueFromString(fname, v ? "1" : "0");
-											fieldChanged = true;
+										if (ImGui::BeginCombo(fname.c_str(), enumOptions[currentValue].c_str())) {
+											for (int i = 0; i < static_cast<int>(enumOptions.size()); ++i) {
+												bool isSelected = (currentValue == i);
+												if (ImGui::Selectable(enumOptions[i].c_str(), isSelected)) {
+													comp.Instance->SetFieldValueFromString(fname, std::to_string(i));
+													fieldChanged = true;
+												}
+												if (isSelected) {
+													ImGui::SetItemDefaultFocus();
+												}
+											}
+											ImGui::EndCombo();
 										}
 									}
-									else if (ftype == "int") {
-										int v = 0; if (!fval.empty()) v = std::stoi(fval);
+									else {
+										// Fallback if no enum options provided
+										ImGui::Text("%s: %s (enum - no options)", fname.c_str(), fval.c_str());
+									}
+								}
+								else if (ftype.starts_with("componentref:")) {
+									// Component reference field
+									// Extract component type (e.g., "Transform" from "componentref:Transform")
+									std::string componentType = ftype.substr(13); // Skip "componentref:"
+
+									// Get current pointer value and try to find the entity name
+									std::string displayName = "None";
+									uint32_t assignedEntityId = NE::ECS::NO_ENTITY;
+									std::string noEntityStr = std::to_string(NE::ECS::NO_ENTITY);								
+									if (!fval.empty() && fval != noEntityStr) {
+										try {
+											// Now fval is entity ID, not a pointer!
+											assignedEntityId = static_cast<uint32_t>(std::stoul(fval));
+
+											// Verify entity still exists and has the component
+											NE::ECS::Signature entitySig(NE::ECS::Query::GetEntitySignature(assignedEntityId));
+											bool isValid = false;
+
+											if (componentType == "Transform") {
+												isValid = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::Transform)]);
+											}
+											else if (componentType == "Rigidbody") {
+												isValid = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::Rigidbody)]);
+											}
+											else if (componentType == "AudioSource") {
+												isValid = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::AudioSource)]);
+											}
+
+											if (isValid) {
+												const auto& meta = NE::ECS::Query::GetEntityMeta(assignedEntityId);
+												displayName = meta.name.empty() ? "Entity" : meta.name;
+											}
+											else {
+												displayName = "[Invalid Reference]";
+												assignedEntityId = NE::ECS::NO_ENTITY;
+											}
+										}
+										catch (...) {
+											displayName = "[Error]";
+										}
+									}
+
+									// Display the component reference field
+									ImGui::Text("%s (%s)", fname.c_str(), componentType.c_str());
+
+									ImGui::PushID((fname + "_compref").c_str());
+
+									// Button shows entity name or status
+									if (ImGui::Button(displayName.c_str(), ImVec2(200, 0))) {
+										// Future: could select the referenced entity in hierarchy
+										if (assignedEntityId != NE::ECS::NO_ENTITY) {
+											SPD_DEBUG("Referenced entity: {} (ID: {})", displayName, assignedEntityId);
+										}
+									}
+
+									// Drag-drop support - accept entity drops
+									if (ImGui::BeginDragDropTarget()) {
+										// Try to accept HIER_DRAG_ID (from Hierarchy panel)
+										const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("HIER_DRAG_ID");
+										if (payload && payload->DataSize == sizeof(uint32_t)) {
+											uint32_t droppedEntity = *(const uint32_t*)payload->Data;
+
+											// Verify entity has the required component
+											bool hasComponent = false;
+											NE::ECS::Signature entitySig(NE::ECS::Query::GetEntitySignature(droppedEntity));
+
+											if (componentType == "Transform") {
+												hasComponent = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::Transform)]);
+											}
+											else if (componentType == "Rigidbody") {
+												hasComponent = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::Rigidbody)]);
+											}
+											else if (componentType == "AudioSource") {
+												hasComponent = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::AudioSource)]);
+											}
+
+											if (hasComponent) {
+												const auto& meta = NE::ECS::Query::GetEntityMeta(droppedEntity);
+												std::string entityName = meta.name.empty() ? "Entity" : meta.name;
+
+												// Store entity ID (not pointer!)
+												bool success = comp.Instance->SetFieldValueFromString(fname, std::to_string(droppedEntity));
+
+												if (success) {
+													comp.Instance->RefreshComponentReferences();
+													(fieldChanged = true);
+												}
+											}
+										}
+										ImGui::EndDragDropTarget();
+									}
+
+									// Clear button
+									ImGui::SameLine();
+									if (ImGui::Button("X")) {
+										comp.Instance->SetFieldValueFromString(fname, noEntityStr);
+										comp.Instance->RefreshComponentReferences(); // Clear the pointer too
+										fieldChanged = true;
+									}
+
+									ImGui::PopID();
+								}
+								else if (ftype.starts_with("vector<")) {
+									// Array/Vector support (int, float, bool, string)
+									// NOTE: Nested struct vectors not yet supported - will be added in future commit
+									size_t arraySize = comp.Instance->GetArraySize(fname);
+
+									if (ImGui::TreeNode(fname.c_str(), "%s [%zu]", fname.c_str(), arraySize)) {
+										// Add element button
+										if (ImGui::Button("+##add")) {
+											comp.Instance->AddArrayElement(fname);
+											fieldChanged = true;
+										}
+										ImGui::SameLine();
+										ImGui::Text("Add Element");
+
+										// Display each element
+										for (size_t i = 0; i < arraySize; ++i) {
+											ImGui::PushID(static_cast<int>(i));
+
+											std::string elemValue = comp.Instance->GetArrayElement(fname, i);
+
+											// Determine element type from vector<T>
+											std::string elementType = ftype.substr(7, ftype.length() - 8); // Extract T from "vector<T>"
+
+											ImGui::Text("[%zu]", i);
+											ImGui::SameLine();
+
+											bool elemChanged = false;
+											if (elementType == "int") {
+												int val = elemValue.empty() ? 0 : std::stoi(elemValue);
+												if (ImGui::DragInt("##elem", &val)) {
+													comp.Instance->SetArrayElement(fname, i, std::to_string(val));
+													elemChanged = true;
+												}
+											}
+											else if (elementType == "float") {
+												float val = elemValue.empty() ? 0.0f : std::stof(elemValue);
+												if (ImGui::DragFloat("##elem", &val, 0.01f)) {
+													comp.Instance->SetArrayElement(fname, i, std::to_string(val));
+													elemChanged = true;
+												}
+											}
+											else if (elementType == "bool") {
+												bool val = (elemValue == "1" || elemValue == "true");
+												if (ImGui::Checkbox("##elem", &val)) {
+													comp.Instance->SetArrayElement(fname, i, val ? "1" : "0");
+													elemChanged = true;
+
+													// Verification removed for release
+													//std::string verifyValue = comp.Instance->GetArrayElement(fname, i);
+													//SPD_DEBUG(" Verification: flags[" << i << "] is now '" << verifyValue << "'");
+												}
+											}
+											else if (elementType == "string") {
+												// String support for vector<string>
+												char buf[256];
+												strncpy_s(buf, elemValue.c_str(), sizeof(buf));
+												buf[sizeof(buf) - 1] = '\0';
+												if (ImGui::InputText("##elem", buf, sizeof(buf))) {
+													comp.Instance->SetArrayElement(fname, i, std::string(buf));
+													elemChanged = true;
+												}
+											}
+											else {
+												// Unknown type fallback - treat as string
+												char buf[256];
+												strncpy_s(buf, elemValue.c_str(), sizeof(buf));
+												buf[sizeof(buf) - 1] = '\0';
+												if (ImGui::InputText("##elem", buf, sizeof(buf))) {
+													comp.Instance->SetArrayElement(fname, i, std::string(buf));
+													elemChanged = true;
+												}
+											}
+
+											ImGui::SameLine();
+											if (ImGui::Button("-##remove")) {
+												comp.Instance->RemoveArrayElement(fname, i);
+												fieldChanged = true;
+											}
+
+											if (elemChanged) {
+												fieldChanged = true;
+											}
+
+											ImGui::PopID();
+										}
+
+										ImGui::TreePop();
+									}
+								}
+								else if (fname.find('.') != std::string::npos) {
+									// Struct field (contains dot notation)
+									// NOTE: Nested struct serialization not fully supported yet - will be added in future commit
+									   // Display as normal field, but with indentation
+									ImGui::Indent();
+
+									if (ftype == "int") {
+										int v = 0;
+										if (!fval.empty()) v = std::stoi(fval);
 										if (ImGui::DragInt(fname.c_str(), &v)) {
 											comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
 											fieldChanged = true;
 										}
 									}
 									else if (ftype == "float") {
-										float v = 0.f; if (!fval.empty()) v = std::stof(fval);
+										float v = 0.0f;
+										if (!fval.empty()) v = std::stof(fval);
 										if (ImGui::DragFloat(fname.c_str(), &v, 0.01f)) {
 											comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
 											fieldChanged = true;
 										}
 									}
-									else if (ftype == "vec3") {
-										NE::Math::Vec3 vv = Vec3FromString(fval);
-										if (Editor::DrawVec3Control(fname.c_str(), vv, 0.0f, 100.0f)) {
-											comp.Instance->SetFieldValueFromString(fname, Vec3ToString(vv));
+									else if (ftype == "bool") {
+										bool v = (fval == "1" || fval == "true");
+										if (ImGui::Checkbox(fname.c_str(), &v)) {
+											comp.Instance->SetFieldValueFromString(fname, v ? "1" : "0");
 											fieldChanged = true;
 										}
 									}
-									else if (ftype == "enum") {
-										// Enum dropdown support
-										auto enumOptions = comp.Instance->GetEnumOptions(fname);
-										if (!enumOptions.empty()) {
-											int currentValue = 0;
-											if (!fval.empty()) {
-												try {
-													currentValue = std::stoi(fval);
-												}
-												catch (...) {
-													currentValue = 0;
-												}
-											}
 
-											// Clamp to valid range
-											if (currentValue < 0 || currentValue >= static_cast<int>(enumOptions.size())) {
-												currentValue = 0;
-											}
-
-											if (ImGui::BeginCombo(fname.c_str(), enumOptions[currentValue].c_str())) {
-												for (int i = 0; i < static_cast<int>(enumOptions.size()); ++i) {
-													bool isSelected = (currentValue == i);
-													if (ImGui::Selectable(enumOptions[i].c_str(), isSelected)) {
-														comp.Instance->SetFieldValueFromString(fname, std::to_string(i));
-														fieldChanged = true;
-													}
-													if (isSelected) {
-														ImGui::SetItemDefaultFocus();
-													}
-												}
-												ImGui::EndCombo();
-											}
-										}
-										else {
-											// Fallback if no enum options provided
-											ImGui::Text("%s: %s (enum - no options)", fname.c_str(), fval.c_str());
-										}
+									ImGui::Unindent();
+								}
+								else { // treat as string
+									char buf[256];
+									strncpy_s(buf, fval.c_str(), sizeof(buf));
+									if (ImGui::InputText(fname.c_str(), buf, sizeof(buf))) {
+										comp.Instance->SetFieldValueFromString(fname, std::string(buf));
+										fieldChanged = true;
 									}
-									else if (ftype.starts_with("componentref:")) {
-										// Component reference field
-										// Extract component type (e.g., "Transform" from "componentref:Transform")
-										std::string componentType = ftype.substr(13); // Skip "componentref:"
+								}
 
-										// Get current pointer value and try to find the entity name
-										std::string displayName = "None";
-										uint32_t assignedEntityId = NE::ECS::NO_ENTITY;
+								// Call OnValidate() when a field changes (editor-only)
+								if (fieldChanged) {
+									comp.Instance->OnValidate();
+									NE::MarkSceneDirty();
+									// printf("[DirtyFlag] Script field changed - Scene marked DIRTY\n"); // Too spammy
+								}
 
-										if (!fval.empty() && fval != "0") {
-											try {
-												// Now fval is entity ID, not a pointer!
-												assignedEntityId = static_cast<uint32_t>(std::stoul(fval));
+								ImGui::PopID();
+							}
 
-												// Verify entity still exists and has the component
-												NE::ECS::Signature entitySig(NE::ECS::Query::GetEntitySignature(assignedEntityId));
-												bool isValid = false;
+							//  NOW RENDER STRUCT GROUPS
+							for (const auto& [structName, fields] : structGroups) {
+								if (ImGui::TreeNode(structName.c_str())) {
+									for (const auto& fname : fields) {
+										std::string ftype = comp.Instance->GetFieldType(fname);
+										std::string fval = comp.Instance->GetFieldValueAsString(fname);
 
-												if (componentType == "Transform") {
-													isValid = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::Transform)]);
-												}
-												else if (componentType == "Rigidbody") {
-													isValid = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::Rigidbody)]);
-												}
-												else if (componentType == "AudioSource") {
-													isValid = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::AudioSource)]);
-												}
+										// Extract field name after dot (e.g., "health" from "stats.health")
+										size_t dotPos = fname.find('.');
+										std::string fieldName = fname.substr(dotPos + 1);
 
-												if (isValid) {
-													const auto& meta = NE::ECS::Query::GetEntityMeta(assignedEntityId);
-													displayName = meta.name.empty() ? "Entity" : meta.name;
-												}
-												else {
-													displayName = "[Invalid Reference]";
-													assignedEntityId = NE::ECS::NO_ENTITY;
-												}
-											}
-											catch (...) {
-												displayName = "[Error]";
-											}
-										}
-
-										// Display the component reference field
-										ImGui::Text("%s (%s)", fname.c_str(), componentType.c_str());
-
-										ImGui::PushID((fname + "_compref").c_str());
-
-										// Button shows entity name or status
-										if (ImGui::Button(displayName.c_str(), ImVec2(200, 0))) {
-											// Future: could select the referenced entity in hierarchy
-											if (assignedEntityId != NE::ECS::NO_ENTITY) {
-												SPD_DEBUG("Referenced entity: {} (ID: {})", displayName, assignedEntityId);
-											}
-										}
-
-										// Drag-drop support - accept entity drops
-										if (ImGui::BeginDragDropTarget()) {
-											// Try to accept HIER_DRAG_ID (from Hierarchy panel)
-											const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("HIER_DRAG_ID");
-											if (payload && payload->DataSize == sizeof(uint32_t)) {
-												uint32_t droppedEntity = *(const uint32_t*)payload->Data;
-
-												// Verify entity has the required component
-												bool hasComponent = false;
-												NE::ECS::Signature entitySig(NE::ECS::Query::GetEntitySignature(droppedEntity));
-
-												if (componentType == "Transform") {
-													hasComponent = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::Transform)]);
-												}
-												else if (componentType == "Rigidbody") {
-													hasComponent = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::Rigidbody)]);
-												}
-												else if (componentType == "AudioSource") {
-													hasComponent = entitySig.test(NE::ECS::Query::GetRegisteredComponentTypes()[typeid(NE::ECS::Component::AudioSource)]);
-												}
-
-												if (hasComponent) {
-													const auto& meta = NE::ECS::Query::GetEntityMeta(droppedEntity);
-													std::string entityName = meta.name.empty() ? "Entity" : meta.name;
-
-													// Store entity ID (not pointer!)
-													bool success = comp.Instance->SetFieldValueFromString(fname, std::to_string(droppedEntity));
-
-													if (success) {
-														comp.Instance->RefreshComponentReferences();
-														fieldChanged = true;
-													}
-												}
-											}
-											ImGui::EndDragDropTarget();
-										}
-
-										// Clear button
-										ImGui::SameLine();
-										if (ImGui::Button("X")) {
-											comp.Instance->SetFieldValueFromString(fname, "0");
-											comp.Instance->RefreshComponentReferences(); // Clear the pointer too
-											fieldChanged = true;
-										}
-
-										ImGui::PopID();
-									}
-									else if (ftype.starts_with("vector<")) {
-										// Array/Vector support (int, float, bool, string)
-										// NOTE: Nested struct vectors not yet supported - will be added in future commit
-										size_t arraySize = comp.Instance->GetArraySize(fname);
-
-										if (ImGui::TreeNode(fname.c_str(), "%s [%zu]", fname.c_str(), arraySize)) {
-											// Add element button
-											if (ImGui::Button("+##add")) {
-												comp.Instance->AddArrayElement(fname);
-												fieldChanged = true;
-											}
-											ImGui::SameLine();
-											ImGui::Text("Add Element");
-
-											// Display each element
-											for (size_t i = 0; i < arraySize; ++i) {
-												ImGui::PushID(static_cast<int>(i));
-
-												std::string elemValue = comp.Instance->GetArrayElement(fname, i);
-
-												// Determine element type from vector<T>
-												std::string elementType = ftype.substr(7, ftype.length() - 8); // Extract T from "vector<T>"
-
-												ImGui::Text("[%zu]", i);
-												ImGui::SameLine();
-
-												bool elemChanged = false;
-												if (elementType == "int") {
-													int val = elemValue.empty() ? 0 : std::stoi(elemValue);
-													if (ImGui::DragInt("##elem", &val)) {
-														comp.Instance->SetArrayElement(fname, i, std::to_string(val));
-														elemChanged = true;
-													}
-												}
-												else if (elementType == "float") {
-													float val = elemValue.empty() ? 0.0f : std::stof(elemValue);
-													if (ImGui::DragFloat("##elem", &val, 0.01f)) {
-														comp.Instance->SetArrayElement(fname, i, std::to_string(val));
-														elemChanged = true;
-													}
-												}
-												else if (elementType == "bool") {
-													bool val = (elemValue == "1" || elemValue == "true");
-													if (ImGui::Checkbox("##elem", &val)) {
-														comp.Instance->SetArrayElement(fname, i, val ? "1" : "0");
-														elemChanged = true;
-
-														// Verification removed for release
-														//std::string verifyValue = comp.Instance->GetArrayElement(fname, i);
-														//SPD_DEBUG(" Verification: flags[" << i << "] is now '" << verifyValue << "'");
-													}
-												}
-												else if (elementType == "string") {
-													// String support for vector<string>
-													char buf[256];
-													strncpy_s(buf, elemValue.c_str(), sizeof(buf));
-													buf[sizeof(buf) - 1] = '\0';
-													if (ImGui::InputText("##elem", buf, sizeof(buf))) {
-														comp.Instance->SetArrayElement(fname, i, std::string(buf));
-														elemChanged = true;
-													}
-												}
-												else {
-													// Unknown type fallback - treat as string
-													char buf[256];
-													strncpy_s(buf, elemValue.c_str(), sizeof(buf));
-													buf[sizeof(buf) - 1] = '\0';
-													if (ImGui::InputText("##elem", buf, sizeof(buf))) {
-														comp.Instance->SetArrayElement(fname, i, std::string(buf));
-														elemChanged = true;
-													}
-												}
-
-												ImGui::SameLine();
-												if (ImGui::Button("-##remove")) {
-													comp.Instance->RemoveArrayElement(fname, i);
-													fieldChanged = true;
-												}
-
-												if (elemChanged) {
-													fieldChanged = true;
-												}
-
-												ImGui::PopID();
-											}
-
-											ImGui::TreePop();
-										}
-									}
-									else if (fname.find('.') != std::string::npos) {
-										// Struct field (contains dot notation)
-										// NOTE: Nested struct serialization not fully supported yet - will be added in future commit
-									   // Display as normal field, but with indentation
-										ImGui::Indent();
+										ImGui::PushID(fname.c_str());
+										bool fieldChanged = false;
 
 										if (ftype == "int") {
 											int v = 0;
 											if (!fval.empty()) v = std::stoi(fval);
-											if (ImGui::DragInt(fname.c_str(), &v)) {
+											if (ImGui::DragInt(fieldName.c_str(), &v)) {
 												comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
 												fieldChanged = true;
 											}
@@ -971,84 +1048,26 @@ namespace Editor {
 										else if (ftype == "float") {
 											float v = 0.0f;
 											if (!fval.empty()) v = std::stof(fval);
-											if (ImGui::DragFloat(fname.c_str(), &v, 0.01f)) {
+											if (ImGui::DragFloat(fieldName.c_str(), &v, 0.01f)) {
 												comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
 												fieldChanged = true;
 											}
 										}
 										else if (ftype == "bool") {
 											bool v = (fval == "1" || fval == "true");
-											if (ImGui::Checkbox(fname.c_str(), &v)) {
+											if (ImGui::Checkbox(fieldName.c_str(), &v)) {
 												comp.Instance->SetFieldValueFromString(fname, v ? "1" : "0");
 												fieldChanged = true;
 											}
 										}
 
-										ImGui::Unindent();
-									}
-									else { // treat as string
-										char buf[256];
-										strncpy_s(buf, fval.c_str(), sizeof(buf));
-										if (ImGui::InputText(fname.c_str(), buf, sizeof(buf))) {
-											comp.Instance->SetFieldValueFromString(fname, std::string(buf));
-											fieldChanged = true;
+										if (fieldChanged) {
+											comp.Instance->OnValidate();
 										}
+
+										ImGui::PopID();
 									}
-
-									// Call OnValidate() when a field changes (editor-only)
-									if (fieldChanged) {
-										comp.Instance->OnValidate();
-									}
-
-									ImGui::PopID();
-								}
-
-								//  NOW RENDER STRUCT GROUPS
-								for (const auto& [structName, fields] : structGroups) {
-									if (ImGui::TreeNode(structName.c_str())) {
-										for (const auto& fname : fields) {
-											std::string ftype = comp.Instance->GetFieldType(fname);
-											std::string fval = comp.Instance->GetFieldValueAsString(fname);
-
-											// Extract field name after dot (e.g., "health" from "stats.health")
-											size_t dotPos = fname.find('.');
-											std::string fieldName = fname.substr(dotPos + 1);
-
-											ImGui::PushID(fname.c_str());
-											bool fieldChanged = false;
-
-											if (ftype == "int") {
-												int v = 0;
-												if (!fval.empty()) v = std::stoi(fval);
-												if (ImGui::DragInt(fieldName.c_str(), &v)) {
-													comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
-													fieldChanged = true;
-												}
-											}
-											else if (ftype == "float") {
-												float v = 0.0f;
-												if (!fval.empty()) v = std::stof(fval);
-												if (ImGui::DragFloat(fieldName.c_str(), &v, 0.01f)) {
-													comp.Instance->SetFieldValueFromString(fname, std::to_string(v));
-													fieldChanged = true;
-												}
-											}
-											else if (ftype == "bool") {
-												bool v = (fval == "1" || fval == "true");
-												if (ImGui::Checkbox(fieldName.c_str(), &v)) {
-													comp.Instance->SetFieldValueFromString(fname, v ? "1" : "0");
-													fieldChanged = true;
-												}
-											}
-
-											if (fieldChanged) {
-												comp.Instance->OnValidate();
-											}
-
-											ImGui::PopID();
-										}
-										ImGui::TreePop();
-									}
+									ImGui::TreePop();
 								}
 							}
 						}
@@ -1067,6 +1086,7 @@ namespace Editor {
 					auto& comp = NE::ECS::Query::GetEntityCamera(entity);
 					ImGui::SeparatorText("Camera");
 
+					//auto& comp = NE::ECS::Query::GetEntityCamera(entity);
 					NE::Core::ForEachFieldView<NE::ECS::Component::Camera>(comp,
 						[&](auto const& desc, auto const& currentValue) {
 							using Owner = NE::ECS::Component::Camera;
@@ -1219,29 +1239,46 @@ namespace Editor {
 			if (ImGui::BeginPopup("ComponentList")) { // automate this next time with a registry
 				if (ImGui::MenuItem("Renderer")) {
 					NE::ECS::Command::AddRendererComponent(EditorScene::s_selectedEntity->linkedEntity);
+					NE::MarkSceneDirty();
+					SPD_DEBUG("[DirtyFlag] Added Renderer component - Scene marked DIRTY");
 				}
 				if (ImGui::MenuItem("Rigidbody")) {
 					NE::ECS::Command::AddColliderComponent(EditorScene::s_selectedEntity->linkedEntity);
 					NE::ECS::Command::AddRigidbodyComponent(EditorScene::s_selectedEntity->linkedEntity);
+					NE::MarkSceneDirty();
+					SPD_DEBUG("[DirtyFlag] Added Rigidbody/Collider components - Scene marked DIRTY");
 				}
 				if (ImGui::MenuItem("Collider")) {
 					NE::ECS::Command::AddColliderComponent(EditorScene::s_selectedEntity->linkedEntity);
+					NE::MarkSceneDirty();
+					SPD_DEBUG("[DirtyFlag] Added Collider component - Scene marked DIRTY");
 				}
 				if (ImGui::MenuItem("Light")) {
 					NE::ECS::Command::AddLightComponent(EditorScene::s_selectedEntity->linkedEntity);
+					NE::MarkSceneDirty();
+					SPD_DEBUG("[DirtyFlag] Added Light component - Scene marked DIRTY");
 				}
 				if (ImGui::MenuItem("AudioSource")) {
 					NE::ECS::Command::AddAudioSourceComponent(EditorScene::s_selectedEntity->linkedEntity);
+					NE::MarkSceneDirty();
+					SPD_DEBUG("[DirtyFlag] Added AudioSource component - Scene marked DIRTY");
 				}
 				if (ImGui::MenuItem("Script")) {
 					NE::ECS::Command::AddScriptComponent(EditorScene::s_selectedEntity->linkedEntity);
+					NE::MarkSceneDirty();
+					SPD_DEBUG("[DirtyFlag] Added Script component - Scene marked DIRTY");
 				}
 				if (ImGui::MenuItem("Camera")) {
 					NE::ECS::Command::AddCameraComponent(EditorScene::s_selectedEntity->linkedEntity);
+					NE::MarkSceneDirty();
+					SPD_DEBUG("[DirtyFlag] Added Camera component - Scene marked DIRTY");
 				}
 				if (ImGui::MenuItem("Animator")) {
 					NE::ECS::Command::AddAnimatorComponent(EditorScene::s_selectedEntity->linkedEntity);
+					NE::MarkSceneDirty();
+					SPD_DEBUG("[DirtyFlag] Added Animator component - Scene marked DIRTY");
 				}
+
 				ImGui::EndPopup();
 			}
 		}

--- a/GameCode/GameCode.vcxproj.filters
+++ b/GameCode/GameCode.vcxproj.filters
@@ -54,12 +54,6 @@
     <ClInclude Include="Scripts\FollowerScript.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Scripts\CameraFollowScript.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Scripts\LookAtScript.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">

--- a/GameCode/GameEntry.cpp
+++ b/GameCode/GameEntry.cpp
@@ -22,6 +22,7 @@
 
 // Component Reference Example Scripts
 #include "Scripts/FollowerScript.hpp"
+
 // extern "C" ensures C linkage so the Engine DLL can find this function
 extern "C" {
     // Export this function so it can be called from the Engine DLL
@@ -70,12 +71,14 @@ extern "C" {
 
         registrar->RegisterScript("k2bswitch", []() -> IScript* {
             return new k2bswitch();
-     });
+            });
 
         // Component Reference Example Scripts
           registrar->RegisterScript("FollowerScript", []() -> IScript* {
           return new FollowerScript();
      });
+
+
 
     }
 }

--- a/GameCode/Scripts/FollowerScript.hpp
+++ b/GameCode/Scripts/FollowerScript.hpp
@@ -6,7 +6,7 @@
 /**
  * Example: Follower Script
  * This entity will follow another entity's Transform component.
- * 
+ *
  * Usage:
  * 1. Add this script to an entity (e.g., "Enemy")
  * 2. In the inspector, drag the "Player" entity onto the "targetTransform" field
@@ -14,75 +14,75 @@
  */
 class FollowerScript : public IScript {
 public:
-    FollowerScript() {
-// Register component reference - this will show up in the inspector
-        SCRIPT_COMPONENT_REF(targetTransform, Transform);
-      
-        // Register other fields
-        SCRIPT_FIELD(followSpeed, Float);
-        SCRIPT_FIELD(stopDistance, Float);
-    }
+	FollowerScript() {
+		// Register component reference - this will show up in the inspector
+		SCRIPT_COMPONENT_REF(targetTransform, Transform);
 
-    void Initialize(NE::ECS::Entity entity) override {
-        // Nothing to do here
-    }
+		// Register other fields
+		SCRIPT_FIELD(followSpeed, Float);
+		SCRIPT_FIELD(stopDistance, Float);
+	}
 
-    void Update(double deltaTime) override {
-        // Check if we have a valid target
-        if (!targetTransform) {
-         return; // No target assigned
-        }
+	void Initialize(NE::ECS::Entity entity) override {
+		// Nothing to do here
+	}
 
-      // Get target position
-        NE::Math::Vec3 targetPos = targetTransform->position;
-        NE::Math::Vec3 myPos = GetPosition();
-        
-        // Calculate direction to target
-        NE::Math::Vec3 direction = {
-    targetPos.x - myPos.x,
-         targetPos.y - myPos.y,
-         targetPos.z - myPos.z
-        };
-        
-        // Calculate distance
-        float distance = std::sqrt(
-      direction.x * direction.x +
-            direction.y * direction.y +
-         direction.z * direction.z
-        );
-        
-// Only move if we're far enough away
-        if (distance > stopDistance) {
-    // Normalize direction
-        direction.x /= distance;
-            direction.y /= distance;
-         direction.z /= distance;
-      
-    // Move towards target
-   float moveAmount = followSpeed * static_cast<float>(deltaTime);
-            Translate(
-     direction.x * moveAmount,
-             direction.y * moveAmount,
-     direction.z * moveAmount
-      );
-    }
-    }
+	void Update(double deltaTime) override {
+		// Check if we have a valid target
+		if (!targetTransform) {
+			return; // No target assigned
+		}
 
- const char* GetTypeName() const override {
-        return "FollowerScript";
-    }
+		// Get target position
+		NE::Math::Vec3 targetPos = targetTransform->position;
+		NE::Math::Vec3 myPos = GetPosition();
 
-    // Event handlers (required by interface)
-    void OnCollisionEnter(NE::ECS::Entity other) override {}
-    void OnCollisionExit(NE::ECS::Entity other) override {}
-    void OnTriggerEnter(NE::ECS::Entity other) override {}
-    void OnTriggerExit(NE::ECS::Entity other) override {}
+		// Calculate direction to target
+		NE::Math::Vec3 direction = {
+		 targetPos.x - myPos.x,
+		 targetPos.y - myPos.y,
+		 targetPos.z - myPos.z
+		};
+
+		// Calculate distance
+		float distance = std::sqrt(
+			direction.x * direction.x +
+			direction.y * direction.y +
+			direction.z * direction.z
+		);
+
+		// Only move if we're far enough away
+		if (distance > stopDistance) {
+			// Normalize direction
+			direction.x /= distance;
+			direction.y /= distance;
+			direction.z /= distance;
+
+			// Move towards target
+			float moveAmount = followSpeed * static_cast<float>(deltaTime);
+			Translate(
+				direction.x * moveAmount,
+				direction.y * moveAmount,
+				direction.z * moveAmount
+			);
+		}
+	}
+
+	const char* GetTypeName() const override {
+		return "FollowerScript";
+	}
+
+	// Event handlers (required by interface)
+	void OnCollisionEnter(NE::ECS::Entity other) override {}
+	void OnCollisionExit(NE::ECS::Entity other) override {}
+	void OnTriggerEnter(NE::ECS::Entity other) override {}
+	void OnTriggerExit(NE::ECS::Entity other) override {}
 
 private:
-    // ? Component reference - will hold pointer to target's Transform
-    ComponentRef<NE::ECS::Component::Transform> targetTransform;
-    
-    // Regular fields
-    float followSpeed = 5.0f;
-    float stopDistance = 2.0f;
+	// ? Component reference - will hold pointer to target's Transform
+	ComponentRef<NE::ECS::Component::Transform> targetTransform;
+
+	// Regular fields
+	float followSpeed = 5.0f;
+	float stopDistance = 2.0f;
 };

--- a/GameCode/Scripts/TestScript.hpp
+++ b/GameCode/Scripts/TestScript.hpp
@@ -8,82 +8,87 @@
 /**
  * Test script to demonstrate the new built-in field system.
  * This script shows how easy it is to expose fields to the editor.
+ *
+ * DIRTY FLAG SYSTEM:
+ * - Changes made during Play Mode do NOT mark components dirty (they reset on Stop)
+ * - Changes made during Editor Mode DO mark components dirty (they are serialized)
+ * - Use MarkComponentDirty<T>() manually if needed when writing Editor Scripts
  */
 
 void PlayerTestEvent(void* data) {
-    int tmp = *reinterpret_cast<int*>(data);
-   // SPD_CRITICAL("HIIII Player {}", tmp);
-    std::cout << tmp << std::endl;
+	int tmp = *reinterpret_cast<int*>(data);
+	// SPD_CRITICAL("HIIII Player {}", tmp);
+	std::cout << tmp << std::endl;
 }
 
 
 class TestScript : public IScript {
 public:
-    TestScript() {
-        // Register all our fields using the simple macros
-        SCRIPT_FIELD(rotationSpeed, Float);
-        SCRIPT_FIELD(bounceHeight, Float);
-        SCRIPT_FIELD(color, Vec3);
-        SCRIPT_FIELD(particleCount, Int);
-        SCRIPT_FIELD(isActive, Bool);
-        SCRIPT_FIELD(objectName, String);
+	TestScript() {
+		// Register all our fields using the simple macros
+		SCRIPT_FIELD(rotationSpeed, Float);
+		SCRIPT_FIELD(bounceHeight, Float);
+		SCRIPT_FIELD(color, Vec3);
+		SCRIPT_FIELD(particleCount, Int);
+		SCRIPT_FIELD(isActive, Bool);
+		SCRIPT_FIELD(objectName, String);
 
-        std::cout << "[TestScript] Created with fields registered" << std::endl;
-    }
+		std::cout << "[TestScript] Created with fields registered" << std::endl;
+	}
 
-    void Initialize(NE::ECS::Entity entity) override {
-        //std::cout << "[TestScript] Initialized for entity " << entity << std::endl;
-        //std::cout << "[TestScript] Initial values:" << std::endl;
-        //std::cout << "  - Rotation Speed: " << rotationSpeed << std::endl;
-        //std::cout << "  - Bounce Height: " << bounceHeight << std::endl;
-        //std::cout << "  - Color: (" << color.x << ", " << color.y << ", " << color.z << ")" << std::endl;
-        //std::cout << "  - Particle Count: " << particleCount << std::endl;
-        //std::cout << "  - Is Active: " << (isActive ? "true" : "false") << std::endl;
-        //std::cout << "  - Object Name: " << objectName << std::endl;
+	void Initialize(NE::ECS::Entity entity) override {
+		//std::cout << "[TestScript] Initialized for entity " << entity << std::endl;
+  //std::cout << "[TestScript] Initial values:" << std::endl;
+	  //std::cout << "  - Rotation Speed: " << rotationSpeed << std::endl;
+		//std::cout << "  - Bounce Height: " << bounceHeight << std::endl;
+		//std::cout << "  - Color: (" << color.x << ", " << color.y << ", " << color.z << ")" << std::endl;
+		//std::cout << "  - Particle Count: " << particleCount << std::endl;
+		//std::cout << "  - Is Active: " << (isActive ? "true" : "false") << std::endl;
+		//std::cout << "  - Object Name: " << objectName << std::endl;
 
-        NANOEngine::Events::RegisterScriptEventListener("OnPlayerHit", PlayerTestEvent);
-    }
+		NANOEngine::Events::RegisterScriptEventListener("OnPlayerHit", PlayerTestEvent);
+	}
 
-    void Update(double deltaTime) override {
-        if (!isActive) return;
+	void Update(double deltaTime) override {
+		if (!isActive) return;
 
-        // Use the exposed fields in our logic
-        auto transform = GetComponent<NE::ECS::Component::Transform>();
-        if (transform) {
-            // Rotate using the rotation speed field
-            static float totalTime = 0.0f;
-            totalTime += static_cast<float>(deltaTime);
-            
-            // Simple bobbing motion using bounce height
-            transform->position.y = std::sin(totalTime * 2.0f) * bounceHeight;
-            
-            // You could also use the color field to set renderer color
-            // You could use particleCount to control particle systems
-            // etc.
-        }
-    }
+		// Use the exposed fields in our logic
+		auto transform = GetComponent<NE::ECS::Component::Transform>();
+		if (transform) {
+			// Rotate using the rotation speed field
+			static float totalTime = 0.0f;
+			totalTime += static_cast<float>(deltaTime);
 
-    void OnDestroy() override {
-        //std::cout << "[TestScript] Destroyed for entity " << GetEntity() << std::endl;
-    }
+			// Simple bobbing motion using bounce height
+			transform->position.y = std::sin(totalTime * 2.0f) * bounceHeight;
 
-    const char* GetTypeName() const override {
-        return "TestScript";
-    }
+			// You could also use the color field to set renderer color
+			// You could use particleCount to control particle systems
+			  // etc.
+		}
+	}
 
-    // Event handlers (required by interface)
-    void OnCollisionEnter(NE::ECS::Entity other) override {}
-    void OnCollisionExit(NE::ECS::Entity other) override {}
-    void OnTriggerEnter(NE::ECS::Entity other) override {}
-    void OnTriggerExit(NE::ECS::Entity other) override {}
+	void OnDestroy() override {
+		//std::cout << "[TestScript] Destroyed for entity " << GetEntity() << std::endl;
+	}
+
+	const char* GetTypeName() const override {
+		return "TestScript";
+	}
+
+	// Event handlers (required by interface)
+	void OnCollisionEnter(NE::ECS::Entity other) override {}
+	void OnCollisionExit(NE::ECS::Entity other) override {}
+	void OnTriggerEnter(NE::ECS::Entity other) override {}
+	void OnTriggerExit(NE::ECS::Entity other) override {}
 
 private:
-    // === Exposed Fields ===
-    // These will automatically appear in the editor inspector
-    float rotationSpeed = 90.0f;  // degrees per second
-    float bounceHeight = 1.0f;    // units
+	// === Exposed Fields ===
+	// These will automatically appear in the editor inspector
+	float rotationSpeed = 90.0f;  // degrees per second
+	float bounceHeight = 1.0f;    // units
     NE::Math::Vec3 color{1.0f, 0.0f, 0.0f};  // red by default
-    int particleCount = 50;
-    bool isActive = true;
-    std::string objectName = "TestObject";
+	int particleCount = 50;
+	bool isActive = true;
+	std::string objectName = "TestObject";
 };

--- a/NANOEngine/src/ECS/Components/Light.hpp
+++ b/NANOEngine/src/ECS/Components/Light.hpp
@@ -31,6 +31,9 @@ namespace NE::ECS::Component {
         float linear{ 0.f };
         float quadratic{ 1.f };
 
+        // Dirty flag for editor changes
+        bool isDirty = false;
+
         NE_REFLECT_BEGIN(Light)
             //NE_REFLECT_FIELD(type),
             NE_REFLECT_FIELD(direction),

--- a/NANOEngine/src/ECS/Components/Renderer.hpp
+++ b/NANOEngine/src/ECS/Components/Renderer.hpp
@@ -18,6 +18,7 @@ namespace NE::ECS::Component {
 		std::shared_ptr<Graphics::Material> material;
 
 		bool visible = true;
+		bool isDirty = false;  // Dirty flag for editor changes
 
 		NE_REFLECT_BEGIN(Renderer)
 			NE_REFLECT_FIELD(modelUUID),

--- a/NANOEngine/src/ECS/Components/Rigidbody.hpp
+++ b/NANOEngine/src/ECS/Components/Rigidbody.hpp
@@ -17,6 +17,9 @@ namespace NE::ECS::Component {
 
 		Math::Vec3 initialVelocity{ 0.f, 0.f, 0.f };
 
+		// Dirty flag for editor changes
+		bool isDirty = false;
+
 		NE_REFLECT_BEGIN(Rigidbody)
 			NE_REFLECT_FIELD(mass),
 			NE_REFLECT_FIELD(motionType),

--- a/NANOEngine/src/EditorInterface/RendererExports.cpp
+++ b/NANOEngine/src/EditorInterface/RendererExports.cpp
@@ -2,6 +2,9 @@
 #include "../SceneManagement/Scene.hpp"
 #include "../ECS/Components/Renderer.hpp"
 #include "ResourceManagement/ResourceManager.hpp"
+#include "../EngineState.hpp"  // For GetEngineState
+#include "../Engine.hpp"  // For MarkSceneDirty
+#include <Core/SpdLogger.hpp>  
 
 namespace NE {
 	SceneManagement::Scene& GetScene();
@@ -23,12 +26,26 @@ namespace NE::Renderer {
 				r.materialUUID = "neunlitmat";
 				r.material = Resource::ResourceManager::GetInstance().LoadResource<Graphics::Material>("neunlitmat");
 			}
+			
+			// Mark component and scene dirty (Edit mode only)
+			if (NE::GetEngineState() == NE::EngineState::Edit) {
+				if constexpr (requires { r.isDirty; }) r.isDirty = true;
+				NE::MarkSceneDirty();
+				SPD_DEBUG("[DirtyFlag] Model changed - Scene marked DIRTY");
+			}
 		}
 
 		void AssignMaterial(uint32_t e, const std::string& uuid) {
 			auto& r = NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::Renderer>(e);
 			r.materialUUID = uuid;
 			r.material = Resource::ResourceManager::GetInstance().LoadResource<Graphics::Material>(uuid);
+			
+			// Mark component and scene dirty (Edit mode only)
+			if (NE::GetEngineState() == NE::EngineState::Edit) {
+				if constexpr (requires { r.isDirty; }) r.isDirty = true;
+				NE::MarkSceneDirty();
+				SPD_DEBUG("[DirtyFlag] Material changed - Scene marked DIRTY");
+			}
 		}
 	}
 

--- a/NANOEngine/src/Engine.cpp
+++ b/NANOEngine/src/Engine.cpp
@@ -178,7 +178,29 @@ namespace NE {
 	}
 
 	void SaveCurrentScene(std::string path) {
-		Serialization::JsonSceneSerializer::Serialize(*gSceneManager.GetActive(), path);
+		auto* editorScene = gSceneManager.GetEditorScene();
+		if (!editorScene) return;
+		
+		SPD_INFO("[DirtyFlag] SaveCurrentScene called - Saving to: {}", path);
+		Serialization::JsonSceneSerializer::Serialize(*editorScene, path);
+		editorScene->ClearDirty();
+		SPD_INFO("[DirtyFlag] Scene saved and marked as CLEAN");
+	}
+
+	void SaveSceneIfDirty(std::string path) {
+		gSceneManager.SaveSceneIfDirty(path);
+	}
+
+	bool IsSceneDirty() {
+		auto* editorScene = gSceneManager.GetEditorScene();
+		return editorScene ? editorScene->IsDirty() : false;
+	}
+
+	void MarkSceneDirty() {
+		auto* editorScene = gSceneManager.GetEditorScene();
+		if (editorScene) {
+			editorScene->MarkDirty();
+		}
 	}
 
 	void LoadTargetScene(std::string targetPath) {

--- a/NANOEngine/src/Engine.hpp
+++ b/NANOEngine/src/Engine.hpp
@@ -30,6 +30,9 @@ namespace NE {
 	NANOENGINE_API uint32_t GetPickedEntity(uint32_t x, uint32_t y);
 	
 	NANOENGINE_API void SaveCurrentScene(std::string path);
+	NANOENGINE_API void SaveSceneIfDirty(std::string path = "");
+	NANOENGINE_API bool IsSceneDirty();
+	NANOENGINE_API void MarkSceneDirty();
 	NANOENGINE_API void LoadTargetScene(std::string targetPath);
 
 	NANOENGINE_API size_t GetNumEntities();

--- a/NANOEngine/src/EngineState.hpp
+++ b/NANOEngine/src/EngineState.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "NANOEngineAPI.hpp"
 
 namespace NE {
     enum class EngineState {
@@ -7,8 +8,8 @@ namespace NE {
         Paused
     };
 
-    extern EngineState g_EngineState;
+    extern NANOENGINE_API EngineState g_EngineState;
 
-    void SetEngineState(EngineState state);
-    EngineState GetEngineState();
+    NANOENGINE_API void SetEngineState(EngineState state);
+    NANOENGINE_API EngineState GetEngineState();
 }

--- a/NANOEngine/src/SceneManagement/Scene.cpp
+++ b/NANOEngine/src/SceneManagement/Scene.cpp
@@ -18,6 +18,7 @@
 #include "ECS/Components/NativeScript.hpp"
 #include "Core/Couroutine.hpp"
 #include <iostream>
+#include "Core/SpdLogger.hpp"  // For console logging
 
 static void LoadAllClipsIntoAnimator(NE::ECS::Systems::AnimatorSystem* sys) {
 	namespace fs = std::filesystem;
@@ -114,6 +115,21 @@ namespace NE::SceneManagement {
 
 	void Scene::ScriptStop() {
 		m_ecsCoordinator.m_scriptSystem->StopScripts();
+	}
+
+	void Scene::MarkDirty() {
+		if (!m_isDirty) {
+			m_isDirty = true;
+			SPD_INFO("[DirtyFlag] Scene marked as DIRTY - has unsaved changes");
+		}
+	}
+
+	void Scene::MarkComponentsDirty() {
+		// Check all components and if any are dirty, mark the scene as dirty
+		// This should be called periodically in Edit mode
+		// For now, we'll mark scene dirty whenever called - 
+		// a more optimized version would scan component pools
+		m_isDirty = true;
 	}
 
 	ECS::ECSCoordinator& Scene::GetECSCoordinator() {

--- a/NANOEngine/src/SceneManagement/Scene.hpp
+++ b/NANOEngine/src/SceneManagement/Scene.hpp
@@ -18,10 +18,18 @@ namespace NE::SceneManagement {
 
 		ECS::ECSCoordinator& GetECSCoordinator();
 
+		// Dirty flag system for editor changes
+		void MarkDirty();  // Changed to non-inline so we can add logging
+		bool IsDirty() const { return m_isDirty; }
+		void ClearDirty() { m_isDirty = false; }
+		void MarkComponentsDirty();
+
 	private:
 		ECS::ECSCoordinator m_ecsCoordinator;
+		bool m_isDirty = false;
 	};
 
 }
+
 
 

--- a/NANOEngine/src/SceneManagement/SceneManager.cpp
+++ b/NANOEngine/src/SceneManagement/SceneManager.cpp
@@ -3,6 +3,7 @@
 #include "Scripting/ScriptingEngine.hpp"
 #include "ECS/Components/NativeScript.hpp"
 #include "ECS/Core/Entity.hpp"
+#include <Core/SpdLogger.hpp>  // For SPD_INFO logging
 
 namespace NE::SceneManagement {
 
@@ -26,6 +27,21 @@ namespace NE::SceneManagement {
 	void SceneManager::SaveScene() {
 		//if (!m_active) return;
 		//Serialization::JsonSceneSerializer::Serialize(*m_active, path);
+	}
+
+	void SceneManager::SaveSceneIfDirty(const std::string& path) {
+		// Only save in Edit mode
+		if (m_isPlaying) return;
+		
+		if (!m_editor || !m_editor->IsDirty()) return;
+
+		std::string savePath = path.empty() ? m_loadedPath : path;
+		if (savePath.empty()) return;
+
+		SPD_INFO("[DirtyFlag] Saving scene to: {}", savePath);
+		Serialization::JsonSceneSerializer::Serialize(*m_editor, savePath);
+		m_editor->ClearDirty();
+		SPD_INFO("[DirtyFlag] Scene saved and marked as CLEAN");
 	}
 
 	void SceneManager::BeginPlay() {

--- a/NANOEngine/src/SceneManagement/SceneManager.hpp
+++ b/NANOEngine/src/SceneManagement/SceneManager.hpp
@@ -16,12 +16,14 @@ namespace NE::SceneManagement {
 		void Render(RenderPass pass);
 		void ExitScene();
 		void SaveScene();
+		void SaveSceneIfDirty(const std::string& path = "");
 
 		void BeginPlay();
 		void StopPlay();
 		bool IsPlaying() const;
 
 		Scene* GetActive();
+		Scene* GetEditorScene() { return m_editor.get(); }
 
 	private:
 		std::string m_loadedPath;

--- a/NANOEngine/src/Scripting/IScript.cpp
+++ b/NANOEngine/src/Scripting/IScript.cpp
@@ -8,6 +8,7 @@
 #include "../ECS/Components/Rigidbody.hpp"
 #include "../ECS/Components/AudioSource.hpp"
 #include "../Physics/PhysicsManager.hpp"
+#include "../EngineState.hpp"  // Include EngineState for dirty flag logic
 
 // PIMPL implementation to hide std containers from DLL interface
 class IScript::FieldRegistry {
@@ -239,6 +240,11 @@ void IScript::SetPosition(const NE::Math::Vec3& pos) {
 		auto& transform = m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity);
 		transform.position = pos;
 		transform.isDirty = true;
+		
+		// Only mark dirty for serialization if in Edit mode
+		if (NE::GetEngineState() == NE::EngineState::Edit) {
+			transform.isDirty = true;  // This will trigger scene save
+		}
 	}
 }
 
@@ -262,6 +268,11 @@ void IScript::SetRotation(const NE::Math::Vec3& rot) {
 		auto& transform = m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity);
 		transform.rotation = rot;
 		transform.isDirty = true;
+		
+		// Only mark dirty for serialization if in Edit mode
+		if (NE::GetEngineState() == NE::EngineState::Edit) {
+			transform.isDirty = true;  // This will trigger scene save
+		}
 	}
 }
 
@@ -285,6 +296,11 @@ void IScript::SetScale(const NE::Math::Vec3& scale) {
 		auto& transform = m_componentManager->GetComponent<NE::ECS::Component::Transform>(m_entity);
 		transform.scale = scale;
 		transform.isDirty = true;
+		
+		// Only mark dirty for serialization if in Edit mode
+		if (NE::GetEngineState() == NE::EngineState::Edit) {
+			transform.isDirty = true;  // This will trigger scene save
+		}
 	}
 }
 
@@ -752,19 +768,20 @@ void IScript::RegisterComponentRefField<NE::ECS::Component::Transform>(const std
 	entry.typeToken = "componentref:Transform";
 	entry.memberPtr = memberPtr;
 
-	// Store the entity ID as a string (safer than raw pointers)
+	// Store the entity ID as a string
 	entry.getValue = [memberPtr]() -> std::string {
-		if (memberPtr->GetOwnerEntity() == 0) {
-			return "0";
+		if (memberPtr->GetOwnerEntity() == NE::ECS::NO_ENTITY) {
+			return std::to_string(NE::ECS::NO_ENTITY);
 		}
 		return std::to_string(memberPtr->GetOwnerEntity());
 	};
 
-	// Set the entity ID - don't try to resolve pointer yet!
+	// Set the entity ID 
 	entry.setValue = [memberPtr](const std::string& value) -> bool {
 		try {
-			if (value == "0" || value.empty()) {
-				memberPtr->Set(nullptr, 0);
+			std::string noEntityStr = std::to_string(NE::ECS::NO_ENTITY);
+			if (value == noEntityStr || value.empty()) {
+				memberPtr->Set(nullptr, NE::ECS::NO_ENTITY);
 				return true;
 			}
 			
@@ -779,7 +796,7 @@ void IScript::RegisterComponentRefField<NE::ECS::Component::Transform>(const std
 			return true;
 		}
 		catch (...) {
-			memberPtr->Set(nullptr, 0);
+			memberPtr->Set(nullptr, NE::ECS::NO_ENTITY);
 			return false;
 		}
 	};
@@ -799,16 +816,17 @@ void IScript::RegisterComponentRefField<NE::ECS::Component::Rigidbody>(const std
 	entry.memberPtr = memberPtr;
 
 	entry.getValue = [memberPtr]() -> std::string {
-		if (memberPtr->GetOwnerEntity() == 0) {
-			return "0";
+		if (memberPtr->GetOwnerEntity() == NE::ECS::NO_ENTITY) {
+			return std::to_string(NE::ECS::NO_ENTITY);
 		}
 		return std::to_string(memberPtr->GetOwnerEntity());
 	};
 
 	entry.setValue = [memberPtr](const std::string& value) -> bool {
 		try {
-			if (value == "0" || value.empty()) {
-				memberPtr->Set(nullptr, 0);
+			std::string noEntityStr = std::to_string(NE::ECS::NO_ENTITY);
+			if (value == noEntityStr || value.empty()) {
+				memberPtr->Set(nullptr, NE::ECS::NO_ENTITY);
 				return true;
 			}
 			
@@ -821,7 +839,7 @@ void IScript::RegisterComponentRefField<NE::ECS::Component::Rigidbody>(const std
 			return true;
 		}
 		catch (...) {
-			memberPtr->Set(nullptr, 0);
+			memberPtr->Set(nullptr, NE::ECS::NO_ENTITY);
 			return false;
 		}
 	};
@@ -841,16 +859,17 @@ void IScript::RegisterComponentRefField<NE::ECS::Component::AudioSource>(const s
 	entry.memberPtr = memberPtr;
 
 	entry.getValue = [memberPtr]() -> std::string {
-		if (memberPtr->GetOwnerEntity() == 0) {
-			return "0";
+		if (memberPtr->GetOwnerEntity() == NE::ECS::NO_ENTITY) {
+			return std::to_string(NE::ECS::NO_ENTITY);
 		}
 		return std::to_string(memberPtr->GetOwnerEntity());
 	};
 
 	entry.setValue = [memberPtr](const std::string& value) -> bool {
 		try {
-			if (value == "0" || value.empty()) {
-				memberPtr->Set(nullptr, 0);
+			std::string noEntityStr = std::to_string(NE::ECS::NO_ENTITY);
+			if (value == noEntityStr || value.empty()) {
+				memberPtr->Set(nullptr, NE::ECS::NO_ENTITY);
 				return true;
 			}
 			
@@ -863,7 +882,7 @@ void IScript::RegisterComponentRefField<NE::ECS::Component::AudioSource>(const s
 			return true;
 		}
 		catch (...) {
-			memberPtr->Set(nullptr, 0);
+			memberPtr->Set(nullptr, NE::ECS::NO_ENTITY);
 			return false;
 		}
 	};

--- a/NANOEngine/src/Scripting/IScript.hpp
+++ b/NANOEngine/src/Scripting/IScript.hpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include "../ECS/Core/ComponentManager.hpp"
 #include "../Math/Vec3.hpp"
+#include "../EngineState.hpp"  // For checking Edit vs Play mode
 
 // Export macros for when Engine is built as DLL
 #ifdef NANOENGINE_EXPORTS
@@ -154,6 +155,14 @@ public:
 	 * Called when the script is disabled.
 	 */
 	virtual void OnDisable() {}
+
+	/**
+	 * Mark a component as dirty for serialization (Editor Mode only).
+	 * This is automatically called by helper functions, but can be called manually
+	 * when directly modifying component fields in Editor Mode scripts.
+	 */
+	template<typename T>
+	void MarkComponentDirty();
 
 	/**
 	 * Get the entity this script is attached to.
@@ -773,4 +782,23 @@ bool IScript::HasComponent() const {
 		return false;
 	}
 	return m_componentManager->HasComponent<T>(m_entity);
+}
+
+template<typename T>
+void IScript::MarkComponentDirty() {
+	// Only mark dirty in Edit mode - runtime changes should not be serialized
+	if (NE::GetEngineState() != NE::EngineState::Edit) {
+		return;
+	}
+
+	if (!m_componentManager || !m_componentManager->HasComponent<T>(m_entity)) {
+		return;
+	}
+
+	auto& component = m_componentManager->GetComponent<T>(m_entity);
+	
+	// Use C++20 requires to check if the component has an isDirty field
+	if constexpr (requires { component.isDirty; }) {
+		component.isDirty = true;
+	}
 }


### PR DESCRIPTION
Introduces a dirty flag system to track unsaved scene changes, marking the scene as dirty when components or scripts are modified. Adds a status bar to the editor UI showing the current scene path and save status, and enables Ctrl+S and menu-based saving only when there are unsaved changes. Also updates InspectorPanel to mark the scene dirty on relevant component and script field changes, and improves UI feedback for save operations.