### PR TITLE
Add model import settings and JSON-based asset metadata

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -203,6 +203,8 @@
     <ClInclude Include="src\AssetManagement\AssetManager.hpp" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="src\AssetManagement\AssetMetadata.hpp" />
+    <ClInclude Include="src\AssetManagement\Assets\IAsset.hpp" />
+    <ClInclude Include="src\AssetManagement\Settings\ModelImportSettings.hpp" />
     <ClInclude Include="src\AssetManagement\Settings\TextureImportSettings.hpp" />
     <ClInclude Include="src\AssetManagement\UUID.hpp" />
     <ClInclude Include="src\Command\EditorSetFieldCommand.hpp" />

--- a/Editor/Editor.vcxproj.filters
+++ b/Editor/Editor.vcxproj.filters
@@ -266,6 +266,9 @@
     <ClInclude Include="src\Panels\AnimationGraphPanel.hpp">
       <Filter>Header Files\src</Filter>
     </ClInclude>
+    <ClInclude Include="src\AssetManagement\Settings\ModelImportSettings.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\AssetManagement\Assets\IAsset.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/Editor/src/AssetManagement/AssetManager.cpp
+++ b/Editor/src/AssetManagement/AssetManager.cpp
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-
-//#define STB_IMAGE_IMPLEMENTATION
 #include "stb_image/stb_image.h"
 #include "compressonator/cmp_compressonatorlib/compressonator.h"
 #include "UUID.hpp"
@@ -23,6 +21,11 @@
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 #include <Math/Vec3.hpp>
+#include "Settings/ModelImportSettings.hpp"
+#include <Serialisation/ReflectionJson.hpp>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/prettywriter.h>
 
 
 namespace {
@@ -210,6 +213,61 @@ namespace {
         float nx, ny, nz;
         float u, v;
     };
+
+    std::string AssetTypeToString(Editor::AssetType type) {
+        switch (type) {
+        case Editor::AssetType::Texture:    return "Texture";
+        case Editor::AssetType::Mesh:       return "Mesh";
+        case Editor::AssetType::Shader:     return "Shader";
+        case Editor::AssetType::Material:   return "Material";
+        case Editor::AssetType::Audio:      return "Audio";
+        default:                            return "Unknown";
+        }
+    }
+
+    bool SaveModelImportSettings(const std::string& metaPath, const Editor::ModelImportSettings& settings) {
+        using namespace rapidjson;
+        using namespace NE::Serialization;
+
+        Document doc;
+        doc.SetObject();
+
+        // Try to load existing meta to preserve other unrelated fields (uuid, assetType, etc.)
+        if (std::filesystem::exists(metaPath)) {
+            std::ifstream ifs(metaPath);
+            if (ifs) {
+                IStreamWrapper isw(ifs);
+                doc.ParseStream(isw);
+                if (doc.HasParseError() || !doc.IsObject()) {
+                    doc.SetObject(); // Reset on failure
+                }
+            }
+        }
+
+        auto& alloc = doc.GetAllocator();
+
+        // Serialize settings via reflection
+        RJson jSettings = to_json(settings, alloc); // object with { scene, mesh, rig, animation, material }
+
+        // Attach / replace "modelImport" in the root doc
+        if (doc.HasMember("modelImport"))
+            doc["modelImport"].CopyFrom(jSettings, alloc);
+        else
+            doc.AddMember("modelImport", jSettings, alloc);
+
+        std::ofstream ofs(metaPath);
+        if (!ofs) {
+            SPD_WARNING("Failed to write meta file: " << metaPath);
+            return false;
+        }
+
+        OStreamWrapper osw(ofs);
+        PrettyWriter<OStreamWrapper> writer(osw);
+        writer.SetIndent(' ', 4);
+        doc.Accept(writer);
+
+        return true;
+    }
 }
 
 namespace Editor {
@@ -232,61 +290,61 @@ namespace Editor {
 		return am;
 	}
 
-	void AssetManager::GenerateMetadata(const std::string& sourcePath) {
-		std::filesystem::path fsSourcePath = sourcePath;
-		std::filesystem::path metaPath = sourcePath + ".meta";
+    void AssetManager::GenerateMetadata(const std::string& sourcePath) {
+        namespace fs = std::filesystem;
+        using namespace rapidjson;
+        using namespace NE::Serialization;
+
+        fs::path fsSourcePath = sourcePath;
+        fs::path metaPath = sourcePath + ".meta";
 
         AssetMetadata metadata{};
         metadata.sourcePath = sourcePath;
 
-        if (std::filesystem::exists(metaPath)) {
+        if (fs::exists(metaPath)) {
             std::ifstream ifs(metaPath);
             if (!ifs) {
                 SPD_WARNING("Failed to read meta file: " << metaPath.string());
                 return;
             }
 
-            std::string line;
-            while (std::getline(ifs, line)) {
-                if (line.starts_with("uuid:")) {
-                    metadata.uuid = line.substr(line.find(':') + 1);
-                    metadata.uuid.erase(0, metadata.uuid.find_first_not_of(" \t"));
-                } else if (line.starts_with("assetType:")) {
-                    std::string typeStr = line.substr(line.find(':') + 1);
-                    typeStr.erase(0, typeStr.find_first_not_of(" \t"));
-                    metadata.type = GetAssetTypeFromString(typeStr);
-                } else if (line.starts_with("sourcePath:")) {
-                    metadata.sourcePath = line.substr(line.find(':') + 1);
-                    metadata.sourcePath.erase(0, metadata.sourcePath.find_first_not_of(" \t"));
-                }
+            IStreamWrapper isw(ifs);
+            Document doc;
+            doc.ParseStream(isw);
+
+            if (doc.HasParseError() || !doc.IsObject()) {
+                SPD_WARNING("Failed to parse meta JSON: " << metaPath.string());
+                return;
             }
 
+            if (doc.HasMember("uuid") && doc["uuid"].IsString())
+                metadata.uuid = doc["uuid"].GetString();
+            if (doc.HasMember("assetType") && doc["assetType"].IsString())
+                metadata.type = GetAssetTypeFromString(doc["assetType"].GetString());
+            if (doc.HasMember("sourcePath") && doc["sourcePath"].IsString())
+                metadata.sourcePath = doc["sourcePath"].GetString();
+
             if (metadata.uuid.empty())
-                metadata.uuid = GenerateUUID(); // fallback, should rarely happen
+                metadata.uuid = GenerateUUID();
             if (metadata.type == AssetType::Unknown)
                 metadata.type = GetAssetTypeFromExtension(fsSourcePath.extension().string());
 
             switch (metadata.type) {
-            case AssetType::Texture: {
+            case AssetType::Texture:
                 GetAssetsOfType<AssetType::Texture>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
                 break;
-            }
-            case AssetType::Mesh: {
+            case AssetType::Mesh:
                 GetAssetsOfType<AssetType::Mesh>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
                 break;
-            }
-            case AssetType::Shader: {
+            case AssetType::Shader:
                 GetAssetsOfType<AssetType::Shader>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
                 break;
-            }
-            case AssetType::Material: {
+            case AssetType::Material:
                 GetAssetsOfType<AssetType::Material>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
                 break;
-            }
-            case AssetType::Audio: {
+            case AssetType::Audio:
                 GetAssetsOfType<AssetType::Audio>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
                 break;
-            }
             default:
                 break;
             }
@@ -295,68 +353,80 @@ namespace Editor {
             return;
         }
 
-		std::string uuid = GenerateUUID();
+        std::string uuid = GenerateUUID();
         std::string outPath = NE::Resource::ComputeArtifactPathFromUUID(uuid);
 
-		std::ofstream ofs(metaPath);
-		ofs << "importerVersion: " << CURRENT_META_SCHEMA_VERSION << '\n'
-			<< "uuid: " << uuid << '\n';
+        AssetType assetType = GetAssetTypeFromExtension(fsSourcePath.extension().string());
+        metadata.uuid = uuid;
+        metadata.type = assetType;
 
-		AssetType assetType = GetAssetTypeFromExtension(fsSourcePath.extension().string());
+        Document doc;
+        doc.SetObject();
+        auto& alloc = doc.GetAllocator();
 
-		switch (assetType) {
-		case AssetType::Texture: {
-			ofs << "assetType: Texture\n"
-				<< "sourcePath: " << sourcePath << '\n';
-            
-            CookTexture(sourcePath, outPath, TextureImportSettings{});
+        doc.AddMember("fileFormatVersion", CURRENT_META_SCHEMA_VERSION, alloc);
+        doc.AddMember("uuid", Value(uuid.c_str(), (rapidjson::SizeType)uuid.size(), alloc), alloc);
+        std::string assetTypeStr = AssetTypeToString(assetType);
+        doc.AddMember("assetType", Value(assetTypeStr.c_str(), (rapidjson::SizeType)assetTypeStr.size(), alloc), alloc);
+        doc.AddMember("sourcePath", Value(sourcePath.c_str(), (rapidjson::SizeType)sourcePath.size(), alloc), alloc);
+
+        switch (assetType) {
+        case AssetType::Texture: {
+            TextureImportSettings defaultSettings{};
+            CookTexture(sourcePath, outPath, defaultSettings);
+
             GetAssetsOfType<AssetType::Texture>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
 
-            ofs << "TextureImporterVersion: 1\n"; // hardcoded for now
+            doc.AddMember("textureImporterVersion", TEXTURE_IMPORTER_VERSION, alloc);
 
-			break;
-		}
-		case AssetType::Mesh: {
-            ofs << "assetType: Mesh\n"
-                << "sourcePath: " << sourcePath << '\n';
-
+            RJson texImportJson = to_json(defaultSettings, alloc);
+            doc.AddMember("textureImport", texImportJson, alloc);
+            break;
+        }
+        case AssetType::Mesh: {
+            ModelImportSettings defaultSettings{};
             CookMesh(sourcePath, outPath);
-            GetAssetsOfType<AssetType::Mesh>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
-			break;
-		}
-        case AssetType::Shader: {
-            ofs << "assetType: Shader\n"
-                << "sourcePath: " << sourcePath << '\n';
 
+            GetAssetsOfType<AssetType::Mesh>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
+
+            doc.AddMember("modelImporterVersion", MODEL_IMPORTER_VERSION, alloc);
+            RJson modelImportJson = to_json(defaultSettings, alloc);
+            doc.AddMember("modelImport", modelImportJson, alloc);
+            break;
+        }
+        case AssetType::Shader: {
             CookShader(sourcePath, outPath);
             GetAssetsOfType<AssetType::Shader>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
             break;
         }
         case AssetType::Material: {
-            ofs << "assetType: Material\n"
-                << "sourcePath: " << sourcePath << '\n';
-
             CookMaterial(sourcePath, outPath);
             GetAssetsOfType<AssetType::Material>().push_back({ fsSourcePath.filename().string(), metadata.uuid });
             break;
         }
         case AssetType::Audio: {
-
+            // TODO: audio import settings later
             break;
         }
-		default:
-			break;
-		}
-
-		ofs.close();
+        default:
+            break;
+        }
 
 
-		metadata.uuid = uuid;
-		metadata.type = assetType;
+        {
+            std::ofstream ofs(metaPath);
+            if (!ofs) {
+                SPD_WARNING("Failed to write meta file: " << metaPath.string());
+            } else {
+                OStreamWrapper osw(ofs);
+                PrettyWriter<OStreamWrapper> writer(osw);
+                writer.SetIndent(' ', 4);
+                doc.Accept(writer);
+            }
+        }
 
-
-		m_assets[uuid] = std::move(metadata);
-	}
+        m_assets[uuid] = std::move(metadata);
+    }
 
     void AssetManager::ReimportAsset(const std::string& sourcePath) {
         std::filesystem::path fsSourcePath = sourcePath;
@@ -401,6 +471,8 @@ namespace Editor {
 
 
             CookTexture(sourcePath, outPath, texSettings);
+
+
             break;
         }
         case AssetType::Mesh: {
@@ -478,46 +550,6 @@ namespace Editor {
 		return AssetType::Unknown;
 	}
 
-    //bool AssetManager::CookTexture(const std::string& sourcePath, const std::string& outPath, const TextureImportSettings& /*settings*/) {
-    //    std::filesystem::path src = sourcePath;
-    //    std::filesystem::path out = outPath;
-    //    std::filesystem::create_directories(out.parent_path());
-
-    //    const bool srgb = GuessSRGBFromExt(src);
-
-    //    // 1) Load
-    //    std::vector<uint8_t> rgba8;
-    //    uint32_t w = 0, h = 0;
-    //    if (!LoadRGBA8(src.string(), rgba8, w, h)) {
-    //        std::fprintf(stderr, "[CookTexture] Failed to load: %s\n", src.string().c_str());
-    //        return false;
-    //    }
-
-    //    // 2) Compress to BC7
-    //    std::vector<uint8_t> bc7;
-    //    const float    quality = 0.6f;  // tune per build config
-    //    const uint32_t threads = 0;     // 0 = auto
-    //    if (CMP_ERROR err = CompressRGBA8ToBC7(rgba8.data(), w, h, quality, threads, bc7); err != CMP_OK) {
-    //        std::fprintf(stderr, "[CookTexture] Compressonator error %d on: %s\n", (int)err, src.string().c_str());
-    //        return false;
-    //    }
-
-    //    // 3) Write .nanotex
-    //    const uint16_t mipCount = 1;          // (future: generate mip chain)
-    //    const uint16_t layers = 1;          // (future: array/cubemap)
-    //    const TexShape shape = TexShape::TwoD;
-    //    const TexFormat fmt = srgb ? TexFormat::BC7_UNORM_SRGB : TexFormat::BC7_UNORM;
-
-    //    if (!WriteNanoTex(out.string(), w, h, srgb, shape, fmt, mipCount, layers, bc7)) {
-    //        std::fprintf(stderr, "[CookTexture] Failed to write: %s\n", out.string().c_str());
-    //        return false;
-    //    }
-
-    //    std::printf("\n[CookTexture] OK: %s -> %s (%ux%u, %zu bytes)\n",
-    //        src.string().c_str(), out.string().c_str(), w, h, bc7.size());
-    //    return true;
-    //}
-
     bool AssetManager::CookTexture(const std::string& sourcePath,
         const std::string& outPath,
         const TextureImportSettings& settings)
@@ -535,7 +567,6 @@ namespace Editor {
             srgb = false;
         }
 
-        // 1) Load RGBA8
         std::vector<uint8_t> rgba8;
         uint32_t w = 0, h = 0;
         if (!LoadRGBA8(src.string(), rgba8, w, h)) {
@@ -549,7 +580,6 @@ namespace Editor {
         const float    quality = 0.6f;
         const uint32_t threads = 0;
 
-        // 2) Compress: BC5 for normals, BC7 otherwise
         if (isNormalMap) {
             if (CMP_ERROR err = CompressRGBA8ToBC5(rgba8.data(), w, h, quality, threads, compressed);
                 err != CMP_OK) {
@@ -569,10 +599,9 @@ namespace Editor {
             fmt = srgb ? TexFormat::BC7_UNORM_SRGB : TexFormat::BC7_UNORM;
         }
 
-        // 3) Write .nanotex
         const uint16_t mipCount = 1;
         const uint16_t layers = 1;
-        const TexShape shape = TexShape::TwoD; // your Editor::TexShape enum
+        const TexShape shape = TexShape::TwoD;
 
         if (!WriteNanoTex(out.string(), w, h, srgb, shape, fmt, mipCount, layers, compressed)) {
             std::fprintf(stderr, "[CookTexture] Failed to write: %s\n", out.string().c_str());
@@ -595,114 +624,6 @@ namespace Editor {
         return NE::CookShader(sourcePath, outPath, shaderStages);
     }
 
-    //bool AssetManager::CookMaterial(const std::string& sourcePath, const std::string& outPath) {
-    //    //std::filesystem::path src = sourcePath;
-    //    std::filesystem::path out = outPath;
-    //    std::filesystem::create_directories(out.parent_path());
-
-    //    std::ifstream in(sourcePath);
-    //    if (!in) return false;
-    //    std::string j((std::istreambuf_iterator<char>(in)), {});
-    //    rapidjson::Document doc; doc.Parse(j.c_str());
-    //    if (!doc.IsObject()) return false;
-
-    //    // 2) Fill header (pipeline state)
-    //    NE::Resource::NanoMatHeader h{};
-    //    h.depthTest = doc.HasMember("DepthTest") ? (doc["DepthTest"].GetBool() ? 1 : 0) : 1;
-    //    h.blendMode = doc.HasMember("BlendMode") ? (doc["BlendMode"].GetBool() ? 1 : 0) : 0;
-    //    h.cullMode = doc.HasMember("CullMode") ? doc["CullMode"].GetUint() : 0;
-    //    h.polygonMode = doc.HasMember("PolygonMode") ? doc["PolygonMode"].GetUint() : 0;
-
-    //    const char* shaderName = doc.HasMember("Shader") ? doc["Shader"].GetString() : "Basic";
-    //    const uint32_t shaderNameLen = (uint32_t)std::strlen(shaderName);
-
-    //    // 3) Collect properties
-    //    std::vector<NE::Resource::MatPropRecord> recs;
-    //    std::string strings; // names will be appended here
-    //    std::string payload; // binary values appended here
-
-    //    if (doc.HasMember("Properties") && doc["Properties"].IsObject()) {
-    //        for (auto it = doc["Properties"].MemberBegin(); it != doc["Properties"].MemberEnd(); ++it) {
-    //            const std::string name = it->name.GetString();
-    //            const auto& v = it->value;
-
-    //            NE::Resource::MatPropRecord r{};
-    //            r.nameLen = (uint32_t)name.size();
-    //            r.nameOffset = 0; // fill later after we know base offsets
-    //            r.count = 1;
-
-    //            // Serialize the value
-    //            size_t dataStart = payload.size();
-    //            if (v.IsInt()) {
-    //                int32_t x = v.GetInt();
-    //                r.type = (uint8_t)NE::Resource::MatPropType::INT;
-    //                payload.append(reinterpret_cast<const char*>(&x), sizeof(x));
-    //            } else if (v.IsNumber()) {
-    //                float f = (float)v.GetDouble();
-    //                r.type = (uint8_t)NE::Resource::MatPropType::FLOAT;
-    //                payload.append(reinterpret_cast<const char*>(&f), sizeof(f));
-    //            } else if (v.IsArray() && v.Size() == 3) {
-    //                float f[3] = { (float)v[0].GetDouble(), (float)v[1].GetDouble(), (float)v[2].GetDouble() };
-    //                r.type = (uint8_t)NE::Resource::MatPropType::VEC3;
-    //                payload.append(reinterpret_cast<const char*>(f), sizeof(f));
-    //            } else if (v.IsArray() && v.Size() == 16) {
-    //                float m[16];
-    //                for (rapidjson::SizeType i = 0; i < 16; ++i) m[i] = (float)v[i].GetDouble();
-    //                r.type = (uint8_t)NE::Resource::MatPropType::MAT4;
-    //                payload.append(reinterpret_cast<const char*>(m), sizeof(m));
-    //            } else {
-    //                // unknown type – skip or handle texture uuid strings later
-    //                continue;
-    //            }
-    //            r.dataOffset = 0; // fill later
-    //            r.dataSize = (uint32_t)(payload.size() - dataStart);
-
-    //            // Add name to string table
-    //            uint32_t nameOff = (uint32_t)strings.size();
-    //            strings.append(name.data(), name.size());
-
-    //            r.nameOffset = nameOff; // relative to strings base (filled after we know base)
-    //            recs.push_back(r);
-    //        }
-    //    }
-
-    //    // 4) Finalize offsets relative to file start
-    //    h.propCount = (uint16_t)recs.size();
-    //    h.shaderNameLen = shaderNameLen;
-
-    //    size_t offset = sizeof(NE::Resource::NanoMatHeader);
-    //    h.shaderNameOffset = (uint32_t)offset;
-    //    offset += shaderNameLen;
-
-    //    const uint32_t propsTableBytes = (uint32_t)(recs.size() * sizeof(NE::Resource::MatPropRecord));
-    //    h.propsOffset = (uint32_t)offset;
-    //    offset += propsTableBytes;
-
-    //    const uint32_t stringsBase = (uint32_t)offset;
-    //    offset += (uint32_t)strings.size();
-
-    //    const uint32_t payloadBase = (uint32_t)offset;
-    //    // payload bytes will follow
-
-    //    // Fix up per-record absolute offsets
-    //    for (auto& r : recs) {
-    //        r.nameOffset += stringsBase;
-    //        r.dataOffset += payloadBase;
-    //    }
-
-    //    // 5) Write file
-    //    std::ofstream ofs(outPath, std::ios::binary);
-    //    if (!ofs) return false;
-
-    //    ofs.write((char*)&h, sizeof(h));
-    //    ofs.write(shaderName, shaderNameLen);
-    //    if (!recs.empty()) ofs.write((char*)recs.data(), propsTableBytes);
-    //    if (!strings.empty()) ofs.write(strings.data(), (std::streamsize)strings.size());
-    //    if (!payload.empty()) ofs.write(payload.data(), (std::streamsize)payload.size());
-
-    //    return ofs.good();
-    //}
-
     bool AssetManager::CookMaterial(const std::string& sourcePath, const std::string& outPath) {
         std::filesystem::path out = outPath;
         std::filesystem::create_directories(out.parent_path());
@@ -713,7 +634,6 @@ namespace Editor {
         rapidjson::Document doc; doc.Parse(j.c_str());
         if (!doc.IsObject()) return false;
 
-        // 1) Header
         NE::Resource::NanoMatHeader h{};
         h.depthTest = doc.HasMember("DepthTest") ? (doc["DepthTest"].GetBool() ? 1 : 0) : 1;
         h.blendMode = doc.HasMember("BlendMode") ? (doc["BlendMode"].GetBool() ? 1 : 0) : 0;
@@ -723,14 +643,13 @@ namespace Editor {
         const char* shaderName = doc.HasMember("Shader") ? doc["Shader"].GetString() : "Basic";
         const uint32_t shaderNameLen = (uint32_t)std::strlen(shaderName);
 
-        // 2) Tables we will build
+        // Tables to build
         std::vector<NE::Resource::MatPropRecord> propRecs;
         std::vector<NE::Resource::MatTexRecord>  texRecs;
 
         std::string strings; // shared string blob (for BOTH prop names and tex names)
         std::string payload; // only for prop data (ints/floats/matrices)
 
-        // 3) Collect properties from JSON
         if (doc.HasMember("Properties") && doc["Properties"].IsObject()) {
             for (auto it = doc["Properties"].MemberBegin(); it != doc["Properties"].MemberEnd(); ++it) {
                 const std::string name = it->name.GetString();
@@ -744,7 +663,6 @@ namespace Editor {
                     r.nameLen = (uint32_t)name.size();
                     r.count = 1;
 
-                    // serialize value
                     size_t dataStart = payload.size();
                     if (v.IsInt()) {
                         int32_t x = v.GetInt();
@@ -825,12 +743,11 @@ namespace Editor {
             }
         }
 
-        // 4) Fill header counts
+        // Fill header counts
         h.propCount = (uint16_t)propRecs.size();
         h.texCount = (uint16_t)texRecs.size();
         h.shaderNameLen = shaderNameLen;
 
-        // 5) Lay out file
         size_t offset = sizeof(NE::Resource::NanoMatHeader);
 
         // shader name
@@ -858,7 +775,7 @@ namespace Editor {
             h.texTableOffset = 0;
         }
 
-        // 6) Fix up per-record absolute offsets
+        // Fix up per-record absolute offsets
         for (auto& r : propRecs) {
             r.nameOffset += stringsBase;
             r.dataOffset += payloadBase;

--- a/Editor/src/AssetManagement/AssetManager.hpp
+++ b/Editor/src/AssetManagement/AssetManager.hpp
@@ -35,7 +35,6 @@ namespace Editor {
 		AssetType GetAssetTypeFromString(std::string_view extension);
 		AssetType GetAssetTypeFromExtension(std::string_view);
 
-		bool ImportTexture();
 		bool CookTexture(const std::string& sourcePath, const std::string& outPath, const TextureImportSettings& settings);
 		bool CookShader(const std::string& sourcePath, const std::string& outPath);
 		bool CookMaterial(const std::string& sourcePath, const std::string& outPath);

--- a/Editor/src/AssetManagement/AssetMetadata.hpp
+++ b/Editor/src/AssetManagement/AssetMetadata.hpp
@@ -25,5 +25,4 @@ namespace Editor {
 
 }
 
-
 #endif

--- a/Editor/src/AssetManagement/Settings/ModelImportSettings.hpp
+++ b/Editor/src/AssetManagement/Settings/ModelImportSettings.hpp
@@ -1,0 +1,171 @@
+#ifndef MODEL_IMPORT_SETTINGS_HPP
+#define MODEL_IMPORT_SETTINGS_HPP
+
+#include <cstdint>
+#include <Core/Reflection.hpp>
+
+namespace Editor {
+
+    inline constexpr int MODEL_IMPORTER_VERSION = 1;
+
+    // ---------------- Scene / File level ----------------
+    struct SceneImportSettings {
+        float scaleFactor = 1.0f;
+        bool convertUnits = true;
+        bool importBlendShapes = true;
+        bool importCameras = false;
+        bool importLights = false;
+        bool preserveHierarchy = true;
+
+        NE_REFLECT_BEGIN(SceneImportSettings)
+            NE_REFLECT_FIELD(scaleFactor),
+            NE_REFLECT_FIELD(convertUnits),
+            NE_REFLECT_FIELD(importCameras),
+            NE_REFLECT_FIELD(importLights),
+            NE_REFLECT_FIELD(preserveHierarchy)
+        NE_REFLECT_END()
+
+    };
+
+    // ---------------- Mesh / Geometry level ----------------
+    struct MeshImportSettings {
+
+        enum class NormalMode : uint8_t {
+            Import,
+            Calculate,
+            None
+        };
+
+        enum class TangentMode : uint8_t {
+            Import,
+            CalculateMikktspace,
+            None
+        };
+
+        enum class IndexFormat : uint8_t {
+            Auto,
+            UInt16,
+            UInt32
+        };
+
+        enum class MeshOptimizationMode : uint8_t {
+            None,
+            Everything,
+            PolygonOrder,
+            VertexOrder
+        };
+
+        // Meshes
+        MeshOptimizationMode meshOptimizationMode = MeshOptimizationMode::Everything;
+        bool generateColliders = false;
+
+        // Mesh LODS
+        bool generateMeshLODs = false;
+
+        // Geometry
+        bool keepQuads = false;
+        bool weldVertices = false;
+        IndexFormat indexFormat = IndexFormat::Auto;
+        NormalMode  normalMode = NormalMode::Import;
+        float smoothingAngle = 60.f;
+        TangentMode tangentMode = TangentMode::Import;
+        bool swapUVs;
+
+        NE_REFLECT_BEGIN(MeshImportSettings)
+            NE_REFLECT_FIELD(weldVertices),
+            NE_REFLECT_FIELD(keepQuads),
+            NE_REFLECT_FIELD(swapUVs),
+            NE_REFLECT_FIELD(generateColliders),
+            NE_REFLECT_FIELD(generateMeshLODs),
+            NE_REFLECT_FIELD(smoothingAngle),
+            NE_REFLECT_FIELD(normalMode),
+            NE_REFLECT_FIELD(tangentMode),
+            NE_REFLECT_FIELD(indexFormat),
+            NE_REFLECT_FIELD(meshOptimizationMode)
+        NE_REFLECT_END()
+    };
+
+    // ---------------- Rig / Skeleton level ----------------
+    struct RigImportSettings {
+
+        enum class AnimationType : uint8_t {
+            None,
+            Generic,
+            Humanoid
+        };
+
+        AnimationType animationType = AnimationType::None;
+        bool stripBones;
+
+        NE_REFLECT_BEGIN(RigImportSettings)
+            NE_REFLECT_FIELD(stripBones),
+            NE_REFLECT_FIELD(animationType)
+        NE_REFLECT_END()
+    };
+
+    // ---------------- Animation level ----------------
+    struct AnimationImportSettings {
+        bool importAnimations = true;
+        bool importConstraints = false;
+        bool importAnimatedCustomProperties = false;
+        bool autoSplitClips = true;
+
+        float sampleRate = 0.0f;
+
+        bool importRootMotion = false;
+        bool lockRootPositionXZ = false;
+        bool lockRootRotationY = false;
+
+        NE_REFLECT_BEGIN(AnimationImportSettings)
+            NE_REFLECT_FIELD(importAnimations),
+            NE_REFLECT_FIELD(importConstraints),
+            NE_REFLECT_FIELD(importAnimatedCustomProperties),
+            NE_REFLECT_FIELD(autoSplitClips),
+            NE_REFLECT_FIELD(importRootMotion),
+            NE_REFLECT_FIELD(lockRootPositionXZ),
+            NE_REFLECT_FIELD(lockRootRotationY),
+            NE_REFLECT_FIELD(sampleRate)
+        NE_REFLECT_END()
+    };
+
+    // ---------------- Material level ----------------
+    struct MaterialImportSettings {
+        bool importMaterials = true;
+
+        bool tryReuseExistingMaterials = true;
+
+        enum class MaterialCreationMode : uint8_t {
+            PerSubmesh,
+            PerMesh,
+            PerFile
+        };
+
+        MaterialCreationMode creationMode = MaterialCreationMode::PerSubmesh;
+
+        NE_REFLECT_BEGIN(MaterialImportSettings)
+            NE_REFLECT_FIELD(importMaterials),
+            NE_REFLECT_FIELD(tryReuseExistingMaterials),
+            NE_REFLECT_FIELD(creationMode)
+        NE_REFLECT_END()
+    };
+
+    // ---------------- Top-level Model (file) settings ----------------
+    struct ModelImportSettings {
+        SceneImportSettings     scene;
+        MeshImportSettings      mesh;
+        RigImportSettings       rig;
+        AnimationImportSettings animation;
+        MaterialImportSettings  material;
+
+        NE_REFLECT_BEGIN(ModelImportSettings)
+            NE_REFLECT_FIELD(scene),
+            NE_REFLECT_FIELD(mesh),
+            NE_REFLECT_FIELD(rig),
+            NE_REFLECT_FIELD(animation),
+            NE_REFLECT_FIELD(material)
+        NE_REFLECT_END()
+    };
+
+} // namespace Editor
+
+#endif // MODEL_IMPORT_SETTINGS_HPP

--- a/Editor/src/AssetManagement/Settings/TextureImportSettings.hpp
+++ b/Editor/src/AssetManagement/Settings/TextureImportSettings.hpp
@@ -2,8 +2,11 @@
 #define TEXTURE_IMPORT_SETTINGS_HPP
 
 #include <cstdint>
+#include <Core/Reflection.hpp>
 
 namespace Editor {
+
+	inline constexpr int TEXTURE_IMPORTER_VERSION = 1;
 
 	enum class TexType : uint8_t {
 		Default,
@@ -40,11 +43,21 @@ namespace Editor {
 	struct NormalMapOptions {
 		bool flipGreenChannel = false;
 		bool createFromGrayscale = false;
+
+		NE_REFLECT_BEGIN(NormalMapOptions)
+			NE_REFLECT_FIELD(flipGreenChannel),
+			NE_REFLECT_FIELD(createFromGrayscale)
+		NE_REFLECT_END()
 	};
 
 	struct MipPolicy {
 		bool generateMipmap = true;
 		bool preserveCoverage = false;
+
+		NE_REFLECT_BEGIN(MipPolicy)
+			NE_REFLECT_FIELD(generateMipmap),
+			NE_REFLECT_FIELD(preserveCoverage)
+		NE_REFLECT_END()
 	};
 
 	struct TextureImportSettings {
@@ -55,10 +68,23 @@ namespace Editor {
 		bool alphaIsTransparency = false;
 
 		TexWrapMode wrap = TexWrapMode::Clamp;
-		TexFilterMode filer = TexFilterMode::Bilinear;
+		TexFilterMode filter = TexFilterMode::Bilinear;
 
 		MipPolicy mips{};
 		NormalMapOptions normal{};
+
+
+		NE_REFLECT_BEGIN(TextureImportSettings)
+			NE_REFLECT_FIELD(type),
+			NE_REFLECT_FIELD(shape),
+			NE_REFLECT_FIELD(sRGB),
+			NE_REFLECT_FIELD(alpha),
+			NE_REFLECT_FIELD(alphaIsTransparency),
+			NE_REFLECT_FIELD(wrap),
+			NE_REFLECT_FIELD(filter),
+			NE_REFLECT_FIELD(mips),
+			NE_REFLECT_FIELD(normal)
+		NE_REFLECT_END()
 	};
 
 }

--- a/Editor/src/Panels/AssetBrowserPanel.cpp
+++ b/Editor/src/Panels/AssetBrowserPanel.cpp
@@ -247,6 +247,9 @@ namespace Editor {
                         ImGui::SetDragDropPayload("ASSET_MESH_PATH", assetPath.c_str(), assetPath.size() + 1);
                         ImGui::TextUnformatted(name.c_str());
                         ImGui::EndDragDropSource();
+                    } else if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+                        EditorScene::s_selectedEntity = nullptr;
+                        EditorScene::selectedAsset = entryPath.string();
                     }
                 } else if (entryPath.extension() == ".scene") {    
                     if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -2,7 +2,7 @@
 #include <imgui/imgui.h>
 #include <EditorInterface/ECSExports.hpp>
 #include <EditorInterface/RendererExports.hpp>
-#include <EditorInterface/PhysicsExports.hpp>
+//#include <EditorInterface/PhysicsExports.hpp>
 #include "ECS/Core/Signature.hpp"
 #include <ECS/Components/Transform.hpp>
 #include <ECS/Components/Renderer.hpp>
@@ -17,7 +17,7 @@
 #include <Core/Reflection.hpp>
 #include <Math/Vec3.hpp>
 #include "../EditorScene.hpp"
-#include <Engine.hpp>
+//#include <Engine.hpp>
 #include <imgui/widgets/imsearch/imsearch.h>
 #include "../EditorUI.hpp"
 #include "../Command/EditorSetFieldCommand.hpp"
@@ -31,10 +31,14 @@
 #include <string>
 #include <sstream>
 #include <vector>
-#include "../AssetManagement/Settings/TextureImportSettings.hpp"
-#include <Core/SpdLogger.hpp>
 #include "../AssetManagement/AssetManager.hpp"
+#include "../AssetManagement/Settings/TextureImportSettings.hpp"
+#include "../AssetManagement/Settings/ModelImportSettings.hpp"
+#include <Core/SpdLogger.hpp>
 #include <fstream>
+#include <rapidjson/document.h>
+#include <Serialisation/ReflectionJson.hpp>
+#include <rapidjson/istreamwrapper.h>
 
 namespace {
 	template<typename Owner, typename T>
@@ -200,6 +204,38 @@ namespace {
 				ofs << l << "\n";
 			}
 		}
+	}
+
+	bool LoadModelImportSettings(std::string metaPath, Editor::ModelImportSettings& settings) {
+		using namespace rapidjson;
+		using namespace NE::Serialization;
+
+		if (!std::filesystem::exists(metaPath))
+			return false;
+
+		std::ifstream ifs(metaPath);
+		if (!ifs) {
+			SPD_WARNING("Failed to read meta file: " << metaPath);
+			return false;
+		}
+
+		IStreamWrapper isw(ifs);
+		Document doc;
+		doc.ParseStream(isw);
+
+		if (doc.HasParseError() || !doc.IsObject()) {
+			SPD_WARNING("Failed to parse JSON in meta file: " << metaPath);
+			return false;
+		}
+
+		// If there's no modelImport block yet, just keep default settings
+		if (!doc.HasMember("modelImport") || !doc["modelImport"].IsObject())
+			return true;
+
+		const auto& jSettings = doc["modelImport"];
+		from_json(jSettings, settings);
+
+		return true;
 	}
 }
 
@@ -1251,8 +1287,9 @@ namespace Editor {
 
 			if (assetPath.extension() == ".png" || assetPath.extension() == ".jpg") {
 				RenderTextureImportSettings(assetPath.string() + ".meta");
-			}
-			else if (assetPath.extension() == ".nanomat") {
+			} else if (assetPath.extension() == ".obj" || assetPath.extension() == ".fbx") {
+				RenderModelImportSettings(assetPath.string() + ".meta");
+			} else if (assetPath.extension() == ".nanomat") {
 				//RenderMaterialSettings();
 				if (!m_materialEditor || m_lastPath != assetPath.string()) {
 					m_materialEditor = std::make_unique<MaterialEditor>();
@@ -1315,6 +1352,163 @@ namespace Editor {
 
 		if (ImGui::Button("Apply")) {
 			WriteTextureTypeToMeta(metaPath, currentType);
+		}
+	}
+
+	void InspectorPanel::RenderModelImportSettings(const std::string& metaPath)
+	{
+		using namespace Editor;
+
+		ModelImportSettings settings{};
+		if (!LoadModelImportSettings(metaPath, settings)) {
+			ImGui::TextUnformatted("Failed to load model import settings.");
+			return;
+		}
+
+		static int s_CurrentImportTab = 0;
+
+		const char* tabNames[] = { "Model", "Rig", "Animation", "Materials" };
+		constexpr int tabCount = IM_ARRAYSIZE(tabNames);
+
+		ImGuiStyle& style = ImGui::GetStyle();
+		float fullWidth = ImGui::GetContentRegionAvail().x;
+
+		float totalButtonsWidth = 0.0f;
+		for (int i = 0; i < tabCount; ++i) {
+			ImVec2 textSize = ImGui::CalcTextSize(tabNames[i]);
+			float btnWidth = textSize.x + style.FramePadding.x * 2.0f;
+			totalButtonsWidth += btnWidth;
+			if (i + 1 < tabCount)
+				totalButtonsWidth += style.ItemInnerSpacing.x;
+		}
+
+		float cursorX = (fullWidth - totalButtonsWidth) * 0.5f;
+		if (cursorX < 0.0f) cursorX = 0.0f;
+		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cursorX);
+
+		for (int i = 0; i < tabCount; ++i) {
+			bool isActive = (s_CurrentImportTab == i);
+
+			if (isActive)
+				ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[ImGuiCol_ButtonActive]);
+			else
+				ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[ImGuiCol_Button]);
+
+			if (ImGui::Button(tabNames[i]))
+				s_CurrentImportTab = i;
+
+			ImGui::PopStyleColor();
+
+			if (i + 1 < tabCount)
+				ImGui::SameLine();
+		}
+
+		ImGui::Separator();
+
+		auto DrawComboEnum = [](const char* label, int& currentIndex, const char* const* names, int count) {
+			ImGui::Combo(label, &currentIndex, names, count);
+			};
+
+		switch (s_CurrentImportTab) {
+		case 0:
+		{
+			if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen)) {
+				// SceneImportSettings
+				ImGui::DragFloat("Scale Factor", &settings.scene.scaleFactor, 0.01f, 0.0001f, 100.0f);
+				Editor::DrawCheckbox("Convert Units", settings.scene.convertUnits);
+				Editor::DrawCheckbox("Import Blend Shapes", settings.scene.importBlendShapes);
+				Editor::DrawCheckbox("Import Cameras", settings.scene.importCameras);
+				Editor::DrawCheckbox("Import Lights", settings.scene.importLights);
+				Editor::DrawCheckbox("Preserve Hierarchy", settings.scene.preserveHierarchy);
+			}
+
+			if (ImGui::CollapsingHeader("Mesh", ImGuiTreeNodeFlags_DefaultOpen)) {
+				// MeshImportSettings
+				const char* MeshOptNames[] = { "None", "Everything", "Polygon Order", "Vertex Order" };
+				int meshOptIndex = static_cast<int>(settings.mesh.meshOptimizationMode);
+				DrawComboEnum("Mesh Optimization", meshOptIndex, MeshOptNames, IM_ARRAYSIZE(MeshOptNames));
+				settings.mesh.meshOptimizationMode =
+					static_cast<MeshImportSettings::MeshOptimizationMode>(meshOptIndex);
+
+				Editor::DrawCheckbox("Generate Colliders", settings.mesh.generateColliders);
+				Editor::DrawCheckbox("Generate Mesh LODs", settings.mesh.generateMeshLODs);
+
+				Editor::DrawCheckbox("Keep Quads", settings.mesh.keepQuads);
+				Editor::DrawCheckbox("Weld Vertices", settings.mesh.weldVertices);
+
+				const char* IndexFormatNames[] = { "Auto", "UInt16", "UInt32" };
+				int indexFmtIndex = static_cast<int>(settings.mesh.indexFormat);
+				DrawComboEnum("Index Format", indexFmtIndex, IndexFormatNames, IM_ARRAYSIZE(IndexFormatNames));
+				settings.mesh.indexFormat = static_cast<MeshImportSettings::IndexFormat>(indexFmtIndex);
+
+				const char* NormalModeNames[] = { "Import", "Calculate", "None" };
+				int normalIndex = static_cast<int>(settings.mesh.normalMode);
+				DrawComboEnum("Normals", normalIndex, NormalModeNames, IM_ARRAYSIZE(NormalModeNames));
+				settings.mesh.normalMode = static_cast<MeshImportSettings::NormalMode>(normalIndex);
+
+				ImGui::DragFloat("Smoothing Angle", &settings.mesh.smoothingAngle, 1.0f, 0.0f, 180.0f);
+
+				const char* TangentModeNames[] = { "Import", "Calculate (MikkTSpace)", "None" };
+				int tangentIndex = static_cast<int>(settings.mesh.tangentMode);
+				DrawComboEnum("Tangents", tangentIndex, TangentModeNames, IM_ARRAYSIZE(TangentModeNames));
+				settings.mesh.tangentMode = static_cast<MeshImportSettings::TangentMode>(tangentIndex);
+
+				Editor::DrawCheckbox("Swap UVs", settings.mesh.swapUVs);
+			}
+			break;
+		}
+
+		case 1: // ----- RIG -----
+		{
+			if (ImGui::CollapsingHeader("Rig", ImGuiTreeNodeFlags_DefaultOpen)) {
+				const char* AnimTypeNames[] = { "None", "Generic", "Humanoid" };
+				int animTypeIndex = static_cast<int>(settings.rig.animationType);
+				DrawComboEnum("Animation Type", animTypeIndex, AnimTypeNames, IM_ARRAYSIZE(AnimTypeNames));
+				settings.rig.animationType = static_cast<RigImportSettings::AnimationType>(animTypeIndex);
+
+				Editor::DrawCheckbox("Strip Unused Bones", settings.rig.stripBones);
+			}
+			break;
+		}
+
+		case 2: // ----- ANIMATION -----
+		{
+			if (ImGui::CollapsingHeader("Animation", ImGuiTreeNodeFlags_DefaultOpen)) {
+				Editor::DrawCheckbox("Import Animations", settings.animation.importAnimations);
+				Editor::DrawCheckbox("Import Constraints", settings.animation.importConstraints);
+				Editor::DrawCheckbox("Import Animated Custom Properties", settings.animation.importAnimatedCustomProperties);
+				Editor::DrawCheckbox("Auto Split Clips", settings.animation.autoSplitClips);
+
+				ImGui::DragFloat("Sample Rate", &settings.animation.sampleRate, 1.0f, 0.0f, 480.0f, "%.1f");
+
+				Editor::DrawCheckbox("Import Root Motion", settings.animation.importRootMotion);
+				Editor::DrawCheckbox("Lock Root Position XZ", settings.animation.lockRootPositionXZ);
+				Editor::DrawCheckbox("Lock Root Rotation Y", settings.animation.lockRootRotationY);
+			}
+			break;
+		}
+
+		case 3: // ----- MATERIALS -----
+		{
+			if (ImGui::CollapsingHeader("Materials", ImGuiTreeNodeFlags_DefaultOpen)) {
+				Editor::DrawCheckbox("Import Materials", settings.material.importMaterials);
+				Editor::DrawCheckbox("Try Reuse Existing Materials", settings.material.tryReuseExistingMaterials);
+
+				const char* MaterialModeNames[] = { "Per Submesh", "Per Mesh", "Per File" };
+				int matModeIndex = static_cast<int>(settings.material.creationMode);
+				DrawComboEnum("Material Creation", matModeIndex, MaterialModeNames, IM_ARRAYSIZE(MaterialModeNames));
+				settings.material.creationMode =
+					static_cast<MaterialImportSettings::MaterialCreationMode>(matModeIndex);
+			}
+			break;
+		}
+		}
+
+		ImGui::Spacing();
+		ImGui::Separator();
+
+		if (ImGui::Button("Apply")) {
+			//SaveModelImportSettings(metaPath, settings);
 		}
 	}
 }

--- a/Editor/src/Panels/InspectorPanel.hpp
+++ b/Editor/src/Panels/InspectorPanel.hpp
@@ -18,6 +18,8 @@ namespace Editor {
 
 		void RenderTextureImportSettings(std::string metaPath);
 
+		void RenderModelImportSettings(const std::string& metaPath);
+
 		// temp implementation
 		//std::shared_ptr<NE::Graphics::Material> m_loadedMaterial;
 		//std::string m_loadedPath;


### PR DESCRIPTION
Introduces ModelImportSettings with reflection for model assets and updates AssetManager to use JSON for asset metadata files, supporting both texture and model import settings. InspectorPanel now displays editable model import settings for .obj and .fbx assets. Refactors texture import settings to use reflection and adds versioning constants for importers. Minor UI and code cleanups included.