### PR TITLE
Refactor texture import settings handling

### DIFF
--- a/Editor/src/AssetManagement/AssetManager.cpp
+++ b/Editor/src/AssetManagement/AssetManager.cpp
@@ -432,7 +432,12 @@ namespace Editor {
         using namespace rapidjson;
 
         std::filesystem::path fsSourcePath = sourcePath;
-        std::filesystem::path metaPath = sourcePath + ".meta";
+        std::filesystem::path metaPath = sourcePath;
+        if (metaPath.extension() != ".meta") {
+            metaPath += ".meta";
+        } else {
+            fsSourcePath.replace_extension();
+        }
 
         AssetMetadata metadata{};
         metadata.sourcePath = sourcePath;
@@ -463,35 +468,26 @@ namespace Editor {
             AssetType assetType = GetAssetTypeFromExtension(fsSourcePath.extension().string());
             switch (assetType) {
             case AssetType::Texture: {
-
-
+                
                 TextureImportSettings texSettings{};
                 if (doc.HasMember("textureImport") && doc["textureImport"].IsObject()) {
-                    auto& importSettings = doc["textureImport"];
-
-                    if (importSettings.HasMember("type") && importSettings["type"].IsInt()) {
-                        int v = importSettings["type"].GetInt();
-                        texSettings.type = static_cast<TexType>(v);
-                        SPD_WARNING("TEXTURE TYPE: " << static_cast<int>(texSettings.type));
-                    }
+                    const auto& jSettings = doc["textureImport"];
+                    NE::Serialization::from_json(jSettings, texSettings);
                 }
 
-
-                CookTexture(sourcePath, outPath, texSettings);
-
-
+                CookTexture(fsSourcePath.string(), outPath, texSettings);
                 break;
             }
             case AssetType::Mesh: {
-                CookMesh(sourcePath, outPath);
+                CookMesh(fsSourcePath.string(), outPath);
                 break;
             }
             case AssetType::Shader: {
-                CookShader(sourcePath, outPath);
+                CookShader(fsSourcePath.string(), outPath);
                 break;
             }
             case AssetType::Material: {
-                CookMaterial(sourcePath, outPath);
+                CookMaterial(fsSourcePath.string(), outPath);
                 break;
             }
             case AssetType::Audio: {
@@ -537,6 +533,46 @@ namespace Editor {
             return m_assets.at(uuid).sourcePath;
 
         return "";
+    }
+
+    bool AssetManager::SaveTextureImportSettings(const std::string& metaPath, const TextureImportSettings& settings) {
+        namespace fs = std::filesystem;
+        using namespace rapidjson;
+        using namespace NE::Serialization;
+
+        if (!fs::exists(metaPath))
+            return false;
+
+        std::ifstream ifs(metaPath);
+        if (!ifs)
+            return false;
+
+        IStreamWrapper isw(ifs);
+        Document doc;
+        doc.ParseStream(isw);
+        if (doc.HasParseError() || !doc.IsObject())
+            return false;
+
+        auto& alloc = doc.GetAllocator();
+
+        RJson texImportJson = to_json(settings, alloc);
+
+        if (doc.HasMember("textureImport") && doc["textureImport"].IsObject()) {
+            doc["textureImport"].CopyFrom(texImportJson, alloc);
+        } else {
+            doc.AddMember("textureImport", texImportJson, alloc);
+        }
+
+        std::ofstream ofs(metaPath, std::ios::trunc);
+        if (!ofs)
+            return false;
+
+        OStreamWrapper osw(ofs);
+        PrettyWriter<OStreamWrapper> writer(osw);
+        writer.SetIndent(' ', 4);
+        doc.Accept(writer);
+
+        return true;
     }
 
     AssetType AssetManager::GetAssetTypeFromString(std::string_view extension) {

--- a/Editor/src/AssetManagement/AssetManager.hpp
+++ b/Editor/src/AssetManagement/AssetManager.hpp
@@ -22,6 +22,7 @@ namespace Editor {
 		std::string RetrieveUUID(const std::string& sourcePath);
 		std::string RetrieveFileName(const std::string& uuid);
 		
+		bool SaveTextureImportSettings(const std::string& metaPath, const TextureImportSettings& settings);
 
 		template <AssetType T>
 		std::vector<std::pair<std::string, UUID>>& GetAssetsOfType() {

--- a/Editor/src/AssetManagement/Settings/TextureImportSettings.hpp
+++ b/Editor/src/AssetManagement/Settings/TextureImportSettings.hpp
@@ -61,14 +61,14 @@ namespace Editor {
 	};
 
 	struct TextureImportSettings {
-		TexType type = TexType::Sprite;
+		TexType type = TexType::Default;
 		TexShape shape = TexShape::TwoD;
 		bool sRGB = true;
-		TexAlphaSource alpha = TexAlphaSource::InputTextureAlpha;
+		TexAlphaSource alphaSource = TexAlphaSource::InputTextureAlpha;
 		bool alphaIsTransparency = false;
 
-		TexWrapMode wrap = TexWrapMode::Clamp;
-		TexFilterMode filter = TexFilterMode::Bilinear;
+		TexWrapMode wrapMode = TexWrapMode::Repeat;
+		TexFilterMode filterMode = TexFilterMode::Bilinear;
 
 		MipPolicy mips{};
 		NormalMapOptions normal{};
@@ -78,10 +78,10 @@ namespace Editor {
 			NE_REFLECT_FIELD(type),
 			NE_REFLECT_FIELD(shape),
 			NE_REFLECT_FIELD(sRGB),
-			NE_REFLECT_FIELD(alpha),
+			NE_REFLECT_FIELD(alphaSource),
 			NE_REFLECT_FIELD(alphaIsTransparency),
-			NE_REFLECT_FIELD(wrap),
-			NE_REFLECT_FIELD(filter),
+			NE_REFLECT_FIELD(wrapMode),
+			NE_REFLECT_FIELD(filterMode),
 			NE_REFLECT_FIELD(mips),
 			NE_REFLECT_FIELD(normal)
 		NE_REFLECT_END()

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -169,43 +169,6 @@ namespace {
 		}
 	}
 
-	static void WriteTextureTypeToMeta(const std::string& metaPath, int textureType)
-	{
-		std::vector<std::string> lines;
-
-		// --- Read entire .meta ---
-		{
-			std::ifstream ifs(metaPath);
-			std::string line;
-			while (std::getline(ifs, line)) {
-				lines.push_back(line);
-			}
-		}
-
-		// --- Check if textureType already exists ---
-		bool found = false;
-		for (auto& line : lines) {
-			if (line.rfind("textureType:", 0) == 0) {
-				line = "textureType: " + std::to_string(textureType);
-				found = true;
-				break;
-			}
-		}
-
-		// --- If missing, append to end ---
-		if (!found) {
-			lines.push_back("textureType: " + std::to_string(textureType));
-		}
-
-		// --- Write back ---
-		{
-			std::ofstream ofs(metaPath, std::ios::trunc);
-			for (auto& l : lines) {
-				ofs << l << "\n";
-			}
-		}
-	}
-
 	bool LoadModelImportSettings(std::string metaPath, Editor::ModelImportSettings& settings) {
 		using namespace rapidjson;
 		using namespace NE::Serialization;
@@ -233,6 +196,38 @@ namespace {
 			return true;
 
 		const auto& jSettings = doc["modelImport"];
+		from_json(jSettings, settings);
+
+		return true;
+	}
+
+	bool LoadTextureImportSettings(std::string metaPath, Editor::TextureImportSettings& settings) {
+		using namespace rapidjson;
+		using namespace NE::Serialization;
+
+		if (!std::filesystem::exists(metaPath))
+			return false;
+
+		std::ifstream ifs(metaPath);
+		if (!ifs) {
+			SPD_WARNING("Failed to read meta file: " << metaPath);
+			return false;
+		}
+
+		IStreamWrapper isw(ifs);
+		Document doc;
+		doc.ParseStream(isw);
+
+		if (doc.HasParseError() || !doc.IsObject()) {
+			SPD_WARNING("Failed to parse JSON in meta file: " << metaPath);
+			return false;
+		}
+
+		// If there's no modelImport block yet, just keep default settings
+		if (!doc.HasMember("textureImport") || !doc["textureImport"].IsObject())
+			return true;
+
+		const auto& jSettings = doc["textureImport"];
 		from_json(jSettings, settings);
 
 		return true;
@@ -1308,56 +1303,104 @@ namespace Editor {
 	}
 
 	void InspectorPanel::RenderTextureImportSettings(std::string metaPath) {
+		static std::string s_LastMetaPath;
+		static TextureImportSettings s_Settings{};
+		static bool s_Loaded = false;
+		static bool s_dirty = false;
+
+		if (!s_Loaded || metaPath != s_LastMetaPath) {
+			if (!LoadTextureImportSettings(metaPath, s_Settings)) {
+				ImGui::TextUnformatted("Failed to load texture import settings.");
+				return;
+			}
+
+			s_LastMetaPath = metaPath;
+			s_Loaded = true;
+		}
+
 		static const char* TextureTypeNames[] = { "Default", "Normal Map", "Sprite" };
 		static const char* TextureShapeNames[] = { "2D", "Cube", "2D Array" };
 		static const char* TextureWrapMode[] = { "Repeat", "Clamp", "Mirror", "MirrorOnce", "PerAxis" };
 		static const char* TextureFilterMode[] = { "Point", "Bilinear", "Trilinear" };
 		static const char* AlphaSourceNames[] = { "InputTextureAlpha", "GrayscaleSource", "None" };
 
-		//std::filesystem::path mPath(metaPath);
-
-		int currentType = 0;
+		// ----- Texture Type -----
+		int currentType = static_cast<int>(s_Settings.type); // assuming enum starts at 0
 		if (ImGui::Combo("Texture Type", &currentType, TextureTypeNames, IM_ARRAYSIZE(TextureTypeNames))) {
-			WriteTextureTypeToMeta(metaPath, currentType);
+			s_Settings.type = static_cast<TexType>(currentType);
+			s_dirty = true;
 		}
 
-		int currentShape = 0;
+		// ----- Shape -----
+		int currentShape = static_cast<int>(s_Settings.shape); // TextureShape enum
 		if (ImGui::Combo("Texture Shape", &currentShape, TextureShapeNames, IM_ARRAYSIZE(TextureShapeNames))) {
+			s_Settings.shape = static_cast<TexShape>(currentShape);
+			s_dirty = true;
 		}
 
-		bool isSRGB = true;
+		// ----- sRGB -----
+		bool isSRGB = s_Settings.sRGB;
 		if (Editor::DrawCheckbox("sRGB (Color Texture)", isSRGB)) {
+			s_Settings.sRGB = isSRGB;
+			s_dirty = true;
 		}
 
-		int currentAlpha = 0;
+		// ----- Alpha Source -----
+		int currentAlpha = static_cast<int>(s_Settings.alphaSource); // AlphaSource enum
 		if (ImGui::Combo("Alpha Source", &currentAlpha, AlphaSourceNames, IM_ARRAYSIZE(AlphaSourceNames))) {
+			s_Settings.alphaSource = static_cast<TexAlphaSource>(currentAlpha);
+			s_dirty = true;
 		}
 
+		// ----- Advanced -----
 		if (ImGui::TreeNode("Advanced")) {
-			bool generateMips = true;
+			bool generateMips = s_Settings.mips.generateMipmap;
+			bool preserveCoverage = s_Settings.mips.preserveCoverage;
+
 			if (Editor::DrawCheckbox("Generate Mipmaps", generateMips)) {
+				s_Settings.mips.generateMipmap = generateMips;
+				s_dirty = true;
 			}
-			bool preserveCoverage = false;
+
 			if (Editor::DrawCheckbox("Preserve Coverage", preserveCoverage)) {
+				s_Settings.mips.preserveCoverage = preserveCoverage;
+				s_dirty = true;
 			}
+
 			ImGui::TreePop();
 		}
 
-		int currentFilter = 0;
+		// ----- Filter -----
+		int currentFilter = static_cast<int>(s_Settings.filterMode); // FilterMode enum
 		if (ImGui::Combo("Filter Mode", &currentFilter, TextureFilterMode, IM_ARRAYSIZE(TextureFilterMode))) {
-		}
-		int currentWrap = 0;
-		if (ImGui::Combo("Wrap Mode", &currentWrap, TextureWrapMode, IM_ARRAYSIZE(TextureWrapMode))) {
+			s_Settings.filterMode = static_cast<TexFilterMode>(currentFilter);
+			s_dirty = true;
 		}
 
-		if (ImGui::Button("Apply")) {
-			WriteTextureTypeToMeta(metaPath, currentType);
+		// ----- Wrap -----
+		int currentWrap = static_cast<int>(s_Settings.wrapMode); // WrapMode enum
+		if (ImGui::Combo("Wrap Mode", &currentWrap, TextureWrapMode, IM_ARRAYSIZE(TextureWrapMode))) {
+			s_Settings.wrapMode = static_cast<TexWrapMode>(currentWrap);
+			s_dirty = true;
 		}
+
+		ImGui::BeginDisabled(!s_dirty);
+		if (ImGui::Button("Apply")) {
+			if (!AssetManager::GetInstance().SaveTextureImportSettings(metaPath, s_Settings)) {
+				SPD_WARNING("Failed to save texture import settings for: " << metaPath);
+			} else {
+				AssetManager::GetInstance().ReimportAsset(metaPath);
+			}
+
+			s_dirty = false;
+		}
+		ImGui::EndDisabled();
 	}
 
-	void InspectorPanel::RenderModelImportSettings(const std::string& metaPath)
-	{
-		using namespace Editor;
+	void InspectorPanel::RenderModelImportSettings(const std::string& metaPath) {
+		//static std::string s_LastMetaPath;
+		//static ModelImportSettings s_Settings{};
+		//static bool s_Loaded = false;
 
 		ModelImportSettings settings{};
 		if (!LoadModelImportSettings(metaPath, settings)) {


### PR DESCRIPTION
Reworked texture import settings to use structured JSON fields instead of ad-hoc text lines. Updated TextureImportSettings struct with clearer field names and defaults. Added SaveTextureImportSettings to AssetManager for saving settings. InspectorPanel now loads, edits, and saves texture import settings via JSON, improving reliability and extensibility.