### PR TITLE
Update LightSystem to manage light entities in GraphicsManager

### DIFF
--- a/NANOEngine/src/ECS/Systems/LightSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/LightSystem.cpp
@@ -9,23 +9,35 @@ namespace NE::ECS::Systems {
     LightSystem::LightSystem(NE::ECS::ComponentManager* cm)
         : m_componentManager(cm) {}
 
-    void LightSystem::OnEntityAdded(Entity) {}
+    void LightSystem::OnEntityAdded(Entity entity) {
+        auto& t = m_componentManager->GetComponent<Component::Transform>(entity);
+        auto& sl = m_componentManager->GetComponent<Component::Light>(entity);
+        sl.position = t.localPosition;
+        Graphics::GraphicsManager::m_lights.push_back(&sl);
+    }
 
-    void LightSystem::OnEntityRemoved(Entity) {}
+    void LightSystem::OnEntityRemoved(Entity entity) {
+        auto& sl = m_componentManager->GetComponent<Component::Light>(entity);
+
+        Graphics::GraphicsManager::m_lights.erase(
+            std::remove_if(Graphics::GraphicsManager::m_lights.begin(), Graphics::GraphicsManager::m_lights.end(),
+                [&sl](Component::Light * lightPtr) {
+                    return lightPtr == &sl;
+                }),
+            Graphics::GraphicsManager::m_lights.end()
+        );
+    }
 
     void LightSystem::Init() {}
 
     void LightSystem::Update(double) {
         NE_PROFILE_FUNCTION();            
-        
-        Graphics::GraphicsManager::m_lights.clear();
-
+        // Can optimize with isdirty for light next time
         const auto& entities = GetEntities();
         for (Entity entity : entities) {
             auto& t = m_componentManager->GetComponent<Component::Transform>(entity);
             auto& sl = m_componentManager->GetComponent<Component::Light>(entity);
-            sl.position = t.localPosition;
-            Graphics::GraphicsManager::m_lights.push_back(&sl);
+            sl.position = t.worldMatrix.GetTranslation();
         }
     }
 


### PR DESCRIPTION
Implemented OnEntityAdded and OnEntityRemoved to add and remove light components from GraphicsManager::m_lights. Updated light position assignment in Update to use worldMatrix translation instead of localPosition. Removed clearing and repopulating m_lights in Update for efficiency.