### PR TITLE
Display asset names instead of UUIDs in material editor

### DIFF
--- a/Editor/MaterialEditor.cpp
+++ b/Editor/MaterialEditor.cpp
@@ -26,8 +26,12 @@ namespace Editor {
 
         auto& mat = *m_material;
 
+        ImGui::Text(m_path.c_str());
+        ImGui::Separator();
+
         bool openShaderPopup = false;
-        DrawAssetField("Shader", mat.GetPipeline()->GetSpecification().shaderName, "+", 0.f, &openShaderPopup);
+        std::string uuidToName = AssetManager::GetInstance().RetrieveFileName(mat.GetPipeline()->GetSpecification().shaderName);
+        DrawAssetField("Shader", uuidToName.c_str(), "+", 0.f, &openShaderPopup);
         if (openShaderPopup) ImGui::OpenPopup("AssetPicker_Shader");
 
         if (ImGui::BeginPopup("AssetPicker_Shader")) {

--- a/Editor/src/EditorUI.cpp
+++ b/Editor/src/EditorUI.cpp
@@ -146,6 +146,11 @@ namespace Editor {
                 img = (ImTextureID)(uintptr_t)gltex->GLName();
 
             ImGui::Image(img, ImVec2(previewSize, previewSize));
+            ImGui::SameLine();
+            if (ImGui::Button("x")) {
+                assignById("");
+                changed = true;
+            }
         } else {
             //ImVec2 cursor = ImGui::GetCursorScreenPos();
             //ImDrawList* dl = ImGui::GetWindowDrawList();

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -514,7 +514,7 @@ namespace Editor {
 
 					// Material field
 					char bufMat[256];
-					strncpy_s(bufMat, comp.materialUUID.c_str(), sizeof(bufMat));
+					strncpy_s(bufMat, AssetManager::GetInstance().RetrieveFileName(comp.materialUUID).c_str(), sizeof(bufMat));
 					ImGui::InputText("Material", bufMat, sizeof(bufMat));
 
 					if (ImGui::BeginDragDropTarget()) {

--- a/NANOEngine/src/Graphics/Core/Material.cpp
+++ b/NANOEngine/src/Graphics/Core/Material.cpp
@@ -57,7 +57,8 @@ namespace NE::Graphics {
 
     void Material::SetTexture(const std::string& uName, const std::string& uuid) {
         m_Textures[uName] = Resource::ResourceManager::GetInstance().LoadResource<NE::Graphics::OpenGL::GLTexture>(uuid);
-        m_Textures[uName]->MakeResident();
+        if (uuid != "")
+            m_Textures[uName]->MakeResident();
     }
 
     void Material::SetQueueBase(RenderQueue queue) {


### PR DESCRIPTION
Updated UI components in the material editor and inspector panel to show asset file names instead of UUIDs for better readability. Added a button to clear assigned images in the editor UI. Fixed Material::SetTexture to only call MakeResident when a valid UUID is provided.