### PR TITLE
Delete entities with all descendants in hierarchy

### DIFF
--- a/Editor/src/Command/EditorCommands.cpp
+++ b/Editor/src/Command/EditorCommands.cpp
@@ -61,33 +61,39 @@ namespace Editor {
 
 	void DeleteEntityCommand::Execute()
 	{
-		const uint32_t id = m_entity;
+		const uint32_t rootId = m_entity;
 
-		// temp
-		auto it = std::find_if(EditorScene::s_entities.begin(), EditorScene::s_entities.end(),
-			[id = m_entity](const EditorEntity& entt) {
-				return entt.linkedEntity == id;
-			});
+		std::vector<uint32_t> toDelete;
+		EditorScene::GetAllDescendants(rootId, toDelete);
 
-		if (it != EditorScene::s_entities.end()) {
-			EditorScene::s_entities.erase(it);
+		for (uint32_t id : toDelete) {
+			{
+				auto it = std::find_if(
+					EditorScene::s_entities.begin(), EditorScene::s_entities.end(),
+					[id](const EditorEntity& e) { return e.linkedEntity == id; }
+				);
+				if (it != EditorScene::s_entities.end()) {
+					EditorScene::s_entities.erase(it);
+				}
+			}
+
+			EditorScene::s_nodes.erase(id);
+
+			auto& roots = EditorScene::s_roots;
+			roots.erase(std::remove(roots.begin(), roots.end(), id), roots.end());
+
+			for (auto& [parent, vec] : EditorScene::s_children) {
+				vec.erase(std::remove(vec.begin(), vec.end(), id), vec.end());
+			}
+
+			NE::ECS::Command::DestroyEntity(id);
 		}
 
-		EditorScene::s_nodes.erase(id);
-
-		auto& roots = EditorScene::s_roots;
-		roots.erase(std::remove(roots.begin(), roots.end(), id), roots.end());
-
-		for (auto& [parent, vec] : EditorScene::s_children) {
-			vec.erase(std::remove(vec.begin(), vec.end(), id), vec.end());
+		if (EditorScene::s_selectedEntity &&
+			std::find(toDelete.begin(), toDelete.end(),
+				EditorScene::s_selectedEntity->linkedEntity) != toDelete.end()) {
+			EditorScene::s_selectedEntity = nullptr;
 		}
-
-		if (Editor::EditorScene::s_selectedEntity &&
-			Editor::EditorScene::s_selectedEntity->linkedEntity == id) {
-			Editor::EditorScene::s_selectedEntity = nullptr;
-		}
-
-		NE::ECS::Command::DestroyEntity(m_entity);
 	}
 
 	void DeleteEntityCommand::Undo()

--- a/Editor/src/EditorScene.cpp
+++ b/Editor/src/EditorScene.cpp
@@ -128,6 +128,17 @@ namespace Editor {
         return AttachAsChild(NE::ECS::NO_ENTITY, child, insertIndex);
     }
 
+    void EditorScene::GetAllDescendants(uint32_t id, std::vector<uint32_t>& out) {
+        out.push_back(id);
+
+        auto it = s_children.find(id);
+        if (it != s_children.end()) {
+            for (uint32_t child : it->second) {
+                GetAllDescendants(child, out);
+            }
+        }
+    }
+
     void EditorScene::BuildHierarchyFromECS() {
         s_nodes.clear();
         s_children.clear();

--- a/Editor/src/EditorScene.hpp
+++ b/Editor/src/EditorScene.hpp
@@ -36,6 +36,7 @@ namespace Editor {
         static bool AttachAsChild(uint32_t newParent, uint32_t child, int insertIndex);
         static bool UnparentToRoot(uint32_t child, int insertIndex = -1);
         static void BuildHierarchyFromECS();
+        static void GetAllDescendants(uint32_t id, std::vector<uint32_t>& out);
         // Helpers
         static const std::vector<uint32_t>& ChildrenOf(uint32_t parent);
     };


### PR DESCRIPTION
Refactored DeleteEntityCommand to recursively delete an entity and all its descendants from the editor scene. Added EditorScene::GetAllDescendants to collect all descendant entity IDs for deletion, ensuring proper cleanup of nodes, roots, children, and selection state.