### PR TITLE
Add recursive activation toggle for entity descendants

### DIFF
--- a/Editor/src/EditorScene.cpp
+++ b/Editor/src/EditorScene.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <ECS/Core/Entity.hpp>
 #include <EditorInterface/ECSExports.hpp>
+#include <ECS/Components/EntityMeta.hpp>
 
 namespace {
     void RemoveFromVec(std::vector<uint32_t>& v, uint32_t id) {
@@ -135,6 +136,18 @@ namespace Editor {
         if (it != s_children.end()) {
             for (uint32_t child : it->second) {
                 GetAllDescendants(child, out);
+            }
+        }
+    }
+
+    void EditorScene::SetAllDescendantsActive(uint32_t id, bool& active) {
+        auto& enttMeta = NE::ECS::Command::GetEntityMeta(id);
+        enttMeta.isActive = active;
+
+        auto it = s_children.find(id);
+        if (it != s_children.end()) {
+            for (uint32_t child : it->second) {
+                SetAllDescendantsActive(child, active);
             }
         }
     }

--- a/Editor/src/EditorScene.hpp
+++ b/Editor/src/EditorScene.hpp
@@ -37,6 +37,7 @@ namespace Editor {
         static bool UnparentToRoot(uint32_t child, int insertIndex = -1);
         static void BuildHierarchyFromECS();
         static void GetAllDescendants(uint32_t id, std::vector<uint32_t>& out);
+        static void SetAllDescendantsActive(uint32_t id, bool& active);
         // Helpers
         static const std::vector<uint32_t>& ChildrenOf(uint32_t parent);
     };

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -263,7 +263,10 @@ namespace Editor {
 
 				bool isActiveValue = metaRO.isActive;
 				if (ImGui::Checkbox("isActive", &isActiveValue)) {
-					metaRO.isActive = isActiveValue;
+					//metaRO.isActive = isActiveValue;
+
+					// DONE HERE FOR NOW, SHOULD BE DONE IN SYSTEMS !! OR ELSEWHERE
+					EditorScene::SetAllDescendantsActive(entity, isActiveValue);
 					NE::MarkSceneDirty();
 				}
 


### PR DESCRIPTION
Introduced EditorScene::SetAllDescendantsActive to recursively set the isActive state for an entity and all its descendants. Updated InspectorPanel to use this method when toggling the isActive checkbox, ensuring consistent activation state across entity hierarchies.