### PR TITLE
Add entity duplication, copy, and paste to editor

### DIFF
--- a/Editor/src/Application.cpp
+++ b/Editor/src/Application.cpp
@@ -27,6 +27,7 @@
 #include "Panels/AnimationPanel.hpp"
 #include "Panels/AnimationRuntimePanel.hpp"
 #include "Panels/AnimationGraphPanel.hpp"
+#include "EditorScene.hpp"
 
 namespace Editor {
 	bool Application::isRunning = true;
@@ -112,7 +113,7 @@ namespace Editor {
 		//editorLayer.AddPanel<AnimatorRuntimePanel>();
 		//editorLayer.AddPanel<AnimatorGraphPanel>();
 
-		NE::SetEditorCamera(reinterpret_cast<void*>(sp->GetCamera()));
+		NE::SetEditorCamera(reinterpret_cast<void*>(&EditorScene::m_editorCamera));
 
 		SPD_INFO("=== Application initialization complete ===");
 		SPD_DEBUG("All panels loaded successfully");

--- a/Editor/src/EditorLayer.cpp
+++ b/Editor/src/EditorLayer.cpp
@@ -17,403 +17,394 @@
 #include "EngineState.hpp"  // Add this include
 
 namespace Editor {
-    void EditorLayer::OnImGuiRender() {
-        static bool dockspaceOpen = true;
-        static bool opt_fullscreen_persistent = true;
-        bool opt_fullscreen = opt_fullscreen_persistent;
-
-        static ImGuiDockNodeFlags dockspace_flags = ImGuiDockNodeFlags_PassthruCentralNode;
-
-        ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar |
-            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
-
-        if (opt_fullscreen) {
-            const ImGuiViewport* viewport = ImGui::GetMainViewport();
-            ImGui::SetNextWindowPos(viewport->Pos);
-            ImGui::SetNextWindowSize(viewport->Size);
-            ImGui::SetNextWindowViewport(viewport->ID);
-            window_flags |= ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
-                ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus |
-                ImGuiWindowFlags_NoNavFocus;
-        }
-
-        ImGui::Begin("Editor DockSpace", &dockspaceOpen, window_flags);
-
-        float titleBarHeight = 0.0f;
-        DrawCustomTitleBar("NANOEngine", titleBarHeight, IM_COL32(25, 25, 25, 255));
-
-        // Calculate dockspace size to leave room for status bar at bottom
-        ImVec2 dockspaceSize = ImGui::GetContentRegionAvail();
-        dockspaceSize.y -= 25.0f; // Reserve 25px for status bar
-
-        // SINGLE DockSpace call
-        ImGuiID dockspace_id = ImGui::GetID("EditorDockspace");
-        ImGui::DockSpace(dockspace_id, dockspaceSize, dockspace_flags);
-
-        // === SHORTCUTS (Must be at window level to work) ===
-        // Save shortcut (Ctrl+S) - Check globally, not just when window focused
-        if (ImGui::IsKeyPressed(ImGuiKey_S, false) && (ImGui::GetIO().KeyCtrl && !ImGui::GetIO().KeyShift && !ImGui::GetIO().KeyAlt)) {
-            if (NE::IsSceneDirty()) {
-                SPD_INFO("[DirtyFlag] Ctrl+S pressed - Saving scene");
-                NE::SaveCurrentScene(EditorScene::currentScenePath);
-            }
-            else {
-                SPD_DEBUG("[DirtyFlag] Ctrl+S pressed - No changes to save");
-            }
-        }
-
-        for (auto& panel : m_panels) {
-            panel->OnImGuiRender();
-        }
-
-        // === STATUS BAR (Integrated at bottom of main window) ===
-        ImGui::Separator();
-
-        ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.12f, 0.12f, 0.12f, 1.0f));
-
-        if (ImGui::BeginChild("##StatusBar", ImVec2(0, 25.0f), false, ImGuiWindowFlags_NoScrollbar)) {
-            ImGui::SetCursorPosY(4.0f); // Center text vertically
-
-            // Scene path on the left
-            ImGui::Text("  %s", EditorScene::currentScenePath.c_str());
-
-            // Dirty indicator on the right
-            ImGui::SameLine();
-            float rightOffset = ImGui::GetWindowWidth() - 120.0f;
-            if (rightOffset > ImGui::GetCursorPosX()) {
-                ImGui::SetCursorPosX(rightOffset);
-            }
-
-            bool isSceneDirty = NE::IsSceneDirty();
-            if (isSceneDirty) {
-                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.6f, 0.0f, 1.0f)); // Orange
-                ImGui::Text("* UNSAVED");
-                ImGui::PopStyleColor();
-            }
-            else {
-                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.3f, 0.8f, 0.3f, 1.0f)); // Green
-                ImGui::Text("Saved");
-                ImGui::PopStyleColor();
-            }
-        }
-        ImGui::EndChild();
-
-        ImGui::PopStyleColor();
-
-        ImGui::End();  // End main dockspace window
-    }
-
-    void EditorLayer::SetIcon(unsigned int _iconID) {
-        icon = reinterpret_cast<ImTextureID>(reinterpret_cast<void*>((uintptr_t)_iconID));
-    }
-
-    void EditorLayer::DrawCustomTitleBar(const char* title, float height, ImU32 bgColor) {
-        height; title;
-      ImDrawList* drawList = ImGui::GetWindowDrawList();
-     ImVec2 winPos = ImGui::GetWindowPos();
-        float barHeight = 20.f;
-        ImVec2 menuBarSize = ImVec2(ImGui::GetWindowWidth(), barHeight);
-
-        HWND hwnd = static_cast<HWND>(ImGui::GetMainViewport()->PlatformHandleRaw);
-
-        // Background
-  drawList->AddRectFilled(winPos, ImVec2(winPos.x + menuBarSize.x, winPos.y + menuBarSize.y), bgColor);
-
-        // Begin menu bar region
- ImGui::SetCursorScreenPos(winPos);
-        ImGui::BeginChild("##CustomMenuBar", menuBarSize, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
-
-        // --- Logo (Left) ---
-        ImGui::SetCursorPos(ImVec2(0.f, 2.f));
-        ImGui::Image(icon, ImVec2(18.f, 18.f));
-        ImGui::SameLine();
-
-        // --- Menus (Next to logo) ---
-        float logoSpace = 20.f;
- ImGui::SetCursorPosX(logoSpace);
-
-        ImGuiStyle& style = ImGui::GetStyle();
-     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.f, style.ItemSpacing.y));
-     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(6.f, 2.f));
-        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1, 1, 1, 0.10f));
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1, 1, 1, 0.20f));
-
-        bool openFile = ImGui::Button("File");
-  ImVec2 fileMin = ImGui::GetItemRectMin();
-        ImVec2 fileMax = ImGui::GetItemRectMax();
-
-        ImGui::SameLine();
-        bool openEdit = ImGui::Button("Edit");
-        ImVec2 editMin = ImGui::GetItemRectMin();
-    ImVec2 editMax = ImGui::GetItemRectMax();
-
-        ImGui::SameLine();
-      bool openWindow = ImGui::Button("Window");
-        ImVec2 winMin = ImGui::GetItemRectMin();
-    ImVec2 winMax = ImGui::GetItemRectMax();
-
-        if (openFile)   ImGui::OpenPopup("FileMenu");
-        if (openEdit)   ImGui::OpenPopup("EditMenu");
-    if (openWindow) ImGui::OpenPopup("WindowMenu");
-
-        // Seamless popup styling
-     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(4, 4));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_PopupBorderSize, 1.0f);
-
-        // FILE MENU
-        ImGui::SetNextWindowPos(ImVec2(fileMin.x, fileMax.y), ImGuiCond_Appearing);
-    if (ImGui::BeginPopup("FileMenu")) {
-            if (ImGui::MenuItem("New Scene")) {}
-   if (ImGui::MenuItem("Open Scene")) {}
-ImGui::Separator();
-
-     // FIXED: Single Save menu item with proper dirty check
-            bool isSceneDirty = NE::IsSceneDirty();
-    if (isSceneDirty) {
-         if (ImGui::MenuItem("Save", "Ctrl+S")) {
-              SPD_INFO("[DirtyFlag] Save menu clicked - Saving scene");
-        NE::SaveCurrentScene(EditorScene::currentScenePath);
-                }
-  }
-       else {
-    ImGui::BeginDisabled();
- ImGui::MenuItem("Save", "Ctrl+S");
-     ImGui::EndDisabled();
-            }
-
-  if (ImGui::MenuItem("Save As...")) {
-NE::SaveCurrentScene(EditorScene::currentScenePath);
-  }
-
-         ImGui::Separator();
-          if (ImGui::MenuItem("Exit")) {
-     // Safety check: If playing, prompt to stop first
-        if (NE::GetEngineState() == NE::EngineState::Play) {
-  ImGui::OpenPopup("ExitWhilePlayingModal");
-      } else {
-  PostQuitMessage(0);
-    }
- }
-            ImGui::EndPopup();
-      }
-
-        // EDIT MENU
-        ImGui::SetNextWindowPos(ImVec2(editMin.x, editMax.y), ImGuiCond_Appearing);
-   if (ImGui::BeginPopup("EditMenu")) {
-     if (ImGui::MenuItem("Undo", "Ctrl+Z")) CommandHistory::GetInstance().Undo();
-            if (ImGui::MenuItem("Redo", "Ctrl+Y")) CommandHistory::GetInstance().Redo();
-  ImGui::Separator();
-            if (ImGui::MenuItem("Cut", "Ctrl+X")) {}
-    if (ImGui::MenuItem("Copy", "Ctrl+C")) {}
-            if (ImGui::MenuItem("Paste", "Ctrl+V")) {}
-            ImGui::EndPopup();
-        }
-
-  // WINDOW MENU
-      ImGui::SetNextWindowPos(ImVec2(winMin.x, winMax.y), ImGuiCond_Appearing);
-  if (ImGui::BeginPopup("WindowMenu")) {
-      if (ImGui::BeginMenu("General")) {
-         if (ImGui::MenuItem("Scene", nullptr, false)) {}
-                if (ImGui::MenuItem("Game", nullptr, false)) {}
-          if (ImGui::MenuItem("Inspector", nullptr, false)) {
-    AddPanel<InspectorPanel>();
-                }
-    ImGui::EndMenu();
-            }
-     if (ImGui::BeginMenu("Analysis")) {
-            if (ImGui::MenuItem("Profiler", nullptr, false)) {
-  AddPanel<ProfilerPanel>();
-      }
-            ImGui::EndMenu();
-       }
-          if (ImGui::BeginMenu("Animation")) {
-          if (ImGui::MenuItem("Animation", nullptr, false)) {
-      AddPanel<AnimationPanel>();
-                }
-           if (ImGui::MenuItem("Animator", nullptr, false)) {
-    AddPanel<AnimatorGraphPanel>();
-    }
-   if (ImGui::MenuItem("Animation Runtime", nullptr, false)) {
-     AddPanel<AnimatorRuntimePanel>();
-          }
-    ImGui::EndMenu();
-  }
-       ImGui::EndPopup();
-        }
-
-        ImGui::PopStyleVar(3);
-        ImGui::PopStyleColor(3);
-  ImGui::PopStyleVar(2);
-
-        // === Exit While Playing Modal Dialog ===
-    ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-        if (ImGui::BeginPopupModal("ExitWhilePlayingModal", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
-        ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.0f, 1.0f), "Warning!");
-     ImGui::Separator();
-         ImGui::Text("The scene is currently playing.");
-   ImGui::Text("You must stop play mode before exiting.");
-      ImGui::Spacing();
-            
-      if (ImGui::Button("Stop and Exit", ImVec2(120, 0))) {
-        NE::EditorEdit();  // Stop the scene
-        ImGui::CloseCurrentPopup();
-                PostQuitMessage(0);  // Then exit
-            }
-     
-            ImGui::SameLine();
-       if (ImGui::Button("Cancel", ImVec2(120, 0))) {
-  ImGui::CloseCurrentPopup();
-      }
-            
-       ImGui::EndPopup();
-        }
-
-        // --- History button (top-right), before window controls ---
-        float buttonSize = 20.0f;
-      float spacing = 0.0f;
-        float totalButtonsWidth = 3 * (buttonSize + spacing);
-
-        ImVec2 historySize = ImVec2(140.0f, 20.0f);
-
-      float rightEdge = menuBarSize.x - totalButtonsWidth - 8.0f;
-        ImVec2 pos = ImVec2(rightEdge - historySize.x, (menuBarSize.y - historySize.y) * 0.5f);
-    ImGui::SetCursorPos(pos);
-
-        auto& history = CommandHistory::GetInstance();
-        const auto& undo = history.GetUndoList();
-        const char* preview = undo.empty() ? "History" : undo.back()->GetName();
-
-        ImGui::SetNextItemWidth(historySize.x);
-        ImGuiComboFlags comboFlags = ImGuiComboFlags_NoArrowButton | ImGuiComboFlags_HeightLarge;
-
-        if (ImGui::BeginCombo("##history_dropdown", preview, comboFlags)) {
-  ImGui::TextUnformatted("Undo Stack");
-            ImGui::Separator();
-
-       if (undo.empty()) {
-       ImGui::TextDisabled("  <empty>");
-  }
- else {
-          for (int i = static_cast<int>(undo.size()) - 1; i >= 0; --i)
-        ImGui::BulletText("#%d - %s", i + 1, undo[i]->GetName());
-            }
-
-  ImGui::Spacing();
-  ImGui::TextUnformatted("Redo Stack");
-    ImGui::Separator();
-
-     const auto& redo = history.GetRedoList();
-  if (redo.empty()) {
-       ImGui::TextDisabled("  <empty>");
-            }
-       else {
-         for (int i = static_cast<int>(redo.size()) - 1; i >= 0; --i)
-     ImGui::BulletText("#%d - %s", i + 1, redo[i]->GetName());
-    }
-
-   ImGui::Spacing();
-       if (ImGui::Button("Undo")) history.Undo();
-   ImGui::SameLine();
-            if (ImGui::Button("Redo")) history.Redo();
-
-            ImGui::EndCombo();
-  }
-
-        // --- Window Controls (Far right) ---
-        ImGui::SetCursorPos(ImVec2(menuBarSize.x - totalButtonsWidth, 0.f));
-        ImVec2 btnPos = ImGui::GetCursorScreenPos();
-
-  // Minimize
-        if (ImGui::InvisibleButton("##minimize", ImVec2(buttonSize, buttonSize)))
-            ShowWindow(hwnd, SW_MINIMIZE);
-
-      if (ImGui::IsItemHovered()) {
-            drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
-    drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "-");
-        }
-        else {
-    drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "-");
-        }
-
-    ImGui::SameLine(0, spacing);
-        btnPos.x += buttonSize + spacing;
-
-        // Maximize/Restore
-     WINDOWPLACEMENT placement = { sizeof(WINDOWPLACEMENT) };
-        GetWindowPlacement(hwnd, &placement);
-        bool isMaximized = (placement.showCmd == SW_MAXIMIZE);
-
-      if (ImGui::InvisibleButton("##maximize", ImVec2(buttonSize, buttonSize)))
- ShowWindow(hwnd, isMaximized ? SW_RESTORE : SW_MAXIMIZE);
-
-        if (ImGui::IsItemHovered()) {
-  drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
-            drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "O");
-    }
-        else {
-     drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "O");
-        }
-
-   ImGui::SameLine(0, spacing);
-        btnPos.x += buttonSize + spacing;
-
-        // Close - with safety check for playing state
-        if (ImGui::InvisibleButton("##close", ImVec2(buttonSize, buttonSize))) {
-            // Safety check: If playing, prompt to stop first
- if (NE::GetEngineState() == NE::EngineState::Play) {
-         ImGui::OpenPopup("ExitWhilePlayingModal");
-            } else {
-       PostQuitMessage(0);
-            }
-     }
-
-        if (ImGui::IsItemHovered()) {
-        drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
- drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "X");
-        }
-        else {
-  drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 60, 60, 255), "X");
-        }
-
-     // For dragging of OS window
-        ImGui::SetCursorScreenPos(winPos);
-        ImGui::InvisibleButton("##drag_window", menuBarSize);
-  if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-            static bool restoringFromMaximized = false;
-
-         if (isMaximized && !restoringFromMaximized) {
-             restoringFromMaximized = true;
-
-     POINT cursor;
-    GetCursorPos(&cursor);
-
-     int restoreWidth = placement.rcNormalPosition.right - placement.rcNormalPosition.left;
-
-          ShowWindow(hwnd, SW_RESTORE);
-
-     SetWindowPos(hwnd, nullptr,
-         cursor.x - restoreWidth / 2,
-    cursor.y - 8, 0, 0,
-         SWP_NOSIZE | SWP_NOZORDER);
-   }
-            else {
-           restoringFromMaximized = false;
-
-         ImVec2 dragDelta = ImGui::GetMouseDragDelta();
-    RECT rect;
-      GetWindowRect(hwnd, &rect);
-
-                SetWindowPos(hwnd, nullptr,
-    rect.left + static_cast<int>(dragDelta.x),
-      rect.top + static_cast<int>(dragDelta.y),
-         0, 0, SWP_NOSIZE | SWP_NOZORDER);
-
-           ImGui::ResetMouseDragDelta();
-  }
-        }
-
-        ImGui::EndChild();
-    }
+	void EditorLayer::OnImGuiRender() {
+		static bool dockspaceOpen = true;
+		static bool opt_fullscreen_persistent = true;
+		bool opt_fullscreen = opt_fullscreen_persistent;
+
+		static ImGuiDockNodeFlags dockspace_flags = ImGuiDockNodeFlags_PassthruCentralNode;
+
+		ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar |
+			ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+
+		if (opt_fullscreen) {
+			const ImGuiViewport* viewport = ImGui::GetMainViewport();
+			ImGui::SetNextWindowPos(viewport->Pos);
+			ImGui::SetNextWindowSize(viewport->Size);
+			ImGui::SetNextWindowViewport(viewport->ID);
+			window_flags |= ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+				ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus |
+				ImGuiWindowFlags_NoNavFocus;
+		}
+
+		ImGui::Begin("Editor DockSpace", &dockspaceOpen, window_flags);
+
+		float titleBarHeight = 0.0f;
+		DrawCustomTitleBar("NANOEngine", titleBarHeight, IM_COL32(25, 25, 25, 255));
+
+		// Calculate dockspace size to leave room for status bar at bottom
+		ImVec2 dockspaceSize = ImGui::GetContentRegionAvail();
+		dockspaceSize.y -= 25.0f; // Reserve 25px for status bar
+
+		// SINGLE DockSpace call
+		ImGuiID dockspace_id = ImGui::GetID("EditorDockspace");
+		ImGui::DockSpace(dockspace_id, dockspaceSize, dockspace_flags);
+
+		// === SHORTCUTS (Must be at window level to work) ===
+		// Save shortcut (Ctrl+S) - Check globally, not just when window focused
+		if (ImGui::IsKeyPressed(ImGuiKey_S, false) && (ImGui::GetIO().KeyCtrl && !ImGui::GetIO().KeyShift && !ImGui::GetIO().KeyAlt)) {
+			if (NE::IsSceneDirty()) {
+				SPD_INFO("[DirtyFlag] Ctrl+S pressed - Saving scene");
+				NE::SaveCurrentScene(EditorScene::currentScenePath);
+			} else {
+				SPD_DEBUG("[DirtyFlag] Ctrl+S pressed - No changes to save");
+			}
+		}
+
+		for (auto& panel : m_panels) {
+			panel->OnImGuiRender();
+		}
+
+		// === STATUS BAR (Integrated at bottom of main window) ===
+		ImGui::Separator();
+
+		ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.12f, 0.12f, 0.12f, 1.0f));
+
+		if (ImGui::BeginChild("##StatusBar", ImVec2(0, 25.0f), false, ImGuiWindowFlags_NoScrollbar)) {
+			ImGui::SetCursorPosY(4.0f); // Center text vertically
+
+			// Scene path on the left
+			ImGui::Text("  %s", EditorScene::currentScenePath.c_str());
+
+			// Dirty indicator on the right
+			ImGui::SameLine();
+			float rightOffset = ImGui::GetWindowWidth() - 120.0f;
+			if (rightOffset > ImGui::GetCursorPosX()) {
+				ImGui::SetCursorPosX(rightOffset);
+			}
+
+			bool isSceneDirty = NE::IsSceneDirty();
+			if (isSceneDirty) {
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.6f, 0.0f, 1.0f)); // Orange
+				ImGui::Text("* UNSAVED");
+				ImGui::PopStyleColor();
+			} else {
+				ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.3f, 0.8f, 0.3f, 1.0f)); // Green
+				ImGui::Text("Saved");
+				ImGui::PopStyleColor();
+			}
+		}
+		ImGui::EndChild();
+
+		ImGui::PopStyleColor();
+
+		ImGui::End();  // End main dockspace window
+	}
+
+	void EditorLayer::SetIcon(unsigned int _iconID) {
+		icon = reinterpret_cast<ImTextureID>(reinterpret_cast<void*>((uintptr_t)_iconID));
+	}
+
+	void EditorLayer::DrawCustomTitleBar(const char* title, float height, ImU32 bgColor) {
+		height; title;
+		ImDrawList* drawList = ImGui::GetWindowDrawList();
+		ImVec2 winPos = ImGui::GetWindowPos();
+		float barHeight = 20.f;
+		ImVec2 menuBarSize = ImVec2(ImGui::GetWindowWidth(), barHeight);
+
+		HWND hwnd = static_cast<HWND>(ImGui::GetMainViewport()->PlatformHandleRaw);
+
+		// Background
+		drawList->AddRectFilled(winPos, ImVec2(winPos.x + menuBarSize.x, winPos.y + menuBarSize.y), bgColor);
+
+		// Begin menu bar region
+		ImGui::SetCursorScreenPos(winPos);
+		ImGui::BeginChild("##CustomMenuBar", menuBarSize, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+
+		// --- Logo (Left) ---
+		ImGui::SetCursorPos(ImVec2(0.f, 2.f));
+		ImGui::Image(icon, ImVec2(18.f, 18.f));
+		ImGui::SameLine();
+
+		// --- Menus (Next to logo) ---
+		float logoSpace = 20.f;
+		ImGui::SetCursorPosX(logoSpace);
+
+		ImGuiStyle& style = ImGui::GetStyle();
+		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.f, style.ItemSpacing.y));
+		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(6.f, 2.f));
+		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1, 1, 1, 0.10f));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1, 1, 1, 0.20f));
+
+		bool openFile = ImGui::Button("File");
+		ImVec2 fileMin = ImGui::GetItemRectMin();
+		ImVec2 fileMax = ImGui::GetItemRectMax();
+
+		ImGui::SameLine();
+		bool openEdit = ImGui::Button("Edit");
+		ImVec2 editMin = ImGui::GetItemRectMin();
+		ImVec2 editMax = ImGui::GetItemRectMax();
+
+		ImGui::SameLine();
+		bool openWindow = ImGui::Button("Window");
+		ImVec2 winMin = ImGui::GetItemRectMin();
+		ImVec2 winMax = ImGui::GetItemRectMax();
+
+		if (openFile)   ImGui::OpenPopup("FileMenu");
+		if (openEdit)   ImGui::OpenPopup("EditMenu");
+		if (openWindow) ImGui::OpenPopup("WindowMenu");
+
+		// Seamless popup styling
+		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(4, 4));
+		ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+		ImGui::PushStyleVar(ImGuiStyleVar_PopupBorderSize, 1.0f);
+
+		// FILE MENU
+		ImGui::SetNextWindowPos(ImVec2(fileMin.x, fileMax.y), ImGuiCond_Appearing);
+		if (ImGui::BeginPopup("FileMenu")) {
+			if (ImGui::MenuItem("New Scene")) {}
+			if (ImGui::MenuItem("Open Scene")) {}
+			ImGui::Separator();
+
+			// FIXED: Single Save menu item with proper dirty check
+			bool isSceneDirty = NE::IsSceneDirty();
+			if (isSceneDirty) {
+				if (ImGui::MenuItem("Save", "Ctrl+S")) {
+					SPD_INFO("[DirtyFlag] Save menu clicked - Saving scene");
+					NE::SaveCurrentScene(EditorScene::currentScenePath);
+				}
+			} else {
+				ImGui::BeginDisabled();
+				ImGui::MenuItem("Save", "Ctrl+S");
+				ImGui::EndDisabled();
+			}
+
+			if (ImGui::MenuItem("Save As...")) {
+				NE::SaveCurrentScene(EditorScene::currentScenePath);
+			}
+
+			ImGui::Separator();
+			if (ImGui::MenuItem("Exit")) {
+				// Safety check: If playing, prompt to stop first
+				if (NE::GetEngineState() == NE::EngineState::Play) {
+					ImGui::OpenPopup("ExitWhilePlayingModal");
+				} else {
+					PostQuitMessage(0);
+				}
+			}
+			ImGui::EndPopup();
+		}
+
+		// EDIT MENU
+		ImGui::SetNextWindowPos(ImVec2(editMin.x, editMax.y), ImGuiCond_Appearing);
+		if (ImGui::BeginPopup("EditMenu")) {
+			if (ImGui::MenuItem("Undo", "Ctrl+Z")) CommandHistory::GetInstance().Undo();
+			if (ImGui::MenuItem("Redo", "Ctrl+Y")) CommandHistory::GetInstance().Redo();
+			ImGui::Separator();
+			if (ImGui::MenuItem("Cut", "Ctrl+X")) {}
+			if (ImGui::MenuItem("Copy", "Ctrl+C")) {}
+			if (ImGui::MenuItem("Paste", "Ctrl+V")) {}
+			ImGui::EndPopup();
+		}
+
+		// WINDOW MENU
+		ImGui::SetNextWindowPos(ImVec2(winMin.x, winMax.y), ImGuiCond_Appearing);
+		if (ImGui::BeginPopup("WindowMenu")) {
+			if (ImGui::BeginMenu("General")) {
+				if (ImGui::MenuItem("Scene", nullptr, false)) {}
+				if (ImGui::MenuItem("Game", nullptr, false)) {}
+				if (ImGui::MenuItem("Inspector", nullptr, false)) {
+					AddPanel<InspectorPanel>();
+				}
+				ImGui::EndMenu();
+			}
+			if (ImGui::BeginMenu("Analysis")) {
+				if (ImGui::MenuItem("Profiler", nullptr, false)) {
+					AddPanel<ProfilerPanel>();
+				}
+				ImGui::EndMenu();
+			}
+			if (ImGui::BeginMenu("Animation")) {
+				if (ImGui::MenuItem("Animation", nullptr, false)) {
+					AddPanel<AnimationPanel>();
+				}
+				if (ImGui::MenuItem("Animator", nullptr, false)) {
+					AddPanel<AnimatorGraphPanel>();
+				}
+				if (ImGui::MenuItem("Animation Runtime", nullptr, false)) {
+					AddPanel<AnimatorRuntimePanel>();
+				}
+				ImGui::EndMenu();
+			}
+			ImGui::EndPopup();
+		}
+
+		ImGui::PopStyleVar(3);
+		ImGui::PopStyleColor(3);
+		ImGui::PopStyleVar(2);
+
+		// === Exit While Playing Modal Dialog ===
+		ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+		if (ImGui::BeginPopupModal("ExitWhilePlayingModal", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
+			ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.0f, 1.0f), "Warning!");
+			ImGui::Separator();
+			ImGui::Text("The scene is currently playing.");
+			ImGui::Text("You must stop play mode before exiting.");
+			ImGui::Spacing();
+
+			if (ImGui::Button("Stop and Exit", ImVec2(120, 0))) {
+				NE::EditorEdit();  // Stop the scene
+				ImGui::CloseCurrentPopup();
+				PostQuitMessage(0);  // Then exit
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+				ImGui::CloseCurrentPopup();
+			}
+
+			ImGui::EndPopup();
+		}
+
+		// --- History button (top-right), before window controls ---
+		float buttonSize = 20.0f;
+		float spacing = 0.0f;
+		float totalButtonsWidth = 3 * (buttonSize + spacing);
+
+		ImVec2 historySize = ImVec2(140.0f, 20.0f);
+
+		float rightEdge = menuBarSize.x - totalButtonsWidth - 8.0f;
+		ImVec2 pos = ImVec2(rightEdge - historySize.x, (menuBarSize.y - historySize.y) * 0.5f);
+		ImGui::SetCursorPos(pos);
+
+		auto& history = CommandHistory::GetInstance();
+		const auto& undo = history.GetUndoList();
+		const char* preview = undo.empty() ? "History" : undo.back()->GetName();
+
+		ImGui::SetNextItemWidth(historySize.x);
+		ImGuiComboFlags comboFlags = ImGuiComboFlags_NoArrowButton | ImGuiComboFlags_HeightLarge;
+
+		if (ImGui::BeginCombo("##history_dropdown", preview, comboFlags)) {
+			ImGui::TextUnformatted("Undo Stack");
+			ImGui::Separator();
+
+			if (undo.empty()) {
+				ImGui::TextDisabled("  <empty>");
+			} else {
+				for (int i = static_cast<int>(undo.size()) - 1; i >= 0; --i)
+					ImGui::BulletText("#%d - %s", i + 1, undo[i]->GetName());
+			}
+
+			ImGui::Spacing();
+			ImGui::TextUnformatted("Redo Stack");
+			ImGui::Separator();
+
+			const auto& redo = history.GetRedoList();
+			if (redo.empty()) {
+				ImGui::TextDisabled("  <empty>");
+			} else {
+				for (int i = static_cast<int>(redo.size()) - 1; i >= 0; --i)
+					ImGui::BulletText("#%d - %s", i + 1, redo[i]->GetName());
+			}
+
+			ImGui::Spacing();
+			if (ImGui::Button("Undo")) history.Undo();
+			ImGui::SameLine();
+			if (ImGui::Button("Redo")) history.Redo();
+
+			ImGui::EndCombo();
+		}
+
+		// --- Window Controls (Far right) ---
+		ImGui::SetCursorPos(ImVec2(menuBarSize.x - totalButtonsWidth, 0.f));
+		ImVec2 btnPos = ImGui::GetCursorScreenPos();
+
+		// Minimize
+		if (ImGui::InvisibleButton("##minimize", ImVec2(buttonSize, buttonSize)))
+			ShowWindow(hwnd, SW_MINIMIZE);
+
+		if (ImGui::IsItemHovered()) {
+			drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
+			drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "-");
+		} else {
+			drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "-");
+		}
+
+		ImGui::SameLine(0, spacing);
+		btnPos.x += buttonSize + spacing;
+
+		// Maximize/Restore
+		WINDOWPLACEMENT placement = { sizeof(WINDOWPLACEMENT) };
+		GetWindowPlacement(hwnd, &placement);
+		bool isMaximized = (placement.showCmd == SW_MAXIMIZE);
+
+		if (ImGui::InvisibleButton("##maximize", ImVec2(buttonSize, buttonSize)))
+			ShowWindow(hwnd, isMaximized ? SW_RESTORE : SW_MAXIMIZE);
+
+		if (ImGui::IsItemHovered()) {
+			drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
+			drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "O");
+		} else {
+			drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "O");
+		}
+
+		ImGui::SameLine(0, spacing);
+		btnPos.x += buttonSize + spacing;
+
+		// Close - with safety check for playing state
+		if (ImGui::InvisibleButton("##close", ImVec2(buttonSize, buttonSize))) {
+			// Safety check: If playing, prompt to stop first
+			if (NE::GetEngineState() == NE::EngineState::Play) {
+				ImGui::OpenPopup("ExitWhilePlayingModal");
+			} else {
+				PostQuitMessage(0);
+			}
+		}
+
+		if (ImGui::IsItemHovered()) {
+			drawList->AddRectFilled(btnPos, ImVec2(btnPos.x + buttonSize, btnPos.y + buttonSize), IM_COL32(200, 50, 50, 255), 2.0f);
+			drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 200, 200, 255), "X");
+		} else {
+			drawList->AddText(ImVec2(btnPos.x + 6.5f, btnPos.y + 3.5f), IM_COL32(200, 60, 60, 255), "X");
+		}
+
+		// For dragging of OS window
+		ImGui::SetCursorScreenPos(winPos);
+		ImGui::InvisibleButton("##drag_window", menuBarSize);
+		if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+			static bool restoringFromMaximized = false;
+
+			if (isMaximized && !restoringFromMaximized) {
+				restoringFromMaximized = true;
+
+				POINT cursor;
+				GetCursorPos(&cursor);
+
+				int restoreWidth = placement.rcNormalPosition.right - placement.rcNormalPosition.left;
+
+				ShowWindow(hwnd, SW_RESTORE);
+
+				SetWindowPos(hwnd, nullptr,
+					cursor.x - restoreWidth / 2,
+					cursor.y - 8, 0, 0,
+					SWP_NOSIZE | SWP_NOZORDER);
+			} else {
+				restoringFromMaximized = false;
+
+				ImVec2 dragDelta = ImGui::GetMouseDragDelta();
+				RECT rect;
+				GetWindowRect(hwnd, &rect);
+
+				SetWindowPos(hwnd, nullptr,
+					rect.left + static_cast<int>(dragDelta.x),
+					rect.top + static_cast<int>(dragDelta.y),
+					0, 0, SWP_NOSIZE | SWP_NOZORDER);
+
+				ImGui::ResetMouseDragDelta();
+			}
+		}
+
+		ImGui::EndChild();
+	}
 }

--- a/Editor/src/EditorScene.cpp
+++ b/Editor/src/EditorScene.cpp
@@ -26,6 +26,8 @@ namespace Editor {
     std::unordered_map<uint32_t, std::vector<uint32_t>> EditorScene::s_children;
     std::vector<uint32_t> EditorScene::s_roots;
 
+    NE::Graphics::EditorCamera EditorScene::m_editorCamera;
+
     static void RenormalizeKeys(std::vector<uint32_t>& ids, uint32_t) {
         float k = 0.f;
         for (auto id : ids) {

--- a/Editor/src/EditorScene.hpp
+++ b/Editor/src/EditorScene.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <unordered_map>
 #include "EditorEntity.hpp"
+#include "Graphics/Core/EditorCamera.hpp"
 
 namespace Editor {
 
@@ -21,6 +22,8 @@ namespace Editor {
         static std::string selectedAsset;
         static std::string currentScenePath;
         static std::string selectedPrefab;
+
+        static NE::Graphics::EditorCamera m_editorCamera;
 
         // NEW: hierarchy index
         static std::unordered_map<uint32_t, Node> s_nodes;                // id -> node

--- a/Editor/src/Panels/HierarchyPanel.cpp
+++ b/Editor/src/Panels/HierarchyPanel.cpp
@@ -11,6 +11,8 @@
 #include <EditorInterface/ECSExports.hpp>
 #include <ECS/Components/EntityMeta.hpp>
 #include "../AssetManagement/AssetManager.hpp"
+#include <unordered_set>
+#include <Math/Vec3.hpp>
 
 namespace Editor {
 	HierarchyPanel::HierarchyPanel() {
@@ -26,23 +28,34 @@ namespace Editor {
 	void HierarchyPanel::OnImGuiRender() {
 		ImGui::Begin("Hierarchy", nullptr, ImGuiWindowFlags_MenuBar);
 
+		bool canEditHierarchy = EditorScene::s_selectedEntity && EditorScene::selectedPrefab.empty();
+		if (ImGui::GetIO().KeyCtrl && !ImGui::GetIO().KeyShift && !ImGui::GetIO().KeyAlt) {
+			if (canEditHierarchy && ImGui::IsKeyPressed(ImGuiKey_D, false)) {
+				DuplicateSelected();
+			} else if (ImGui::IsKeyPressed(ImGuiKey_C, false)) {
+				CopySelected();
+			} else if (EditorScene::selectedPrefab.empty() && ImGui::IsKeyPressed(ImGuiKey_V, false)) {
+				PasteSelected();
+			}
+		}
+
 		if (ImGui::IsWindowHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Right)) {
 			ImGui::OpenPopup("HierarchyContextMenu");
 		}
 
-		bool canEditHierarchy = EditorScene::s_selectedEntity && EditorScene::selectedPrefab.empty();
 		if (ImGui::BeginPopupContextWindow("HierarchyContextMenu")) {
 			if (ImGui::MenuItem("Cut", "Ctrl+X", false, false)) {
 			}
-			if (ImGui::MenuItem("Copy", "Ctrl+C", false, false)) {
+			if (ImGui::MenuItem("Copy", "Ctrl+C", false, canEditHierarchy)) {
+				CopySelected();
 			}
-			if (ImGui::MenuItem("Paste", "Ctrl+V", false, false)) {
-			}
-			if (ImGui::MenuItem("Paste Special", "", false, false)) {
+			if (ImGui::MenuItem("Paste", "Ctrl+V", false, canEditHierarchy && !clipboard.empty())) {
+				PasteSelected();
 			}
 			if (ImGui::MenuItem("Rename", "", false, false)) {
 			}
-			if (ImGui::MenuItem("Duplicate", "Ctrl+D", false, false)) {
+			if (ImGui::MenuItem("Duplicate", "Ctrl+D", false, canEditHierarchy)) {
+				DuplicateSelected();
 			}
 			if (ImGui::MenuItem("Delete", "Del", false, canEditHierarchy)) {
 				NANOEngine::Events::EventBus::Get().Dispatch(NANOEngine::Events::EventDomain::Editor, DeleteEntityEvent{ EditorScene::s_selectedEntity->linkedEntity });
@@ -69,21 +82,21 @@ namespace Editor {
 				NANOEngine::Events::EventBus::Get().Dispatch(NANOEngine::Events::EventDomain::Editor, CreateEntityEvent{});
 			}
 			if (ImGui::BeginMenu("3D Object")) {
-				if (ImGui::MenuItem("Cube")) {
+				if (ImGui::MenuItem("Cube", "", false, false)) {
 				}
-				if (ImGui::MenuItem("Sphere")) {
+				if (ImGui::MenuItem("Sphere", "", false, false)) {
 				}
-				if (ImGui::MenuItem("Capsule")) {
+				if (ImGui::MenuItem("Capsule", "", false, false)) {
 				}
-				if (ImGui::MenuItem("Cylinder")) {
+				if (ImGui::MenuItem("Cylinder", "", false, false)) {
 				}
-				if (ImGui::MenuItem("Plane")) {
+				if (ImGui::MenuItem("Plane", "", false, false)) {
 				}
-				if (ImGui::MenuItem("Quad")) {
+				if (ImGui::MenuItem("Quad", "", false, false)) {
 				}
 				ImGui::EndMenu();
 			}
-			if (ImGui::MenuItem("Camera")) {
+			if (ImGui::MenuItem("Camera", "", false, false)) {
 				//CreateCameraEntity();
 			}
 
@@ -371,6 +384,73 @@ namespace Editor {
 		}
 
 		ImGui::End();
+	}
+
+	void HierarchyPanel::DuplicateSelected() {
+		std::vector<uint32_t> newEntities = NE::DuplicateEntity(EditorScene::s_selectedEntity->linkedEntity);
+
+		if (newEntities.empty()) return;
+
+		std::unordered_set<uint32_t> newSet(newEntities.begin(), newEntities.end());
+
+		for (uint32_t entt : newEntities) {
+			EditorScene::s_entities.push_back(Editor::EditorEntity{ entt });
+
+			Node node{};
+			node.id = entt;
+
+			uint32_t parent = NE::ECS::Command::GetParent(entt);
+			node.parent = parent;
+
+			if (parent == NE::ECS::NO_ENTITY) {
+				node.orderKey = static_cast<float>(Editor::EditorScene::s_roots.size());
+				EditorScene::s_roots.push_back(entt);
+			} else {
+				auto& childrenVec = Editor::EditorScene::s_children[parent];
+				node.orderKey = static_cast<float>(childrenVec.size());
+				childrenVec.push_back(entt);
+			}
+
+			EditorScene::s_nodes[entt] = node;
+		}
+
+		EditorScene::s_selectedEntity = nullptr;
+	}
+
+	void HierarchyPanel::CopySelected() {
+		clipboard = NE::CopyEntity(EditorScene::s_selectedEntity->linkedEntity);
+	}
+
+	void HierarchyPanel::PasteSelected() {
+		NE::Math::Vec3 camForwardPos = EditorScene::m_editorCamera.GetPosition() + EditorScene::m_editorCamera.GetForward() * 6.0f;
+		std::vector<uint32_t> newEntities = NE::PasteEntity(clipboard, camForwardPos);
+
+		if (newEntities.empty()) return;
+
+		std::unordered_set<uint32_t> newSet(newEntities.begin(), newEntities.end());
+
+		for (uint32_t entt : newEntities) {
+			EditorScene::s_entities.push_back(Editor::EditorEntity{ entt });
+
+			Node node{};
+			node.id = entt;
+
+			uint32_t parent = NE::ECS::Command::GetParent(entt);
+			node.parent = parent;
+
+			if (parent == NE::ECS::NO_ENTITY) {
+				node.orderKey = static_cast<float>(Editor::EditorScene::s_roots.size());
+				EditorScene::s_roots.push_back(entt);
+			} else {
+				auto& childrenVec = Editor::EditorScene::s_children[parent];
+				node.orderKey = static_cast<float>(childrenVec.size());
+				childrenVec.push_back(entt);
+			}
+
+			EditorScene::s_nodes[entt] = node;
+		}
+
+		EditorScene::s_selectedEntity = nullptr;
 	}
 
 }

--- a/Editor/src/Panels/HierarchyPanel.hpp
+++ b/Editor/src/Panels/HierarchyPanel.hpp
@@ -11,6 +11,13 @@ namespace Editor {
 
 		virtual void OnImGuiRender() override;
 
+
 	private:
+		void DuplicateSelected();
+		void CopySelected();
+		void PasteSelected();
+
+		// here for now
+		std::vector<uint8_t> clipboard;
 	};
 }

--- a/Editor/src/Panels/ScenePanel.cpp
+++ b/Editor/src/Panels/ScenePanel.cpp
@@ -34,12 +34,12 @@ namespace Editor {
 		float nearPlane = 0.1f;
 		float farPlane = 1000.0f;
 
-		m_editorCamera.SetPerspective(fovYRadians, aspectRatio, nearPlane, farPlane);
-		m_editorCamera.SetPosition(position);
-		m_editorCamera.LookAt(target, up);
+		EditorScene::m_editorCamera.SetPerspective(fovYRadians, aspectRatio, nearPlane, farPlane);
+		EditorScene::m_editorCamera.SetPosition(position);
+		EditorScene::m_editorCamera.LookAt(target, up);
 
 		// Give address of the editor camera to the scene camera tweener
-		sceneCameraTweener.SetSceneCamera(GetCamera());
+		sceneCameraTweener.SetSceneCamera(&EditorScene::m_editorCamera);
 
 		//NE::UpdateEditorCameraData();
 	}
@@ -67,7 +67,7 @@ namespace Editor {
 			if (const ImGuiPayload* p = ImGui::AcceptDragDropPayload("PREFAB_ASSET_PATH")) {
 				std::string dropped((const char*)p->Data, p->DataSize - 1);
 				std::string uuid = AssetManager::GetInstance().RetrieveUUID(dropped);
-				Vec3 camForwardPos = m_editorCamera.GetPosition() + m_editorCamera.GetForward() * 8.0f;
+				Vec3 camForwardPos = EditorScene::m_editorCamera.GetPosition() + EditorScene::m_editorCamera.GetForward() * 6.0f;
 				std::vector<uint32_t> newEntities = NE::DeserializePrefab(dropped, uuid, camForwardPos);
 
 				if (newEntities.empty()) {
@@ -202,11 +202,11 @@ namespace Editor {
 				if (move.LengthSquared() > 0.0f) {
 					move.Normalize();
 					// Calculate direction vectors
-					Vec3 forward = m_editorCamera.GetForward();
+					Vec3 forward = EditorScene::m_editorCamera.GetForward();
 					Vec3 right = forward.Cross(Vec3(0, 1, 0)).Normalized();
 
 					Vec3 offset = (right * move.x + forward * move.z + Vec3(0, 1, 0) * move.y) * m_cameraSpeed * deltaTime;
-					m_editorCamera.SetPosition(m_editorCamera.GetPosition() + offset);
+					EditorScene::m_editorCamera.SetPosition(EditorScene::m_editorCamera.GetPosition() + offset);
 				}
 
 				ImVec2 delta = { io.MousePos.x - m_lastMousePos.x, io.MousePos.y - m_lastMousePos.y };
@@ -297,8 +297,8 @@ namespace Editor {
 			memcpy(worldMatrix, tRO.worldMatrix.Data(), sizeof(float) * 16);
 
 			bool editedThisFrame = ImGuizmo::Manipulate(
-				m_editorCamera.GetViewMatrix().Data(),
-				m_editorCamera.GetProjectionMatrix().Data(),
+				EditorScene::m_editorCamera.GetViewMatrix().Data(),
+				EditorScene::m_editorCamera.GetProjectionMatrix().Data(),
 				currentOperation, ImGuizmo::LOCAL, worldMatrix
 			);
 			bool isUsing = ImGuizmo::IsUsing();
@@ -399,15 +399,10 @@ namespace Editor {
 		dir.x = cosf(Radians(m_cameraYaw)) * cosf(Radians(m_cameraPitch));
 		dir.y = sinf(Radians(m_cameraPitch));
 		dir.z = sinf(Radians(m_cameraYaw)) * cosf(Radians(m_cameraPitch));
-		m_editorCamera.LookAt(m_editorCamera.GetPosition() + dir, Vec3(0, 1, 0));
+		EditorScene::m_editorCamera.LookAt(EditorScene::m_editorCamera.GetPosition() + dir, Vec3(0, 1, 0));
 
 		NE::UpdateEditorCameraData();
 
 		ImGui::End();
-	}
-
-	NE::Graphics::EditorCamera* ScenePanel::GetCamera()
-	{
-		return &m_editorCamera;
 	}
 }

--- a/Editor/src/Panels/ScenePanel.hpp
+++ b/Editor/src/Panels/ScenePanel.hpp
@@ -3,7 +3,6 @@
 #include "IPanel.hpp"
 #include <vector>
 #include <string>
-#include "Graphics/Core/EditorCamera.hpp"
 #include "imgui/imgui_internal.h"
 #include "SceneCameraTweener.hpp"
 
@@ -13,12 +12,7 @@ namespace Editor {
 		ScenePanel();
 
 		virtual void OnImGuiRender() override;
-
-		NE::Graphics::EditorCamera* GetCamera();
-
 	private:
-		NE::Graphics::EditorCamera m_editorCamera;
-
 		float m_cameraYaw = -90.0f;  // looking along -Z
 		float m_cameraPitch = 0.0f;
 		float m_cameraSpeed = 5.0f;

--- a/Editor/src/PrefabManagement/PrefabManager.cpp
+++ b/Editor/src/PrefabManagement/PrefabManager.cpp
@@ -1,1 +1,0 @@
-#include "PrefabManager.hpp"

--- a/Editor/src/PrefabManagement/PrefabManager.hpp
+++ b/Editor/src/PrefabManagement/PrefabManager.hpp
@@ -1,4 +1,0 @@
-#pragma once
-class PrefabManager {
-};
-

--- a/NANOEngine/src/Engine.cpp
+++ b/NANOEngine/src/Engine.cpp
@@ -10,6 +10,7 @@
 //#include <glad/glad.h>
 #include "SceneManagement/Scene.hpp"
 #include "../../src/Serialisation/JsonSceneSerializer.hpp"
+#include "ECS/Components/Transform.hpp"
 //#include "AssetManager.hpp"
 #include "Physics/PhysicsManager.hpp"
 #include "Physics/JoltDebugRenderer.hpp"
@@ -250,6 +251,51 @@ namespace NE {
 
 	void ClosePrefabScene() {
 		gSceneManager.ClosePrefabScene();
+	}
+
+	std::vector<uint32_t> DuplicateEntity(uint32_t entity) {
+		std::vector<uint8_t> buffer;
+		NE::Serialization::JsonSceneSerializer::SerializePrefabToMemory(*gSceneManager.GetActive(), entity, buffer);
+
+		if (buffer.empty())
+			return std::vector<uint32_t>{};
+
+		auto newEntities =
+			NE::Serialization::JsonSceneSerializer::DeserializePrefabFromMemory(*gSceneManager.GetActive(), buffer);
+
+		if (newEntities.empty())
+			return std::vector<uint32_t>{};
+
+		auto& transform = gSceneManager.
+			GetActive()->GetECSCoordinator().
+			GetComponent<ECS::Component::Transform>(newEntities[0]);
+
+		transform.localPosition.x += 0.5f;
+		transform.localPosition.y += 0.5f;
+		transform.localPosition.z += 0.5f;
+		transform.isDirty = true;
+
+		return newEntities;
+	}
+
+	std::vector<uint8_t> CopyEntity(uint32_t entity) {
+		std::vector<uint8_t> buffer;
+		NE::Serialization::JsonSceneSerializer::SerializePrefabToMemory(*gSceneManager.GetActive(), entity, buffer);
+		return buffer;
+	}
+
+	std::vector<uint32_t> PasteEntity(std::vector<uint8_t> clipboard, Math::Vec3 pos) {
+		auto newEntities =
+			NE::Serialization::JsonSceneSerializer::DeserializePrefabFromMemory(*gSceneManager.GetActive(), clipboard);
+
+		auto& transform = gSceneManager.
+			GetActive()->GetECSCoordinator().
+			GetComponent<ECS::Component::Transform>(newEntities[0]);
+
+		transform.localPosition = pos;
+		transform.isDirty = true;
+
+		return newEntities;
 	}
 
 	// Internal use only

--- a/NANOEngine/src/Engine.hpp
+++ b/NANOEngine/src/Engine.hpp
@@ -39,12 +39,16 @@ namespace NE {
 
 	NANOENGINE_API const std::vector<uint32_t>& GetNumEntities();
 	NANOENGINE_API std::string SerializePrefab(uint32_t entt, std::string targetPath);
-	NANOENGINE_API std::vector<uint32_t> DeserializePrefab(std::string prefabPath, std::string uuid);
+	NANOENGINE_API std::vector<uint32_t> DeserializePrefab(std::string prefabPath, std::string uuid); // Deprecated
 	NANOENGINE_API std::vector<uint32_t> DeserializePrefab(std::string prefabPath, std::string uuid, Math::Vec3 pos);
 	NANOENGINE_API void LoadPrefabScene(std::string prefabPath);
 	NANOENGINE_API void SavePrefabScene(std::string prefabPath);
 	NANOENGINE_API void ReloadAllInstancesOfPrefab(std::string prefabUUID, std::string prefabPath);
 	NANOENGINE_API void ClosePrefabScene();
+
+	NANOENGINE_API std::vector<uint32_t> DuplicateEntity(uint32_t entity);
+	NANOENGINE_API std::vector<uint8_t> CopyEntity(uint32_t entity);
+	NANOENGINE_API std::vector<uint32_t> PasteEntity(std::vector<uint8_t> clipboard, Math::Vec3 pos);
 
 	//NANOENGINE_API const std::vector<std::pair<std::string, std::shared_ptr<Asset::AudioBank>>>& GetAllAudioBanks();
 

--- a/NANOEngine/src/Serialisation/JsonSceneSerializer.cpp
+++ b/NANOEngine/src/Serialisation/JsonSceneSerializer.cpp
@@ -561,26 +561,195 @@ namespace NE::Serialization {
         }
     }
 
+    void JsonSceneSerializer::SerializePrefabToMemory(SceneManagement::Scene& scene,
+        uint32_t rootEnt,
+        std::vector<uint8_t>& outBuffer)
+    {
+        using namespace rapidjson;
+        auto& ecs = scene.GetECSCoordinator();
 
-    //void JsonSceneSerializer::ReloadEntityFromJson(SceneManagement::Scene& scene,
-    //    uint32_t entity,
-    //    uint32_t instanceRoot,
-    //    const rapidjson::Value& entVal)
-    //{
-    //    auto& ecs = scene.GetECSCoordinator();
+        using NE::ECS::Component::EntityMeta;
+        using NE::ECS::Component::Transform;
 
-    //    using NE::ECS::Component::Transform;
+        if (!ecs.HasComponent<Transform>(rootEnt))
+            return;
 
-    //    ForEachComponentType([&]<typename C>() {
-    //        // Keep root Transform as per-instance override:
-    //        if constexpr (std::is_same_v<C, Transform>) {
-    //            if (entity == instanceRoot)
-    //                return;
-    //        }
+        std::vector<uint32_t> entities;
+        entities.reserve(16);
+        CollectPrefabSubtree(ecs, rootEnt, entities);
 
-    //        ReadComponentIfPresent<C>(ecs, entity, entVal);
-    //    });
-    //}
+        if (entities.empty())
+            return;
+
+        std::unordered_map<uint32_t, uint64_t> entityToLocalId;
+        entityToLocalId.reserve(entities.size());
+
+        uint64_t nextId = 1;
+        for (uint32_t e : entities) {
+            entityToLocalId[e] = nextId++;
+        }
+
+        Document doc;
+        doc.SetObject();
+        auto& a = doc.GetAllocator();
+        Value entitiesArr(kArrayType);
+
+        for (uint32_t e : entities) {
+            Value ent(kObjectType);
+
+            ForEachComponentType([&]<typename C>() {
+                WriteComponentIfPresent<C>(ecs, e, ent, a);
+            });
+
+            if (ent.HasMember(ComponentKey<EntityMeta>::value)) {
+                auto& eJson = ent[ComponentKey<EntityMeta>::value];
+                const uint64_t myId = entityToLocalId[e];
+
+                if (eJson.HasMember("prefabLocalID"))
+                    eJson["prefabLocalID"].SetUint64(myId);
+                else
+                    eJson.AddMember("prefabLocalID", myId, a);
+            }
+
+            if (ent.HasMember(ComponentKey<Transform>::value)) {
+                auto& tJson = ent[ComponentKey<Transform>::value];
+                const auto& t = ecs.GetComponent<Transform>(e);
+
+                const uint64_t myId = entityToLocalId[e];
+
+                uint64_t parentId = 0;
+                if (t.parent != NE::ECS::Component::INVALID_PARENT) {
+                    auto it = entityToLocalId.find(t.parent);
+                    if (it != entityToLocalId.end())
+                        parentId = it->second;
+                }
+
+                if (tJson.HasMember("luid"))
+                    tJson["luid"].SetUint64(myId);
+                else
+                    tJson.AddMember("luid", myId, a);
+
+                if (tJson.HasMember("parentLuid"))
+                    tJson["parentLuid"].SetUint64(parentId);
+                else
+                    tJson.AddMember("parentLuid", parentId, a);
+            }
+
+            entitiesArr.PushBack(ent, a);
+        }
+
+        doc.AddMember("Entities", entitiesArr, a);
+
+        rapidjson::StringBuffer sb;
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> wr(sb);
+        doc.Accept(wr);
+
+        outBuffer.clear();
+        outBuffer.resize(sb.GetSize());
+        std::memcpy(outBuffer.data(), sb.GetString(), sb.GetSize());
+    }
+
+    std::vector<uint32_t> JsonSceneSerializer::DeserializePrefabFromMemory(SceneManagement::Scene& scene,
+        const uint8_t* data,
+        size_t size)
+    {
+        std::vector<uint32_t> ret{};
+        if (!data || size == 0)
+            return ret;
+
+        using namespace rapidjson;
+
+        std::string jsonStr(reinterpret_cast<const char*>(data), size);
+        Document doc;
+        doc.Parse(jsonStr.c_str());
+        if (!doc.IsObject() || !doc.HasMember("Entities"))
+            return ret;
+
+        auto& ecs = scene.GetECSCoordinator();
+        auto entities = doc["Entities"].GetArray();
+        const size_t count = entities.Size();
+
+        using NE::ECS::Component::Transform;
+
+        std::vector<NE::ECS::Entity> created(count, NE::ECS::NO_ENTITY);
+        std::vector<uint64_t> prefabLuid(count, 0);
+        std::vector<uint64_t> prefabParentLuid(count, 0);
+        std::vector<bool> hasTransform(count, false);
+
+        for (size_t i = 0; i < count; ++i) {
+            auto& entVal = entities[i];
+
+            if (entVal.HasMember(ComponentKey<Transform>::value)) {
+                auto& tJson = entVal[ComponentKey<Transform>::value];
+
+                if (tJson.HasMember("luid") && tJson["luid"].IsUint64())
+                    prefabLuid[i] = tJson["luid"].GetUint64();
+
+                if (tJson.HasMember("parentLuid") && tJson["parentLuid"].IsUint64())
+                    prefabParentLuid[i] = tJson["parentLuid"].GetUint64();
+
+                hasTransform[i] = true;
+
+                uint64_t newLuid = Core::LUIDGenerator::Generate("tr");
+                tJson["luid"].SetUint64(newLuid);
+                tJson["parentLuid"].SetUint64(0);
+            }
+
+            NE::ECS::Entity e = ecs.CreateEntity();
+            ret.push_back(e);
+            created[i] = e;
+
+            ForEachComponentType([&]<typename C>() {
+                ReadComponentIfPresent<C>(ecs, e, entVal);
+            });
+        }
+
+        std::unordered_map<uint64_t, NE::ECS::Entity> prefabToEntity;
+        prefabToEntity.reserve(count);
+
+        for (size_t i = 0; i < count; ++i) {
+            if (!hasTransform[i]) continue;
+            if (prefabLuid[i] == 0) continue;
+            prefabToEntity[prefabLuid[i]] = created[i];
+        }
+
+        for (size_t i = 0; i < count; ++i) {
+            if (!hasTransform[i]) continue;
+
+            uint64_t parentLocal = prefabParentLuid[i];
+            if (parentLocal == 0)
+                continue;
+
+            auto it = prefabToEntity.find(parentLocal);
+            if (it == prefabToEntity.end())
+                continue;
+
+            NE::ECS::Entity child = created[i];
+            NE::ECS::Entity parent = it->second;
+
+            auto& childT = ecs.GetComponent<Transform>(child);
+            auto& parentT = ecs.GetComponent<Transform>(parent);
+
+            if (childT.parent != NE::ECS::Component::INVALID_PARENT) {
+                auto& oldParentT = ecs.GetComponent<Transform>(childT.parent);
+                auto& vec = oldParentT.children;
+                vec.erase(std::remove(vec.begin(), vec.end(), child), vec.end());
+            }
+
+            childT.parent = parent;
+            parentT.children.push_back(child);
+            childT.parentLuid = parentT.luid;
+            childT.isDirty = true;
+        }
+
+        return ret;
+    }
+
+    std::vector<uint32_t> JsonSceneSerializer::DeserializePrefabFromMemory(SceneManagement::Scene& scene,
+        const std::vector<uint8_t>& buffer)
+    {
+        return DeserializePrefabFromMemory(scene, buffer.data(), buffer.size());
+    }
 
 
     void JsonSceneSerializer::SerializeToMemory(SceneManagement::Scene& scene, std::vector<uint8_t>& outBuffer) {

--- a/NANOEngine/src/Serialisation/JsonSceneSerializer.hpp
+++ b/NANOEngine/src/Serialisation/JsonSceneSerializer.hpp
@@ -15,12 +15,23 @@ namespace NE::Serialization {
         static void Deserialize(SceneManagement::Scene& scene, const std::string& path);
    
         static std::string SerializePrefab(SceneManagement::Scene& scene, uint32_t entt, const std::string& path);
-        static std::vector<uint32_t> DeserializePrefab(SceneManagement::Scene& scene, const std::string& path);
+        static std::vector<uint32_t> DeserializePrefab(SceneManagement::Scene& scene, const std::string& path); // Deprecated
         static std::vector<uint32_t> DeserializePrefab(SceneManagement::Scene& scene, const std::string& path, NE::Math::Vec3 camForwardPos);
         static void ReloadComponentsForEntity(SceneManagement::Scene& scene,
             uint32_t entity,
             uint32_t rootEntity,
             const rapidjson::Value& entVal);
+
+        static void SerializePrefabToMemory(SceneManagement::Scene& scene,
+            uint32_t rootEnt,
+            std::vector<uint8_t>& outBuffer);
+
+        static std::vector<uint32_t> DeserializePrefabFromMemory(SceneManagement::Scene& scene,
+            const uint8_t* data,
+            size_t size);
+
+        static std::vector<uint32_t> DeserializePrefabFromMemory(SceneManagement::Scene& scene,
+            const std::vector<uint8_t>& buffer);
 
         static void SerializeToMemory(SceneManagement::Scene& scene, std::vector<uint8_t>& outBuffer);
         static void DeserializeFromMemory(SceneManagement::Scene& scene, const uint8_t* data, size_t size);


### PR DESCRIPTION
Introduces DuplicateEntity, CopyEntity, and PasteEntity functions in the engine and exposes them to the editor. Refactors editor camera management to be shared via EditorScene, updates HierarchyPanel to support duplication, copy, and paste via context menu and shortcuts, and removes unused PrefabManager files. ScenePanel and related code now use the shared editor camera. Also adds in-memory prefab serialization/deserialization for clipboard operations.