### PR TITLE
Add drag-and-drop for materials and meshes in ScenePanel

### DIFF
--- a/Editor/src/EditorScene.hpp
+++ b/Editor/src/EditorScene.hpp
@@ -17,7 +17,7 @@ namespace Editor {
 
     struct EditorScene {
     public:
-        static std::vector<EditorEntity> s_entities;
+        static std::vector<EditorEntity> s_entities; // to be removed soon
         static EditorEntity* s_selectedEntity;
         static std::string selectedAsset;
         static std::string currentScenePath;

--- a/Editor/src/Panels/ScenePanel.cpp
+++ b/Editor/src/Panels/ScenePanel.cpp
@@ -12,6 +12,7 @@
 #include <ECS/Core/Entity.hpp>
 #include "../AssetManagement/AssetManager.hpp"
 #include <ECS/Components/EntityMeta.hpp>
+#include <EditorInterface/RendererExports.hpp>
 
 namespace Editor {
 	static std::unique_ptr<Editor::SetTransformCommand> s_gizmoCmd;
@@ -64,8 +65,8 @@ namespace Editor {
 		);
 
 		if (ImGui::BeginDragDropTarget()) {
-			if (const ImGuiPayload* p = ImGui::AcceptDragDropPayload("PREFAB_ASSET_PATH")) {
-				std::string dropped((const char*)p->Data, p->DataSize - 1);
+			if (const ImGuiPayload* prefabPayload = ImGui::AcceptDragDropPayload("PREFAB_ASSET_PATH")) {
+				std::string dropped((const char*)prefabPayload->Data, prefabPayload->DataSize - 1);
 				std::string uuid = AssetManager::GetInstance().RetrieveUUID(dropped);
 				Vec3 camForwardPos = EditorScene::m_editorCamera.GetPosition() + EditorScene::m_editorCamera.GetForward() * 6.0f;
 				std::vector<uint32_t> newEntities = NE::DeserializePrefab(dropped, uuid, camForwardPos);
@@ -128,6 +129,52 @@ namespace Editor {
 
 				// Clear asset selection since we just selected an entity
 				Editor::EditorScene::selectedAsset.clear();
+			} else if (const ImGuiPayload* materialPayload = ImGui::AcceptDragDropPayload("MATERIAL_PATH")) {
+				std::string dropped((const char*)materialPayload->Data, materialPayload->DataSize - 1);
+				std::string uuid = AssetManager::GetInstance().RetrieveUUID(dropped);
+				
+				if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+					ImVec2 mousePos = ImGui::GetMousePos();
+					if (mousePos.x >= panelPos.x && mousePos.x < panelPos.x + panelSize.x &&
+						mousePos.y >= panelPos.y && mousePos.y < panelPos.y + panelSize.y) {
+
+						float localX = mousePos.x - panelPos.x;
+						float localY = mousePos.y - panelPos.y;
+						float spMouseX = localX / panelSize.x;
+						float spMouseY = localY / panelSize.y;
+
+						uint32_t x = static_cast<int>(spMouseX * 1920.f); // temp hardcoded
+						uint32_t y = static_cast<int>(1080 - 1 - (spMouseY * 1080)); // temp hardcoded
+
+						uint32_t id = NE::GetPickedEntity(x, y);
+
+						if (id != NE::ECS::NO_ENTITY)
+							NE::Renderer::Command::AssignMaterial(id, uuid);
+					}
+				}
+			} else if (const ImGuiPayload* modalPayload = ImGui::AcceptDragDropPayload("ASSET_MESH_PATH")) {
+				std::string dropped((const char*)modalPayload->Data, modalPayload->DataSize - 1);
+				std::string uuid = AssetManager::GetInstance().RetrieveUUID(dropped);
+
+				if (ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {
+					ImVec2 mousePos = ImGui::GetMousePos();
+					if (mousePos.x >= panelPos.x && mousePos.x < panelPos.x + panelSize.x &&
+						mousePos.y >= panelPos.y && mousePos.y < panelPos.y + panelSize.y) {
+
+						float localX = mousePos.x - panelPos.x;
+						float localY = mousePos.y - panelPos.y;
+						float spMouseX = localX / panelSize.x;
+						float spMouseY = localY / panelSize.y;
+
+						uint32_t x = static_cast<int>(spMouseX * 1920.f);
+						uint32_t y = static_cast<int>(1080 - 1 - (spMouseY * 1080));
+
+						uint32_t id = NE::GetPickedEntity(x, y);
+
+						if (id != NE::ECS::NO_ENTITY)
+							NE::Renderer::Command::AssignModel(id, uuid);
+					}
+				}
 			}
 			ImGui::EndDragDropTarget();
 		}
@@ -240,7 +287,8 @@ namespace Editor {
 
 						EditorScene::s_selectedEntity = nullptr;
 						EditorScene::selectedAsset = "";
-						for (auto& ent : EditorScene::s_entities) {
+						// probably need to change this looks terrible when we have alot of entities
+						for (auto& ent : EditorScene::s_entities) { 
 							if (ent.linkedEntity == id) {
 								EditorScene::s_selectedEntity = &ent;
 								break;
@@ -253,9 +301,9 @@ namespace Editor {
 
 		if (EditorScene::s_selectedEntity) {
 			static ImGuizmo::OPERATION currentOperation = ImGuizmo::TRANSLATE;
-			if (ImGui::IsKeyPressed(ImGuiKey_Q)) currentOperation = ImGuizmo::TRANSLATE;
-			if (ImGui::IsKeyPressed(ImGuiKey_W)) currentOperation = ImGuizmo::ROTATE;
-			if (ImGui::IsKeyPressed(ImGuiKey_E)) currentOperation = ImGuizmo::SCALE;
+			if (ImGui::IsKeyPressed(ImGuiKey_W)) currentOperation = ImGuizmo::TRANSLATE;
+			if (ImGui::IsKeyPressed(ImGuiKey_E)) currentOperation = ImGuizmo::ROTATE;
+			if (ImGui::IsKeyPressed(ImGuiKey_R)) currentOperation = ImGuizmo::SCALE;
 
 			ImGuizmo::SetOrthographic(false);
 			ImGuizmo::SetDrawlist();

--- a/NANOEngine/src/Graphics/OpenGL/GLFrameBuffer.cpp
+++ b/NANOEngine/src/Graphics/OpenGL/GLFrameBuffer.cpp
@@ -1,6 +1,7 @@
 #include "GLFrameBuffer.hpp"
 #include <glad/glad.h>
 #include "../../src/Core/Logger.hpp"
+#include "ECS/Core/Entity.hpp"
 
 namespace NE::Graphics::OpenGL {
 
@@ -109,6 +110,9 @@ namespace NE::Graphics::OpenGL {
         glReadPixels(x, y, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, data);
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         uint32_t id = data[0] | (data[1] << 8) | (data[2] << 16);
+
+        if (id > ECS::MAX_ENTITIES) return ECS::NO_ENTITY;
+
         return id;
 	}
 

--- a/binfiles/imgui.ini
+++ b/binfiles/imgui.ini
@@ -9,31 +9,31 @@ Size=400,400
 Collapsed=0
 
 [Window][Scene]
-Pos=8,64
-Size=1029,623
+Pos=8,24
+Size=1029,638
 Collapsed=0
 DockId=0x00000005,0
 
 [Window][Game]
-Pos=8,64
-Size=1029,623
+Pos=8,24
+Size=1029,638
 Collapsed=0
 DockId=0x00000005,1
 
 [Window][Hierarchy]
-Pos=1039,64
-Size=518,623
+Pos=1039,24
+Size=518,558
 Collapsed=0
-DockId=0x00000006,0
+DockId=0x00000007,0
 
 [Window][Inspector]
-Pos=1559,64
-Size=353,1008
+Pos=1559,24
+Size=353,1023
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Asset Browser]
-Pos=8,689
+Pos=8,664
 Size=1549,383
 Collapsed=0
 DockId=0x00000002,0
@@ -47,22 +47,22 @@ Collapsed=0
 Pos=1039,53
 Size=518,643
 Collapsed=0
-DockId=0x00000006,2
+DockId=0x00000007,2
 
 [Window][Profiler]
-Pos=1039,64
-Size=518,623
+Pos=1039,24
+Size=518,558
 Collapsed=0
-DockId=0x00000006,1
+DockId=0x00000007,1
 
 [Window][Logger]
-Pos=8,689
+Pos=8,664
 Size=1549,383
 Collapsed=0
 DockId=0x00000002,1
 
 [Window][PlayControls]
-Pos=422,116
+Pos=422,76
 Size=200,40
 Collapsed=0
 
@@ -84,12 +84,20 @@ Size=1549,383
 Collapsed=0
 DockId=0x00000002,4
 
+[Window][Scripts]
+Pos=1039,584
+Size=518,78
+Collapsed=0
+DockId=0x00000008,0
+
 [Docking][Data]
-DockSpace       ID=0x26646FDE Window=0x5F084CD7 Pos=262,214 Size=1904,1008 Split=X
-  DockNode      ID=0x00000003 Parent=0x26646FDE SizeRef=1549,1019 Split=Y
-    DockNode    ID=0x00000001 Parent=0x00000003 SizeRef=1904,623 Split=X
-      DockNode  ID=0x00000005 Parent=0x00000001 SizeRef=1029,761 CentralNode=1 Selected=0xE601B12F
-      DockNode  ID=0x00000006 Parent=0x00000001 SizeRef=518,761 Selected=0xBABDAE5E
-    DockNode    ID=0x00000002 Parent=0x00000003 SizeRef=1904,383 Selected=0x51E9BDF7
-  DockNode      ID=0x00000004 Parent=0x26646FDE SizeRef=353,1019 Selected=0x36DC96AB
+DockSpace         ID=0x26646FDE Window=0x5F084CD7 Pos=251,150 Size=1904,1023 Split=X
+  DockNode        ID=0x00000003 Parent=0x26646FDE SizeRef=1549,1019 Split=Y
+    DockNode      ID=0x00000001 Parent=0x00000003 SizeRef=1904,623 Split=X
+      DockNode    ID=0x00000005 Parent=0x00000001 SizeRef=1029,761 CentralNode=1 Selected=0xE601B12F
+      DockNode    ID=0x00000006 Parent=0x00000001 SizeRef=518,761 Split=Y Selected=0xBABDAE5E
+        DockNode  ID=0x00000007 Parent=0x00000006 SizeRef=518,558 Selected=0xBABDAE5E
+        DockNode  ID=0x00000008 Parent=0x00000006 SizeRef=518,78 Selected=0xE5FA3EBB
+    DockNode      ID=0x00000002 Parent=0x00000003 SizeRef=1904,383 Selected=0x9DD4E196
+  DockNode        ID=0x00000004 Parent=0x26646FDE SizeRef=353,1019 Selected=0x36DC96AB
 


### PR DESCRIPTION
Implemented drag-and-drop support for assigning materials and models to entities in the ScenePanel. Updated key bindings for ImGuizmo operations (W/E/R for translate/rotate/scale). Added entity ID bounds check in GLFrameBuffer::ReadPixel. Minor comments and variable renaming for clarity.