### PR TITLE
Refactor copy, paste, and duplicate logic to EditorScene

### DIFF
--- a/Editor/src/EditorLayer.cpp
+++ b/Editor/src/EditorLayer.cpp
@@ -52,12 +52,26 @@ namespace Editor {
 
 		// === SHORTCUTS (Must be at window level to work) ===
 		// Save shortcut (Ctrl+S) - Check globally, not just when window focused
-		if (ImGui::IsKeyPressed(ImGuiKey_S, false) && (ImGui::GetIO().KeyCtrl && !ImGui::GetIO().KeyShift && !ImGui::GetIO().KeyAlt)) {
-			if (NE::IsSceneDirty()) {
-				SPD_INFO("[DirtyFlag] Ctrl+S pressed - Saving scene");
-				NE::SaveCurrentScene(EditorScene::currentScenePath);
-			} else {
-				SPD_DEBUG("[DirtyFlag] Ctrl+S pressed - No changes to save");
+		if ((ImGui::GetIO().KeyCtrl && !ImGui::GetIO().KeyShift && !ImGui::GetIO().KeyAlt)) {
+			if (ImGui::IsKeyPressed(ImGuiKey_S, false)) {
+				if (NE::IsSceneDirty()) {
+					SPD_INFO("[DirtyFlag] Ctrl+S pressed - Saving scene");
+					NE::SaveCurrentScene(EditorScene::currentScenePath);
+				} else {
+					SPD_DEBUG("[DirtyFlag] Ctrl+S pressed - No changes to save");
+				}
+			}
+
+			if (!ImGui::IsAnyItemActive() &&
+				!ImGui::IsAnyItemFocused()) {
+				bool canEditHierarchy = EditorScene::selectedPrefab.empty();
+				if (canEditHierarchy && ImGui::IsKeyPressed(ImGuiKey_D, false)) {
+					EditorScene::DuplicateSelected();
+				} else if (ImGui::IsKeyPressed(ImGuiKey_C, false)) {
+					EditorScene::CopySelected();
+				} else if (canEditHierarchy && ImGui::IsKeyPressed(ImGuiKey_V, false)) {
+					EditorScene::PasteSelected();
+				}
 			}
 		}
 

--- a/Editor/src/EditorScene.cpp
+++ b/Editor/src/EditorScene.cpp
@@ -4,6 +4,7 @@
 #include <EditorInterface/ECSExports.hpp>
 #include <Engine.hpp>
 #include <ECS/Components/EntityMeta.hpp>
+#include <unordered_set>
 
 namespace {
     void RemoveFromVec(std::vector<uint32_t>& v, uint32_t id) {
@@ -19,7 +20,7 @@ namespace Editor {
 
     std::string EditorScene::selectedAsset;
     std::string EditorScene::selectedPrefab;
-
+    std::vector<uint8_t> EditorScene::clipboard;
     std::string EditorScene::currentScenePath("Assets/NewScene.scene");
 
     std::unordered_map<uint32_t, Node> EditorScene::s_nodes;
@@ -198,5 +199,78 @@ namespace Editor {
                 }
             }
         }
+    }
+
+    void EditorScene::DuplicateSelected() {
+        if (!s_selectedEntity) return;
+
+        std::vector<uint32_t> newEntities = NE::DuplicateEntity(EditorScene::s_selectedEntity->linkedEntity);
+
+        if (newEntities.empty()) return;
+
+        std::unordered_set<uint32_t> newSet(newEntities.begin(), newEntities.end());
+
+        for (uint32_t entt : newEntities) {
+            EditorScene::s_entities.push_back(Editor::EditorEntity{ entt });
+
+            Node node{};
+            node.id = entt;
+
+            uint32_t parent = NE::ECS::Command::GetParent(entt);
+            node.parent = parent;
+
+            if (parent == NE::ECS::NO_ENTITY) {
+                node.orderKey = static_cast<float>(Editor::EditorScene::s_roots.size());
+                EditorScene::s_roots.push_back(entt);
+            } else {
+                auto& childrenVec = Editor::EditorScene::s_children[parent];
+                node.orderKey = static_cast<float>(childrenVec.size());
+                childrenVec.push_back(entt);
+            }
+
+            EditorScene::s_nodes[entt] = node;
+        }
+
+        EditorScene::s_selectedEntity = nullptr;
+    }
+
+    void EditorScene::CopySelected() {
+        if (!s_selectedEntity) return;
+
+        clipboard = NE::CopyEntity(EditorScene::s_selectedEntity->linkedEntity);
+    }
+
+    void EditorScene::PasteSelected() {
+        if (clipboard.empty()) return;
+
+        NE::Math::Vec3 camForwardPos = EditorScene::m_editorCamera.GetPosition() + EditorScene::m_editorCamera.GetForward() * 6.0f;
+        std::vector<uint32_t> newEntities = NE::PasteEntity(clipboard, camForwardPos);
+
+        if (newEntities.empty()) return;
+
+        std::unordered_set<uint32_t> newSet(newEntities.begin(), newEntities.end());
+
+        for (uint32_t entt : newEntities) {
+            EditorScene::s_entities.push_back(Editor::EditorEntity{ entt });
+
+            Node node{};
+            node.id = entt;
+
+            uint32_t parent = NE::ECS::Command::GetParent(entt);
+            node.parent = parent;
+
+            if (parent == NE::ECS::NO_ENTITY) {
+                node.orderKey = static_cast<float>(Editor::EditorScene::s_roots.size());
+                EditorScene::s_roots.push_back(entt);
+            } else {
+                auto& childrenVec = Editor::EditorScene::s_children[parent];
+                node.orderKey = static_cast<float>(childrenVec.size());
+                childrenVec.push_back(entt);
+            }
+
+            EditorScene::s_nodes[entt] = node;
+        }
+
+        EditorScene::s_selectedEntity = nullptr;
     }
 }

--- a/Editor/src/EditorScene.hpp
+++ b/Editor/src/EditorScene.hpp
@@ -25,6 +25,8 @@ namespace Editor {
 
         static NE::Graphics::EditorCamera m_editorCamera;
 
+        static std::vector<uint8_t> clipboard;
+
         // NEW: hierarchy index
         static std::unordered_map<uint32_t, Node> s_nodes;                // id -> node
         static std::unordered_map<uint32_t, std::vector<uint32_t>> s_children; // parent -> children ids
@@ -39,6 +41,11 @@ namespace Editor {
         // Helpers
         static void RebuildFromActiveScene();
         static const std::vector<uint32_t>& ChildrenOf(uint32_t parent);
+
+
+        static void DuplicateSelected();
+        static void CopySelected();
+        static void PasteSelected();
     };
 
 }

--- a/Editor/src/Panels/HierarchyPanel.cpp
+++ b/Editor/src/Panels/HierarchyPanel.cpp
@@ -11,7 +11,6 @@
 #include <EditorInterface/ECSExports.hpp>
 #include <ECS/Components/EntityMeta.hpp>
 #include "../AssetManagement/AssetManager.hpp"
-#include <unordered_set>
 #include <Math/Vec3.hpp>
 
 namespace Editor {
@@ -28,34 +27,26 @@ namespace Editor {
 	void HierarchyPanel::OnImGuiRender() {
 		ImGui::Begin("Hierarchy", nullptr, ImGuiWindowFlags_MenuBar);
 
-		bool canEditHierarchy = EditorScene::s_selectedEntity && EditorScene::selectedPrefab.empty();
-		if (ImGui::GetIO().KeyCtrl && !ImGui::GetIO().KeyShift && !ImGui::GetIO().KeyAlt) {
-			if (canEditHierarchy && ImGui::IsKeyPressed(ImGuiKey_D, false)) {
-				DuplicateSelected();
-			} else if (ImGui::IsKeyPressed(ImGuiKey_C, false)) {
-				CopySelected();
-			} else if (EditorScene::selectedPrefab.empty() && ImGui::IsKeyPressed(ImGuiKey_V, false)) {
-				PasteSelected();
+		bool canEditHierarchy = EditorScene::selectedPrefab.empty();
+		if (ImGui::IsWindowHovered()) {
+			if (ImGui::IsMouseReleased(ImGuiMouseButton_Right)) {
+				ImGui::OpenPopup("HierarchyContextMenu");
 			}
-		}
-
-		if (ImGui::IsWindowHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Right)) {
-			ImGui::OpenPopup("HierarchyContextMenu");
 		}
 
 		if (ImGui::BeginPopupContextWindow("HierarchyContextMenu")) {
 			if (ImGui::MenuItem("Cut", "Ctrl+X", false, false)) {
 			}
 			if (ImGui::MenuItem("Copy", "Ctrl+C", false, canEditHierarchy)) {
-				CopySelected();
+				EditorScene::CopySelected();
 			}
-			if (ImGui::MenuItem("Paste", "Ctrl+V", false, canEditHierarchy && !clipboard.empty())) {
-				PasteSelected();
+			if (ImGui::MenuItem("Paste", "Ctrl+V", false, canEditHierarchy)) {
+				EditorScene::PasteSelected();
 			}
 			if (ImGui::MenuItem("Rename", "", false, false)) {
 			}
 			if (ImGui::MenuItem("Duplicate", "Ctrl+D", false, canEditHierarchy)) {
-				DuplicateSelected();
+				EditorScene::DuplicateSelected();
 			}
 			if (ImGui::MenuItem("Delete", "Del", false, canEditHierarchy)) {
 				NANOEngine::Events::EventBus::Get().Dispatch(NANOEngine::Events::EventDomain::Editor, DeleteEntityEvent{ EditorScene::s_selectedEntity->linkedEntity });
@@ -384,73 +375,6 @@ namespace Editor {
 		}
 
 		ImGui::End();
-	}
-
-	void HierarchyPanel::DuplicateSelected() {
-		std::vector<uint32_t> newEntities = NE::DuplicateEntity(EditorScene::s_selectedEntity->linkedEntity);
-
-		if (newEntities.empty()) return;
-
-		std::unordered_set<uint32_t> newSet(newEntities.begin(), newEntities.end());
-
-		for (uint32_t entt : newEntities) {
-			EditorScene::s_entities.push_back(Editor::EditorEntity{ entt });
-
-			Node node{};
-			node.id = entt;
-
-			uint32_t parent = NE::ECS::Command::GetParent(entt);
-			node.parent = parent;
-
-			if (parent == NE::ECS::NO_ENTITY) {
-				node.orderKey = static_cast<float>(Editor::EditorScene::s_roots.size());
-				EditorScene::s_roots.push_back(entt);
-			} else {
-				auto& childrenVec = Editor::EditorScene::s_children[parent];
-				node.orderKey = static_cast<float>(childrenVec.size());
-				childrenVec.push_back(entt);
-			}
-
-			EditorScene::s_nodes[entt] = node;
-		}
-
-		EditorScene::s_selectedEntity = nullptr;
-	}
-
-	void HierarchyPanel::CopySelected() {
-		clipboard = NE::CopyEntity(EditorScene::s_selectedEntity->linkedEntity);
-	}
-
-	void HierarchyPanel::PasteSelected() {
-		NE::Math::Vec3 camForwardPos = EditorScene::m_editorCamera.GetPosition() + EditorScene::m_editorCamera.GetForward() * 6.0f;
-		std::vector<uint32_t> newEntities = NE::PasteEntity(clipboard, camForwardPos);
-
-		if (newEntities.empty()) return;
-
-		std::unordered_set<uint32_t> newSet(newEntities.begin(), newEntities.end());
-
-		for (uint32_t entt : newEntities) {
-			EditorScene::s_entities.push_back(Editor::EditorEntity{ entt });
-
-			Node node{};
-			node.id = entt;
-
-			uint32_t parent = NE::ECS::Command::GetParent(entt);
-			node.parent = parent;
-
-			if (parent == NE::ECS::NO_ENTITY) {
-				node.orderKey = static_cast<float>(Editor::EditorScene::s_roots.size());
-				EditorScene::s_roots.push_back(entt);
-			} else {
-				auto& childrenVec = Editor::EditorScene::s_children[parent];
-				node.orderKey = static_cast<float>(childrenVec.size());
-				childrenVec.push_back(entt);
-			}
-
-			EditorScene::s_nodes[entt] = node;
-		}
-
-		EditorScene::s_selectedEntity = nullptr;
 	}
 
 }

--- a/Editor/src/Panels/HierarchyPanel.hpp
+++ b/Editor/src/Panels/HierarchyPanel.hpp
@@ -10,14 +10,5 @@ namespace Editor {
 		HierarchyPanel();
 
 		virtual void OnImGuiRender() override;
-
-
-	private:
-		void DuplicateSelected();
-		void CopySelected();
-		void PasteSelected();
-
-		// here for now
-		std::vector<uint8_t> clipboard;
 	};
 }


### PR DESCRIPTION
Moved the implementation of DuplicateSelected, CopySelected, and PasteSelected from HierarchyPanel to EditorScene for better separation of concerns and reusability. Updated shortcut handling in EditorLayer and context menu actions in HierarchyPanel to use the new EditorScene methods. Removed redundant clipboard and helper methods from HierarchyPanel.