### PR TITLE
Add undo/redo shortcuts and update entity paste logic

### DIFF
--- a/Editor/src/EditorLayer.cpp
+++ b/Editor/src/EditorLayer.cpp
@@ -60,6 +60,10 @@ namespace Editor {
 				} else {
 					SPD_DEBUG("[DirtyFlag] Ctrl+S pressed - No changes to save");
 				}
+			} else if (ImGui::IsKeyPressed(ImGuiKey_Z, false)) {
+				CommandHistory::GetInstance().Undo();
+			} else if (ImGui::IsKeyPressed(ImGuiKey_Y, false)) {
+				CommandHistory::GetInstance().Redo();
 			}
 
 			if (!ImGui::IsAnyItemActive() &&

--- a/Editor/src/EditorScene.cpp
+++ b/Editor/src/EditorScene.cpp
@@ -243,8 +243,7 @@ namespace Editor {
     void EditorScene::PasteSelected() {
         if (clipboard.empty()) return;
 
-        NE::Math::Vec3 camForwardPos = EditorScene::m_editorCamera.GetPosition() + EditorScene::m_editorCamera.GetForward() * 6.0f;
-        std::vector<uint32_t> newEntities = NE::PasteEntity(clipboard, camForwardPos);
+        std::vector<uint32_t> newEntities = NE::PasteEntity(clipboard);
 
         if (newEntities.empty()) return;
 

--- a/Editor/src/Panels/HierarchyPanel.cpp
+++ b/Editor/src/Panels/HierarchyPanel.cpp
@@ -31,6 +31,8 @@ namespace Editor {
 		if (ImGui::IsWindowHovered()) {
 			if (ImGui::IsMouseReleased(ImGuiMouseButton_Right)) {
 				ImGui::OpenPopup("HierarchyContextMenu");
+			} else if (ImGui::IsKeyPressed(ImGuiKey_Delete, false) && EditorScene::s_selectedEntity != nullptr && canEditHierarchy) {
+				NANOEngine::Events::EventBus::Get().Dispatch(NANOEngine::Events::EventDomain::Editor, DeleteEntityEvent{ EditorScene::s_selectedEntity->linkedEntity });
 			}
 		}
 

--- a/NANOEngine/src/Engine.cpp
+++ b/NANOEngine/src/Engine.cpp
@@ -290,16 +290,16 @@ namespace NE {
 		return buffer;
 	}
 
-	std::vector<uint32_t> PasteEntity(std::vector<uint8_t> clipboard, Math::Vec3 pos) {
+	std::vector<uint32_t> PasteEntity(std::vector<uint8_t> clipboard) {
 		auto newEntities =
 			NE::Serialization::JsonSceneSerializer::DeserializePrefabFromMemory(*gSceneManager.GetActive(), clipboard);
 
-		auto& transform = gSceneManager.
-			GetActive()->GetECSCoordinator().
-			GetComponent<ECS::Component::Transform>(newEntities[0]);
+		//auto& transform = gSceneManager.
+		//	GetActive()->GetECSCoordinator().
+		//	GetComponent<ECS::Component::Transform>(newEntities[0]);
 
-		transform.localPosition = pos;
-		transform.isDirty = true;
+		//transform.localPosition = pos;
+		//transform.isDirty = true;
 
 		return newEntities;
 	}

--- a/NANOEngine/src/Engine.hpp
+++ b/NANOEngine/src/Engine.hpp
@@ -49,7 +49,7 @@ namespace NE {
 
 	NANOENGINE_API std::vector<uint32_t> DuplicateEntity(uint32_t entity);
 	NANOENGINE_API std::vector<uint8_t> CopyEntity(uint32_t entity);
-	NANOENGINE_API std::vector<uint32_t> PasteEntity(std::vector<uint8_t> clipboard, Math::Vec3 pos);
+	NANOENGINE_API std::vector<uint32_t> PasteEntity(std::vector<uint8_t> clipboard);
 
 	//NANOENGINE_API const std::vector<std::pair<std::string, std::shared_ptr<Asset::AudioBank>>>& GetAllAudioBanks();
 


### PR DESCRIPTION
Added Ctrl+Z and Ctrl+Y keyboard shortcuts for undo and redo actions in the editor. Enabled entity deletion via the Delete key in the hierarchy panel. Refactored PasteEntity to remove position parameter and updated related calls accordingly.