### PR TITLE
Add GetWorldPosition to ScriptAPI and update PlayerCamera

### DIFF
--- a/ChronoGame/Scripts/PlayerCamera.hpp
+++ b/ChronoGame/Scripts/PlayerCamera.hpp
@@ -9,7 +9,6 @@ public:
     }
 
     void Initialize(Entity entity) override {
-        thisEntity = entity;
     }
 
     void Update(double deltaTime) override {
@@ -42,13 +41,13 @@ public:
         SetRotation(m_pitch, m_yaw, 0.0f);
         
         if (Input::WasMousePressed(0)) {
-            auto forward = GetForward(thisEntity);
-            auto hit = Raycast(GetPosition(thisEntity), forward, 5.f);
-            LOG_DEBUG("Position: " << GetPosition(thisEntity).x << " : " << GetPosition(thisEntity).y << " : " << GetPosition(thisEntity).z);
+            auto forward = GetForward();
+            auto hit = Raycast(GetWorldPosition(), forward, 5.f);
+            LOG_DEBUG("Position: " << GetPosition().x << " : " << GetPosition().y << " : " << GetPosition().z);
             LOG_DEBUG("Forward: " << forward.x << " : " << forward.y << " : " << forward.z);
             
             LOG_DEBUG("Entity Hit: " << hit.entity);
-            std::pair<uint32_t, uint32_t> data = { hit.entity, thisEntity };
+            std::pair<uint32_t, uint32_t> data = { hit.entity, GetEntity() };
 
             if (hit.entity != NE::Scripting::INVALID_ENTITY) {
                 Events::Send("OnCameraRaycastHit", &data);
@@ -71,8 +70,6 @@ public:
     void OnTriggerExit(Entity other) override {}
 
 private:
-    Entity thisEntity;
-
     bool isActive = true;
 
     bool switched = false;

--- a/NANOEngine/include/ScriptSDK/ScriptAPI.h
+++ b/NANOEngine/include/ScriptSDK/ScriptAPI.h
@@ -202,6 +202,7 @@ namespace Scripting {
 
         // Position
         Vec3 GetPosition(Entity entity = DEFAULT_ENTITY_PARAM) const;
+        Vec3 GetWorldPosition(Entity entity = DEFAULT_ENTITY_PARAM) const;
         void SetPosition(const Vec3& pos, Entity entity = DEFAULT_ENTITY_PARAM);
         void SetPosition(float x, float y, float z, Entity entity = DEFAULT_ENTITY_PARAM);
 

--- a/NANOEngine/src/Scripting/ScriptAPI.cpp
+++ b/NANOEngine/src/Scripting/ScriptAPI.cpp
@@ -189,6 +189,20 @@ namespace Scripting {
         return ToSDKVec3(transform.localPosition);
     }
 
+    Vec3 IScript::GetWorldPosition(Entity entity) const {
+        CHECK_CONTEXT_OR_RETURN(Vec3::Zero());
+
+        Entity targetEntity = (entity == DEFAULT_ENTITY_PARAM) ? m_entity : entity;
+
+        if (!m_context->componentManager->HasComponent<ECS::Component::Transform>(targetEntity))
+            return Vec3::Zero();
+
+        auto& transform = m_context->componentManager->GetComponent<ECS::Component::Transform>(targetEntity);
+        Math::Mat4 m = transform.worldMatrix;
+        Math::Vec3 worldPos = m.GetTranslation();
+        return ToSDKVec3(worldPos);
+    }
+
     void IScript::SetPosition(const Vec3& pos, Entity entity) {
         CHECK_CONTEXT_OR_RETURN();
 


### PR DESCRIPTION
Introduces a new GetWorldPosition method to IScript in ScriptAPI for retrieving an entity's world position. Refactors PlayerCamera to use GetWorldPosition and related methods, removing the use of a stored entity reference and improving code clarity.