### PR TITLE
Refactor context menu logic in HierarchyPanel

### DIFF
--- a/Editor/src/Panels/HierarchyPanel.cpp
+++ b/Editor/src/Panels/HierarchyPanel.cpp
@@ -339,6 +339,8 @@ namespace Editor {
 	void HierarchyPanel::DrawHierarchyContextMenuBody(bool canEditHierarchy, uint32_t contextEntityId) {
 		// contextEntityId == NE::ECS::NO_ENTITY = clicked on empty
 		//const bool hasEntity = (contextEntityId != NE::ECS::NO_ENTITY);
+		if (!EditorScene::s_selectedEntity) return;
+
 		const bool hasEntity = (EditorScene::s_selectedEntity != nullptr);
 
 		if (ImGui::MenuItem("Cut", "Ctrl+X", false, hasEntity && canEditHierarchy)) {


### PR DESCRIPTION
Moved UI canvas entity creation options from the entity context menu popup to the main hierarchy context menu. Commented out the per-entity context menu code and updated logic to use the selected entity for context menu actions.