### PR TITLE
Refactor parent query and improve hierarchy filtering

### DIFF
--- a/Editor/src/EditorScene.cpp
+++ b/Editor/src/EditorScene.cpp
@@ -5,7 +5,6 @@
 #include "../src/ECS/Components/UIRectTransform.hpp"
 #include <Engine.hpp>
 #include <ECS/Components/EntityMeta.hpp>
-#include <unordered_set>
 
 namespace {
     // helper function: remove an entity ID from a vector if it exist
@@ -28,6 +27,7 @@ namespace Editor {
     std::unordered_map<uint32_t, Node> EditorScene::s_nodes;
     std::unordered_map<uint32_t, std::vector<uint32_t>> EditorScene::s_children;
     std::vector<uint32_t> EditorScene::s_roots;
+    std::unordered_set<uint32_t> EditorScene::s_forceOpen;
 
     NE::Graphics::EditorCamera EditorScene::m_editorCamera;
 
@@ -177,7 +177,7 @@ namespace Editor {
         for (const auto& e : s_entities) {
             uint32_t id = e.linkedEntity;
 
-            uint32_t parent = NE::ECS::Command::GetParent(id);
+            uint32_t parent = NE::ECS::Query::GetParent(id);
 
             Node node;
             node.id = id;
@@ -227,7 +227,7 @@ namespace Editor {
             Node node{};
             node.id = entt;
 
-            uint32_t parent = NE::ECS::Command::GetParent(entt);
+            uint32_t parent = NE::ECS::Query::GetParent(entt);
             node.parent = parent;
 
             if (parent == NE::ECS::NO_ENTITY) {
@@ -266,7 +266,7 @@ namespace Editor {
             Node node{};
             node.id = entt;
 
-            uint32_t parent = NE::ECS::Command::GetParent(entt);
+            uint32_t parent = NE::ECS::Query::GetParent(entt);
             node.parent = parent;
 
             if (parent == NE::ECS::NO_ENTITY) {
@@ -282,5 +282,17 @@ namespace Editor {
         }
 
         EditorScene::s_selectedEntity = nullptr;
+    }
+
+    void EditorScene::ForceOpenParents(uint32_t child)
+    {
+        uint32_t cur = child;
+        while (true) {
+            uint32_t parent = NE::ECS::Query::GetParent(cur);
+            if (parent == NE::ECS::NO_ENTITY) break;
+
+            s_forceOpen.insert(parent);
+            cur = parent;
+        }
     }
 }

--- a/Editor/src/EditorScene.hpp
+++ b/Editor/src/EditorScene.hpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include "EditorEntity.hpp"
 #include "Graphics/Core/EditorCamera.hpp"
 
@@ -31,6 +32,7 @@ namespace Editor {
         static std::unordered_map<uint32_t, Node> s_nodes;                // id -> node
         static std::unordered_map<uint32_t, std::vector<uint32_t>> s_children; // parent -> children ids
         static std::vector<uint32_t> s_roots;
+        static std::unordered_set<uint32_t> s_forceOpen;
 
         static bool ReorderWithinSiblings(uint32_t parent, uint32_t child, int insertIndex);
         static bool AttachAsChild(uint32_t newParent, uint32_t child, int insertIndex);
@@ -46,6 +48,7 @@ namespace Editor {
         static void DuplicateSelected();
         static void CopySelected();
         static void PasteSelected();
+        static void ForceOpenParents(uint32_t child);
     };
 
 }

--- a/Editor/src/Panels/AssetBrowserPanel.cpp
+++ b/Editor/src/Panels/AssetBrowserPanel.cpp
@@ -69,12 +69,12 @@ namespace Editor {
                 if (p->DataSize == sizeof(uint32_t)) {
                     uint32_t dropped = *static_cast<const uint32_t*>(p->Data);
                     
-                    std::string prefabName = "Prefab";
                     auto& meta = NE::ECS::Command::GetEntityMeta(dropped);
-                    if (!meta.name.empty())
-                        prefabName = meta.name;
+                    std::string prefabName = meta.name;
+                    if (meta.name.empty())
+                        prefabName = "Prefab";
 
-                    std::string filePath = m_currentDirectory.string() + prefabName + ".nfab";
+                    std::string filePath = m_currentDirectory.string() + "/" + prefabName + ".nfab";
                     SPD_INFO("Prefab created at: " << filePath);
                     std::ofstream create(filePath, std::ios::binary | std::ios::trunc);
                     AssetManager::GetInstance().GenerateMetadata(filePath);

--- a/Editor/src/Panels/HierarchyPanel.cpp
+++ b/Editor/src/Panels/HierarchyPanel.cpp
@@ -9,15 +9,52 @@
 #include <ECS/Core/Entity.hpp>
 #include <Engine.hpp>
 #include <imgui/imgui_internal.h>
-#include <EditorInterface/ECSExports.hpp>
+#include <algorithm>
 #include <ECS/Components/EntityMeta.hpp>
 #include "../AssetManagement/AssetManager.hpp"
 #include <Math/Vec3.hpp>
 
+namespace {
+	// Lowercase helper
+	std::string ToLower(std::string s)
+	{
+		std::transform(s.begin(), s.end(), s.begin(),
+			[](unsigned char c) { return (char)std::tolower(c); });
+		return s;
+	}
+
+	bool MarkVisibleRecursive(
+		uint32_t id,
+		const std::string& queryLower,
+		std::unordered_set<uint32_t>& outVisible)
+	{
+		using namespace Editor;
+
+		const auto& meta = NE::ECS::Query::GetEntityMeta(id);
+		std::string nameLower = ToLower(meta.name);
+
+		bool selfMatch = queryLower.empty()
+			? true
+			: (nameLower.find(queryLower) != std::string::npos);
+
+		const auto& kids = Editor::EditorScene::ChildrenOf(id);
+		bool anyChildMatch = false;
+		for (uint32_t child : kids) {
+			if (MarkVisibleRecursive(child, queryLower, outVisible))
+				anyChildMatch = true;
+		}
+
+		if (selfMatch || anyChildMatch) {
+			outVisible.insert(id);
+			return true;
+		}
+		return false;
+	}
+}
+
+
 namespace Editor {
 	HierarchyPanel::HierarchyPanel() {
-		//EditorScene::s_entities.reserve(NE::ECS::MAX_ENTITIES);
-
 		auto numEntt = NE::GetNumEntities();
 		EditorScene::s_entities.reserve(numEntt.size());
 		for (auto e : numEntt) {
@@ -27,6 +64,27 @@ namespace Editor {
 
 	void HierarchyPanel::OnImGuiRender() {
 		ImGui::Begin("Hierarchy", nullptr, ImGuiWindowFlags_MenuBar);
+
+		static bool filtering = false;
+		std::unordered_set<uint32_t> visible;
+		if (ImGui::BeginMenuBar()) {
+			static char s_searchBuf[128] = "";
+			ImGui::SetNextItemWidth(-1.0f);
+			ImGui::InputTextWithHint("##HierarchySearch", "Search...", s_searchBuf, IM_ARRAYSIZE(s_searchBuf));
+
+			std::string search = s_searchBuf;
+			std::string searchLower = ToLower(search);
+			filtering = !searchLower.empty();
+
+			// Build visible set when filtering
+			auto& childrenOf0 = Editor::EditorScene::ChildrenOf(NE::ECS::NO_ENTITY);
+			if (filtering) {
+				for (uint32_t root : childrenOf0)
+					MarkVisibleRecursive(root, searchLower, visible);
+			}
+
+			ImGui::EndMenuBar();
+		}
 
 		bool canEditHierarchy = EditorScene::selectedPrefab.empty();
 
@@ -78,13 +136,6 @@ namespace Editor {
 			Editor::EditorScene::BuildHierarchyFromECS();
 			s_built = true;
 		}
-		//static int s_lastEntityCount = -1;
-		//int currentCount = static_cast<int>(NE::GetNumEntities().size());
-
-		//if (currentCount != s_lastEntityCount) {
-		//	Editor::EditorScene::RebuildFromActiveScene();
-		//	s_lastEntityCount = currentCount;
-		//}
 
 		// ---- Drag state ----
 		static uint32_t draggingId = NE::ECS::NO_ENTITY;
@@ -106,10 +157,13 @@ namespace Editor {
 
 		ImDrawList* dl = ImGui::GetWindowDrawList();
 
-		std::function<void(uint32_t /*parent*/, const std::vector<uint32_t>& /*siblings*/, int /*depth*/)> DrawLevel;
+		std::function<void(uint32_t , const std::vector<uint32_t>& , int )> DrawLevel;
 		DrawLevel = [&](uint32_t parent, const std::vector<uint32_t>& siblings, int depth) {
 			for (int i = 0; i < (int)siblings.size(); ++i) {
 				uint32_t id = siblings[i];
+
+				if (filtering && visible.find(id) == visible.end())
+					continue;
 
 				// -------- label & selection ----------
 				Editor::EditorEntity* ent = nullptr;
@@ -161,36 +215,14 @@ namespace Editor {
 				if (useCustomColor)
 					ImGui::PushStyleColor(ImGuiCol_Text, finalColor);
 
-				// -------------------------------------------------------------------
+				if (EditorScene::s_forceOpen.contains(id) || filtering) {
+					ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+				}
+
 				bool open = ImGui::TreeNodeEx((void*)(uintptr_t)id, flags, "%s", label.c_str());
-
-				//if (ImGui::BeginPopupContextItem("EntityContextMenu")) {
-				//	DrawHierarchyContextMenuBody(canEditHierarchy, id);
-
-				//	bool isCanvas = NE::ECS::Query::HasUICanvas(id);
-				//	if (isCanvas) {
-				//		ImGui::Separator();
-				//		if (ImGui::MenuItem("Image")) {
-				//			NANOEngine::Events::EventBus::Get().Dispatch(
-				//				NANOEngine::Events::EventDomain::Editor,
-				//				CreateUIImageEntityEvent{ id }
-				//			);
-				//		}
-				//		if (ImGui::MenuItem("Text")) {
-				//		}
-				//		if (ImGui::MenuItem("Button")) {
-				//		}
-				//	}
-
-				//	ImGui::EndPopup();
-				//}
-
 
 				if (useCustomColor)
 					ImGui::PopStyleColor();
-
-				// Optional: auto-open non-leaf by default
-				// if (!isLeaf) ImGui::SetNextItemOpen(true, ImGuiCond_Once);
 
 				// Delay selection logic - only select if not starting a drag
 				if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen()) {
@@ -333,13 +365,13 @@ namespace Editor {
 			clickedThisFrame = false;
 		}
 
+		EditorScene::s_forceOpen.clear();
 		ImGui::End();
 	}
 
 	void HierarchyPanel::DrawHierarchyContextMenuBody(bool canEditHierarchy, uint32_t contextEntityId) {
 		// contextEntityId == NE::ECS::NO_ENTITY = clicked on empty
 		//const bool hasEntity = (contextEntityId != NE::ECS::NO_ENTITY);
-		
 
 		const bool hasEntity = (EditorScene::s_selectedEntity != nullptr);
 

--- a/Editor/src/Panels/ScenePanel.cpp
+++ b/Editor/src/Panels/ScenePanel.cpp
@@ -236,7 +236,7 @@ namespace Editor {
 					Editor::Node node{};
 					node.id = entt;
 
-					uint32_t parent = NE::ECS::Command::GetParent(entt);
+					uint32_t parent = NE::ECS::Query::GetParent(entt);
 					node.parent = parent;
 
 					if (parent == NE::ECS::NO_ENTITY) {
@@ -253,7 +253,7 @@ namespace Editor {
 
 				uint32_t prefabRoot = NE::ECS::NO_ENTITY;
 				for (uint32_t entt : newEntities) {
-					uint32_t parent = NE::ECS::Command::GetParent(entt);
+					uint32_t parent = NE::ECS::Query::GetParent(entt);
 					if (parent == NE::ECS::NO_ENTITY || !newSet.count(parent)) {
 						prefabRoot = entt;
 						NE::ECS::Command::GetEntityMeta(entt).prefabID = AssetManager::GetInstance().RetrieveUUID(dropped);
@@ -475,6 +475,7 @@ namespace Editor {
 							for (auto& ent : EditorScene::s_entities) {
 								if (ent.linkedEntity == id) {
 									EditorScene::s_selectedEntity = &ent;
+									EditorScene::ForceOpenParents(ent.linkedEntity);
 									break;
 								}
 							}

--- a/NANOEngine/src/EditorInterface/ECSExports.cpp
+++ b/NANOEngine/src/EditorInterface/ECSExports.cpp
@@ -140,6 +140,20 @@ namespace NE::ECS {
 		const Component::Camera& GetEntityCamera(uint32_t e) {
 			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::Camera>(e);
 		}
+
+		uint32_t GetParent(uint32_t child) {
+			auto& ecs = NE::GetScene().GetECSCoordinator();
+
+			// Check for regular Transform first
+			if (ecs.HasComponent<NE::ECS::Component::Transform>(child)) {
+				return ecs.GetComponent<NE::ECS::Component::Transform>(child).parent;
+			}
+
+			// Check for UI RectTransform
+			if (ecs.HasComponent<NE::ECS::Component::UIRectTransform>(child)) {
+				return ecs.GetComponent<NE::ECS::Component::UIRectTransform>(child).parent;
+			}
+		}
 	}
 
 	namespace Command {
@@ -312,20 +326,6 @@ namespace NE::ECS {
 
 		void SetParent(uint32_t child, uint32_t parent, bool worldPositionStays) {
 			NE::GetScene().GetECSCoordinator().m_transformSystem->SetParent(child, parent);
-		}	
-
-		uint32_t GetParent(uint32_t child) {
-			auto& ecs = NE::GetScene().GetECSCoordinator();
-
-			// Check for regular Transform first
-			if (ecs.HasComponent<NE::ECS::Component::Transform>(child)) {
-				return ecs.GetComponent<NE::ECS::Component::Transform>(child).parent;
-			}
-
-			// Check for UI RectTransform
-			if (ecs.HasComponent<NE::ECS::Component::UIRectTransform>(child)) {
-				return ecs.GetComponent<NE::ECS::Component::UIRectTransform>(child).parent;
-			}
 		}
 
 		// === Script Management Implementation ===

--- a/NANOEngine/src/EditorInterface/ECSExports.hpp
+++ b/NANOEngine/src/EditorInterface/ECSExports.hpp
@@ -64,6 +64,7 @@ namespace NE::ECS {
 
 		NANOENGINE_API const Component::Animator& GetEntityAnimator(uint32_t e);
 		NANOENGINE_API const Component::Camera& GetEntityCamera(uint32_t e);
+		NANOENGINE_API uint32_t GetParent(uint32_t child);
 	}
 
 	namespace Command {
@@ -72,7 +73,6 @@ namespace NE::ECS {
 		NANOENGINE_API uint32_t CreateUIImageEntity(uint32_t parentCanvas);
 		NANOENGINE_API void DestroyEntity(uint32_t e);
 		NANOENGINE_API void SetParent(uint32_t child, uint32_t parent, bool worldPositionStays = true);
-		NANOENGINE_API uint32_t GetParent(uint32_t child);
 
 		NANOENGINE_API void AddLightComponent(uint32_t e);
 		NANOENGINE_API void AddRendererComponent(uint32_t e);

--- a/NANOEngine/src/Serialisation/JsonSceneSerializer.cpp
+++ b/NANOEngine/src/Serialisation/JsonSceneSerializer.cpp
@@ -551,22 +551,36 @@ namespace NE::Serialization {
 	{
 		auto& ecs = scene.GetECSCoordinator();
 
+		using Transform = NE::ECS::Component::Transform;
+
 		ForEachComponentType([&]<typename C>() {
-			// SKIP RULE: skip Transform on root entity (to preserve instance placement)
-			if constexpr (std::is_same_v<C, NE::ECS::Component::Transform>) {
-				if (entity == rootEntity)
+			if constexpr (std::is_same_v<C, Transform>) {
+				if (!ecs.HasComponent<Transform>(entity))
 					return;
+
+				auto& t = ecs.GetComponent<Transform>(entity);
+
+				auto oldPos = t.localPosition;
+				auto oldRot = t.localRotationEuler;
+
+				ReloadComponent<Transform>(ecs, entity, entVal);
+
+				if (entity == rootEntity) {
+					t.localPosition = oldPos;
+					t.localRotationEuler = oldRot;
+				}
+
+				return;
 			}
 
 			ReloadComponent<C>(ecs, entity, entVal);
 		});
 
-		// Optional: after reloading, mark Transform dirty
-		if (ecs.HasComponent<NE::ECS::Component::Transform>(entity)
-			&& entity != rootEntity) {
-			auto& t = ecs.GetComponent<NE::ECS::Component::Transform>(entity);
+		if (ecs.HasComponent<Transform>(entity)) {
+			auto& t = ecs.GetComponent<Transform>(entity);
 			t.isDirty = true;
 		}
+
 		if (ecs.HasComponent<NE::ECS::Component::Renderer>(entity)) {
 			auto& renderer = ecs.GetComponent<NE::ECS::Component::Renderer>(entity);
 
@@ -576,6 +590,7 @@ namespace NE::Serialization {
 				renderer.model = Resource::ResourceManager::GetInstance().LoadResource<Graphics::Model>(renderer.modelUUID);
 		}
 	}
+
 
 	void JsonSceneSerializer::SerializePrefabToMemory(SceneManagement::Scene& scene,
 		uint32_t rootEnt,


### PR DESCRIPTION
Moved GetParent from ECS::Command to ECS::Query for clearer separation of concerns and updated all usages accordingly. Added force-open logic and search filtering to the hierarchy panel, including recursive visibility marking and auto-expansion of parent nodes when selecting entities. Improved prefab asset creation path handling and fixed Transform component reloading to preserve root entity placement during deserialization.