### PR TITLE
Add LayerMask scripting support and editor integration

### DIFF
--- a/ChronoGame/Scripts/EngineAPI.hpp
+++ b/ChronoGame/Scripts/EngineAPI.hpp
@@ -153,6 +153,11 @@ using String = ScriptFieldType::String;
 #define SCRIPT_FIELD_STRUCT(fieldName) \
     RegisterStructField(#fieldName, &this->fieldName)
 
+// SCRIPT_FIELD_LAYERMASK macro - registers LayerMask fields with layer picker
+// Usage: SCRIPT_FIELD_LAYERMASK(collisionMask)
+#define SCRIPT_FIELD_LAYERMASK(fieldName) \
+    RegisterLayerMaskField(#fieldName, &this->fieldName)
+
 // ============ CONVENIENCE NAMESPACES (GLOBAL SCOPE) ============
 // Similar pattern to Input, Events, Coroutines namespaces in ScriptAPI.h
 
@@ -284,6 +289,7 @@ using Vec3 = NE::Scripting::Vec3;
 using Entity = NE::Scripting::Entity;
 using IScript = NE::Scripting::IScript;
 using RaycastHit = NE::Scripting::RaycastHit;
+using LayerMask = NE::Scripting::LayerMask;
 
 // Component reference types
 using TransformRef = NE::Scripting::TransformRef;

--- a/ChronoGame/Scripts/TestScript.hpp
+++ b/ChronoGame/Scripts/TestScript.hpp
@@ -28,15 +28,29 @@ public:
 		SCRIPT_FIELD(respawnDelay, Float);
 		SCRIPT_FIELD(enableAutoRespawn, Bool);
 
-		std::cout << "[TestScript] Created with fields registered" << std::endl;
+		// Register LayerMask field for testing
+		SCRIPT_FIELD_LAYERMASK(collisionLayers);
+
+		//std::cout << "[TestScript] Created with fields registered" << std::endl;
 	}
 
     void Initialize(Entity entity) override {
-		std::cout << "[TestScript] Initialized for entity " << entity << std::endl;
-		std::cout << "  Controls:" << std::endl;
-		std::cout << "  - Press 'R' to trigger respawn (deactivate then reactivate)" << std::endl;
-		std::cout << "  - Use Inspector 'isActive' checkbox to toggle entity on/off" << std::endl;
-		std::cout << "  - Use Inspector 'Enabled' checkbox to enable/disable this script" << std::endl;
+		//std::cout << "[TestScript] Initialized for entity " << entity << std::endl;
+		//std::cout << "  Controls:" << std::endl;
+		//std::cout << "  - Press 'R' to trigger respawn (deactivate then reactivate)" << std::endl;
+		//std::cout << "  - Use Inspector 'isActive' checkbox to toggle entity on/off" << std::endl;
+		//std::cout << "  - Use Inspector 'Enabled' checkbox to enable/disable this script" << std::endl;
+
+		//// Test LayerMask functionality
+		//std::cout << "[TestScript] LayerMask Test:" << std::endl;
+		//std::cout << "  Collision Layers Mask: " << collisionLayers.GetMask() << std::endl;
+		//std::cout << "  Contains Layer 0 (Default): " << (collisionLayers.Contains(0) ? "Yes" : "No") << std::endl;
+		//std::cout << "  Contains Layer 2 (Player): " << (collisionLayers.Contains(2) ? "Yes" : "No") << std::endl;
+
+		// Programmatically set some layers for testing
+		collisionLayers.Add(0);  // Add Default layer
+		collisionLayers.Add(2);  // Add Player layer
+		//std::cout << "  After adding layers 0 and 2, mask = " << collisionLayers.GetMask() << std::endl;
 	}
 
 	void Update(double deltaTime) override {
@@ -49,10 +63,10 @@ public:
 				// Respawn complete - reactivate entity
 				SetActive(GetEntity(), true);
 				m_isRespawning = false;
-				std::cout << "[TestScript] Entity '" << objectName << "' respawned!" << std::endl;
+			/*	std::cout << "[TestScript] Entity '" << objectName << "' respawned!" << std::endl;
 				std::cout << "  - Scripts: ENABLED" << std::endl;
 				std::cout << "  - Rendering: ENABLED" << std::endl;
-				std::cout << "  - Physics: ENABLED" << std::endl;
+				std::cout << "  - Physics: ENABLED" << std::endl;*/
 			}
 			return; // Don't do normal update logic while respawning
 		}
@@ -139,6 +153,9 @@ private:
 	std::string objectName = "TestObject";
 	float respawnDelay = 2.0f;    // seconds before respawn
 	bool enableAutoRespawn = false; // Auto-respawn every 5 seconds
+
+	// LayerMask field for testing (Unity-style multi-select layer picker)
+	LayerMask collisionLayers;
 
 	// === Internal State (Not exposed to editor) ===
 	float m_totalTime = 0.0f;

--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -78,7 +78,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)bin\$(ProjectName)\$(Configuration)-$(Platform)\</OutDir>
     <IntDir>$(SolutionDir).tmp\$(ProjectName)\$(Configuration)-$(Platform)\</IntDir>
-    <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/NANOEngine/include/ScriptSDK/ScriptAPI.h
+++ b/NANOEngine/include/ScriptSDK/ScriptAPI.h
@@ -542,6 +542,9 @@ namespace Scripting {
         template<typename EnumType>
         void RegisterEnumField(const std::string& name, EnumType* memberPtr, const std::vector<std::string>& enumOptions);
 
+        // LayerMask field registration (multi-select layer picker in editor)
+        void RegisterLayerMaskField(const std::string& name, LayerMask* memberPtr);
+
         // Struct field registration (with reflection support)
         // NOTE: StructType must have NE_REFLECT macros. Include "Reflection.h" in your script.
         template<typename StructType>
@@ -561,6 +564,10 @@ namespace Scripting {
         virtual std::vector<std::string> GetEnumOptions(const std::string& fieldName) const;
         virtual int GetEnumValue(const std::string& fieldName) const;
         virtual void SetEnumValue(const std::string& fieldName, int value);
+
+        // LayerMask field support
+        virtual uint32_t GetLayerMaskValue(const std::string& fieldName) const;
+        virtual void SetLayerMaskValue(const std::string& fieldName, uint32_t value);
 
         // Array/vector field support
         virtual size_t GetArraySize(const std::string& fieldName) const;
@@ -601,6 +608,10 @@ namespace Scripting {
         void SetFieldEnumCallbacks(const std::string& name,
             std::function<int()> getEnumValue,
             std::function<void(int)> setEnumValue);
+
+        void SetFieldLayerMaskCallbacks(const std::string& name,
+            std::function<uint32_t()> getLayerMaskValue,
+            std::function<void(uint32_t)> setLayerMaskValue);
 
      Entity m_entity = INVALID_ENTITY;
         bool m_enabled = true;

--- a/NANOEngine/include/ScriptSDK/ScriptTypes.h
+++ b/NANOEngine/include/ScriptSDK/ScriptTypes.h
@@ -166,5 +166,85 @@ namespace Scripting {
     using MaterialRef = ComponentRef<MaterialHandle>;
     using PrefabRef = ComponentRef<PrefabHandle>;
 
+    //=========================================================================
+    // LAYER MASK (Physics layer filtering)
+    //=========================================================================
+
+    /// Layer mask for physics filtering - similar to Unity's LayerMask
+    /// Stores a bitmask of enabled layers for collision/raycast filtering
+    struct SCRIPT_API LayerMask {
+        uint32_t mask = 0;  ///< Bitmask of enabled layers
+
+        LayerMask() = default;
+        LayerMask(uint32_t value) : mask(value) {}
+
+        /// Check if a specific layer is enabled in this mask
+        bool Contains(uint8_t layer) const {
+            return (mask & (1u << static_cast<uint32_t>(layer))) != 0;
+        }
+
+        /// Enable a specific layer in this mask
+        void Add(uint8_t layer) {
+            mask |= (1u << static_cast<uint32_t>(layer));
+        }
+
+        /// Disable a specific layer in this mask
+        void Remove(uint8_t layer) {
+            mask &= ~(1u << static_cast<uint32_t>(layer));
+        }
+
+        /// Toggle a specific layer in this mask
+        void Toggle(uint8_t layer) {
+            mask ^= (1u << static_cast<uint32_t>(layer));
+        }
+
+        /// Set the layer mask from a list of layers
+        void Set(std::initializer_list<uint8_t> layers) {
+            mask = 0;
+            for (uint8_t layer : layers) {
+                mask |= (1u << static_cast<uint32_t>(layer));
+            }
+        }
+
+        /// Clear all layers
+        void Clear() {
+            mask = 0;
+        }
+
+        /// Check if mask is empty (no layers enabled)
+        bool IsEmpty() const {
+            return mask == 0;
+        }
+
+        /// Get the raw mask value
+        uint32_t GetMask() const {
+            return mask;
+        }
+
+        /// Set the raw mask value
+        void SetMask(uint32_t value) {
+            mask = value;
+        }
+
+        /// Implicit conversion to uint32_t for convenience
+        operator uint32_t() const {
+            return mask;
+        }
+
+        // Comparison operators
+        bool operator==(const LayerMask& other) const { return mask == other.mask; }
+        bool operator!=(const LayerMask& other) const { return mask != other.mask; }
+
+        // Bitwise operators
+        LayerMask operator|(const LayerMask& other) const { return LayerMask(mask | other.mask); }
+        LayerMask operator&(const LayerMask& other) const { return LayerMask(mask & other.mask); }
+        LayerMask operator^(const LayerMask& other) const { return LayerMask(mask ^ other.mask); }
+        LayerMask operator~() const { return LayerMask(~mask); }
+
+        LayerMask& operator|=(const LayerMask& other) { mask |= other.mask; return *this; }
+        LayerMask& operator&=(const LayerMask& other) { mask &= other.mask; return *this; }
+        LayerMask& operator^=(const LayerMask& other) { mask ^= other.mask; return *this; }
+    };
+
 } // namespace Scripting
 } // namespace NE

--- a/NANOEngine/src/Scripting/ScriptAPI.cpp
+++ b/NANOEngine/src/Scripting/ScriptAPI.cpp
@@ -129,6 +129,10 @@ namespace Scripting {
             std::vector<std::string> enumOptions;
             std::function<int()> getEnumValue;
             std::function<void(int)> setEnumValue;
+
+            // LayerMask support
+            std::function<uint32_t()> getLayerMaskValue;
+            std::function<void(uint32_t)> setLayerMaskValue;
         };
 
         std::unordered_map<std::string, FieldEntry> fields;
@@ -1893,6 +1897,37 @@ namespace Scripting {
         MarkFieldAsEntityReference(name);  // Track for LUID conversion during scene serialization
     }
 
+    void IScript::RegisterLayerMaskField(const std::string& name, LayerMask* memberPtr) {
+        RegisterFieldInternal(
+            name,
+            "layermask",
+            memberPtr,
+            // getValue: Return mask as string
+            [memberPtr]() -> std::string {
+                return std::to_string(memberPtr->mask);
+            },
+            // setValue: Set mask from string
+            [memberPtr](const std::string& value) -> bool {
+                try {
+                    memberPtr->mask = std::stoul(value);
+                    return true;
+                } catch (...) {
+                    return false;
+                }
+            }
+        );
+
+        // Set LayerMask callbacks for editor access
+        SetFieldLayerMaskCallbacks(name,
+            [memberPtr]() -> uint32_t {
+                return memberPtr->mask;
+            },
+            [memberPtr](uint32_t value) {
+                memberPtr->mask = value;
+            }
+        );
+    }
+
     //=========================================================================
     // Helper Methods for Template Functions
     //=========================================================================
@@ -1919,6 +1954,20 @@ namespace Scripting {
         if (it != m_fieldRegistry->fields.end()) {
             it->second.getEnumValue = getEnumValue;
             it->second.setEnumValue = setEnumValue;
+        }
+    }
+
+    void IScript::SetFieldLayerMaskCallbacks(const std::string& name,
+        std::function<uint32_t()> getLayerMaskValue,
+        std::function<void(uint32_t)> setLayerMaskValue) {
+        if (!m_fieldRegistry) {
+            m_fieldRegistry = new FieldRegistry();
+        }
+
+        auto it = m_fieldRegistry->fields.find(name);
+        if (it != m_fieldRegistry->fields.end()) {
+            it->second.getLayerMaskValue = getLayerMaskValue;
+            it->second.setLayerMaskValue = setLayerMaskValue;
         }
     }
 
@@ -2002,6 +2051,25 @@ namespace Scripting {
         auto it = m_fieldRegistry->fields.find(fieldName);
         if (it != m_fieldRegistry->fields.end() && it->second.setEnumValue) {
             it->second.setEnumValue(value);
+        }
+    }
+
+    uint32_t IScript::GetLayerMaskValue(const std::string& fieldName) const {
+        if (!m_fieldRegistry) return 0;
+
+        auto it = m_fieldRegistry->fields.find(fieldName);
+        if (it != m_fieldRegistry->fields.end() && it->second.getLayerMaskValue) {
+            return it->second.getLayerMaskValue();
+        }
+        return 0;
+    }
+
+    void IScript::SetLayerMaskValue(const std::string& fieldName, uint32_t value) {
+        if (!m_fieldRegistry) return;
+
+        auto it = m_fieldRegistry->fields.find(fieldName);
+        if (it != m_fieldRegistry->fields.end() && it->second.setLayerMaskValue) {
+            it->second.setLayerMaskValue(value);
         }
     }
 


### PR DESCRIPTION
Introduces LayerMask type for physics layer filtering in scripts, with bitmask operations and utility methods. Adds SCRIPT_FIELD_LAYERMASK macro and registration functions for editor multi-select layer picker. Updates TestScript to demonstrate LayerMask usage and disables debug output. Implements LayerMask field accessors and callbacks in ScriptAPI for editor integration.