### PR TITLE
Add support for Rigidbody constraints in physics

### DIFF
--- a/Editor/src/Command/EditorSetFieldCommand.hpp
+++ b/Editor/src/Command/EditorSetFieldCommand.hpp
@@ -34,11 +34,15 @@ namespace Editor {
 		void Execute() override {
 			auto& c = m_getter(m_entity);
 			c.*m_member = m_after;
+
+            MarkDirtyIfPresent(c);
 		}
 
 		void Undo() override {
 			auto& c = m_getter(m_entity);
 			c.*m_member = m_before;
+
+            MarkDirtyIfPresent(c);
 		}
 
 		const char* GetName() const override { return m_name.c_str(); }
@@ -60,6 +64,11 @@ namespace Editor {
 		const T& After()  const { return m_after; }
 
 	private:
+        template <typename C>
+        static void MarkDirtyIfPresent(C& comp) {
+            if constexpr (requires(C x) { x.isDirty; }) comp.isDirty = true;
+        }
+
 		uint32_t m_entity;
 		std::string m_name;
 		MemberPtr m_member;

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -2905,19 +2905,19 @@ namespace Editor {
 		if (ImGui::TreeNode("Constraints")) {
 			ImGui::Text("Position ");
 			ImGui::SameLine();
-			Editor::DrawCheckbox("X", comp.freezePosX);
+			Editor::DrawCheckbox("X##Pos", comp.freezePosX);
 			ImGui::SameLine();
-			Editor::DrawCheckbox("Y", comp.freezePosY);
+			Editor::DrawCheckbox("Y##Pos", comp.freezePosY);
 			ImGui::SameLine();
-			Editor::DrawCheckbox("Z", comp.freezePosZ);
+			Editor::DrawCheckbox("Z##Pos", comp.freezePosZ);
 
 			ImGui::Text("Rotation ");
 			ImGui::SameLine();
-			Editor::DrawCheckbox("X", comp.freezeRotX);
+			Editor::DrawCheckbox("X##Rot", comp.freezeRotX);
 			ImGui::SameLine();
-			Editor::DrawCheckbox("Y", comp.freezeRotY);
+			Editor::DrawCheckbox("Y##Rot", comp.freezeRotY);
 			ImGui::SameLine();
-			Editor::DrawCheckbox("Z", comp.freezeRotZ);
+			Editor::DrawCheckbox("Z##Rot", comp.freezeRotZ);
 
 			ImGui::TreePop();
 		}

--- a/NANOEngine/src/ECS/Components/Collider.hpp
+++ b/NANOEngine/src/ECS/Components/Collider.hpp
@@ -7,85 +7,82 @@
 #include "Math/Vec3.hpp"
 #include "Core/Reflection.hpp"
 
-
 namespace NE::ECS::Component {
+	struct Collider {
+		struct NoColliderData {
+			NE_REFLECT_BEGIN(NoColliderData)
+				NE_REFLECT_END()
+		};
 
-    struct Collider {
-        struct NoColliderData {
-            NE_REFLECT_BEGIN(NoColliderData)
-            NE_REFLECT_END()
-        };
+		struct BoxColliderData {
+			Math::Vec3 halfExtents{ 0.5f, 0.5f, 0.5f };
+			NE_REFLECT_BEGIN(BoxColliderData)
+				NE_REFLECT_FIELD(halfExtents)
+				NE_REFLECT_END()
+		};
 
-        struct BoxColliderData {
-            Math::Vec3 halfExtents{ 0.5f, 0.5f, 0.5f };
-            NE_REFLECT_BEGIN(BoxColliderData)
-                NE_REFLECT_FIELD(halfExtents)
-            NE_REFLECT_END()
-        };
+		struct SphereColliderData {
+			float radius{ 0.5f };
+			NE_REFLECT_BEGIN(SphereColliderData)
+				NE_REFLECT_FIELD(radius)
+				NE_REFLECT_END()
+		};
 
-        struct SphereColliderData {
-            float radius{ 0.5f };
-            NE_REFLECT_BEGIN(SphereColliderData)
-                NE_REFLECT_FIELD(radius)
-            NE_REFLECT_END()
-        };
+		struct CapsuleColliderData {
+			float radius{ 0.5f };
+			float height{ 1.0f };
+			NE_REFLECT_BEGIN(CapsuleColliderData)
+				NE_REFLECT_FIELD(radius),
+				NE_REFLECT_FIELD(height)
+				NE_REFLECT_END()
+		};
 
-        struct CapsuleColliderData {
-            float radius{ 0.5f };
-            float height{ 1.0f };
-            NE_REFLECT_BEGIN(CapsuleColliderData)
-                NE_REFLECT_FIELD(radius),
-                NE_REFLECT_FIELD(height)
-            NE_REFLECT_END()
-        };
+		struct CylinderColliderData {
+			float radius{ 0.5f };
+			float height{ 1.0f };
+			NE_REFLECT_BEGIN(CylinderColliderData)
+				NE_REFLECT_FIELD(radius),
+				NE_REFLECT_FIELD(height)
+				NE_REFLECT_END()
+		};
 
-        struct CylinderColliderData {
-            float radius{ 0.5f };
-            float height{ 1.0f };
-            NE_REFLECT_BEGIN(CylinderColliderData)
-                NE_REFLECT_FIELD(radius),
-                NE_REFLECT_FIELD(height)
-            NE_REFLECT_END()
-        };
+		struct MeshColliderData {
+			NE_REFLECT_BEGIN(MeshColliderData)
+				NE_REFLECT_END()
+		};
 
-        struct MeshColliderData {
-            NE_REFLECT_BEGIN(MeshColliderData)
-            NE_REFLECT_END()
-        };
+		using ColliderData = std::variant<
+			NoColliderData,
+			BoxColliderData,
+			SphereColliderData,
+			CapsuleColliderData,
+			CylinderColliderData,
+			MeshColliderData
+		>;
 
-        using ColliderData = std::variant<
-            NoColliderData,
-            BoxColliderData,
-            SphereColliderData,
-            CapsuleColliderData,
-            CylinderColliderData,
-            MeshColliderData
-        >;
+		enum class ColliderType : uint8_t {
+			None,
+			Box,
+			Sphere,
+			Capsule,
+			Cylinder,
+			Mesh
+		};
 
-        enum class ColliderType : uint8_t {
-            None,
-            Box,
-            Sphere,
-            Capsule,
-            Cylinder,
-            Mesh
-        };
+		ColliderData data;
+		Math::Vec3 center{ 0.f, 0.f, 0.f };
+		ColliderType type{ ColliderType::None };
+		bool isTrigger = false;
 
-        ColliderData data;
-        Math::Vec3 center{ 0.f, 0.f, 0.f };
-        ColliderType type{ ColliderType::None };
-        bool isTrigger = false;
+		bool isDirty = false;
 
-        // Internal
-        bool isDirty = false;
-
-        NE_REFLECT_BEGIN(Collider)
-            NE_REFLECT_FIELD_HIDDEN(type), // Hidden due to no enum reflection support but for disk serialization
-            NE_REFLECT_FIELD(isTrigger),
-            NE_REFLECT_FIELD(center),
-            NE_REFLECT_FIELD_HIDDEN(data) // Hidden due to no std::variant reflection support but for disk serialization
-        NE_REFLECT_END()
-    };
+		NE_REFLECT_BEGIN(Collider)
+			NE_REFLECT_FIELD_HIDDEN(type), // Hidden due to no enum reflection support but for disk serialization
+			NE_REFLECT_FIELD(isTrigger),
+			NE_REFLECT_FIELD(center),
+			NE_REFLECT_FIELD_HIDDEN(data) // Hidden due to no std::variant reflection support but for disk serialization
+			NE_REFLECT_END()
+	};
 }
 
 #endif

--- a/NANOEngine/src/ECS/Components/Rigidbody.hpp
+++ b/NANOEngine/src/ECS/Components/Rigidbody.hpp
@@ -4,14 +4,12 @@
 #include "Math/Vec3.hpp"
 
 namespace NE::ECS::Component {
-
 	struct Rigidbody {
 		float mass{ 1.0f };
 		float linearDamping{ 0.f };
 		float angularDamping{ 0.05f };
 		bool useGravity = true;
 		bool isKinematic = false;
-		//uint8_t motionType = 2U;  // 0 = Static, 1 = Kinematic, 2 = Dynamic
 
 		bool freezeRotX = false;
 		bool freezeRotY = false;
@@ -27,18 +25,17 @@ namespace NE::ECS::Component {
 		bool isDirty = false;
 
 		NE_REFLECT_BEGIN(Rigidbody)
-			NE_REFLECT_FIELD(mass),
-			NE_REFLECT_FIELD(linearDamping),
-			NE_REFLECT_FIELD(angularDamping),
-			NE_REFLECT_FIELD(useGravity),
-			NE_REFLECT_FIELD(isKinematic),
+			NE_REFLECT_FIELD_NAMED(mass, "Mass"),
+			NE_REFLECT_FIELD_NAMED(linearDamping, "Linear Damping"),
+			NE_REFLECT_FIELD_NAMED(angularDamping, "Angular Damping"),
+			NE_REFLECT_FIELD_NAMED(useGravity, "Use Gravity"),
+			NE_REFLECT_FIELD_NAMED(isKinematic, "Is Kinematic"),
 			NE_REFLECT_FIELD_HIDDEN(freezeRotX),
 			NE_REFLECT_FIELD_HIDDEN(freezeRotY),
 			NE_REFLECT_FIELD_HIDDEN(freezeRotZ),
 			NE_REFLECT_FIELD_HIDDEN(freezePosX),
 			NE_REFLECT_FIELD_HIDDEN(freezePosY),
 			NE_REFLECT_FIELD_HIDDEN(freezePosZ)
-		NE_REFLECT_END()
+			NE_REFLECT_END()
 	};
-
 }

--- a/NANOEngine/src/Physics/PhysicsManager.cpp
+++ b/NANOEngine/src/Physics/PhysicsManager.cpp
@@ -248,6 +248,18 @@ namespace NE::Physics {
         settings.mLinearDamping = rb.linearDamping;
         settings.mAngularDamping = rb.angularDamping;
         settings.mIsSensor = col.isTrigger;
+
+        JPH::EAllowedDOFs allowedDOFs = JPH::EAllowedDOFs::All;
+
+        if (rb.freezePosX) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationX;
+        if (rb.freezePosY) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationY;
+        if (rb.freezePosZ) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationZ;
+
+        if (rb.freezeRotX) allowedDOFs &= ~JPH::EAllowedDOFs::RotationX;
+        if (rb.freezeRotY) allowedDOFs &= ~JPH::EAllowedDOFs::RotationY;
+        if (rb.freezeRotZ) allowedDOFs &= ~JPH::EAllowedDOFs::RotationZ;
+
+        settings.mAllowedDOFs = allowedDOFs;
         
         if (motion == JPH::EMotionType::Dynamic) {
             settings.mOverrideMassProperties = JPH::EOverrideMassProperties::CalculateInertia;


### PR DESCRIPTION
Implemented handling of Rigidbody position and rotation freeze constraints in PhysicsManager by setting allowed DOFs. Updated InspectorPanel checkbox labels for clarity and improved reflection metadata in Rigidbody and Collider components. EditorSetFieldCommand now marks components as dirty when fields are changed.