### PR TITLE
Refactor LUIDRegistry usage in ECS systems

### DIFF
--- a/NANOEngine/src/Core/LUIDRegistry.cpp
+++ b/NANOEngine/src/Core/LUIDRegistry.cpp
@@ -2,8 +2,8 @@
 
 namespace NE::Core {
 
-	void LUIDRegistry::Register(uint64_t _id, void* _ptr, uint32_t _entityOwner, LuidType _type) {
-		m_map[_id] = { _ptr, _entityOwner, _type };
+	void LUIDRegistry::Register(uint64_t _id, void* _ptr, uint32_t _entityOwner) {
+		m_map[_id] = { _ptr, _entityOwner };
 	}
 
 	void LUIDRegistry::Unregister(uint64_t _id) {

--- a/NANOEngine/src/Core/LUIDRegistry.hpp
+++ b/NANOEngine/src/Core/LUIDRegistry.hpp
@@ -6,19 +6,14 @@
 
 namespace NE::Core {
 
-	enum class LuidType : uint8_t {
-
-	};
-
 	struct LuidRecord {
 		void* m_ptr;
 		uint32_t m_entityOwner;
-		LuidType m_type;
 	};
 
 	class LUIDRegistry {
 	public:
-		void Register(uint64_t, void*, uint32_t, LuidType);
+		void Register(uint64_t, void*, uint32_t);
 		void Unregister(uint64_t);
 		const LuidRecord* Find(uint64_t) const;
 		void Clear();

--- a/NANOEngine/src/ECS/Core/ECSCoordinator.cpp
+++ b/NANOEngine/src/ECS/Core/ECSCoordinator.cpp
@@ -35,9 +35,10 @@
 namespace NE::ECS {
 
     ECSCoordinator::ECSCoordinator()
-    : m_entityManager(std::make_unique<EntityManager>())
-    , m_componentManager(std::make_unique<ComponentManager>())
-    , m_systemManager(std::make_unique<SystemManager>()) 
+        : m_entityManager(std::make_unique<EntityManager>())
+        , m_componentManager(std::make_unique<ComponentManager>())
+        , m_systemManager(std::make_unique<SystemManager>()) 
+        , m_luidRegistry(std::make_unique<Core::LUIDRegistry>())
     {
 
         RegisterComponent<Component::EntityMeta>();
@@ -56,12 +57,12 @@ namespace NE::ECS {
         RegisterComponent<Component::NativeScript>();
         
 
-        m_transformSystem = m_systemManager->RegisterSystem<Systems::TransformSystem>(m_componentManager.get());
+        m_transformSystem = m_systemManager->RegisterSystem<Systems::TransformSystem>(m_componentManager.get(), m_luidRegistry.get());
         SetSystemSignature<Systems::TransformSystem>(
             Signature{}.set(GetComponentType<Component::Transform>())
         );
 
-        m_renderSystem = m_systemManager->RegisterSystem<Systems::RenderSystem>(m_componentManager.get());
+        m_renderSystem = m_systemManager->RegisterSystem<Systems::RenderSystem>(m_componentManager.get(), m_luidRegistry.get());
         {
             Signature sig;
             sig.set(GetComponentType<Component::Transform>());
@@ -77,7 +78,7 @@ namespace NE::ECS {
             SetSystemSignature<Systems::LightSystem>(sig);
         }
 
-        m_rigidbodySystem = m_systemManager->RegisterSystem<Systems::RigidbodySystem>(m_componentManager.get(), m_entityManager.get());
+        m_rigidbodySystem = m_systemManager->RegisterSystem<Systems::RigidbodySystem>(m_componentManager.get(), m_entityManager.get(), m_luidRegistry.get());
         {
             Signature sig;
             sig.set(GetComponentType<Component::Transform>());

--- a/NANOEngine/src/ECS/Core/ECSCoordinator.hpp
+++ b/NANOEngine/src/ECS/Core/ECSCoordinator.hpp
@@ -2,6 +2,7 @@
 #include "EntityManager.hpp"
 #include "ComponentManager.hpp"
 #include "SystemManager.hpp"
+#include "Core/LUIDRegistry.hpp"
 
 namespace NE::ECS::Systems {
     class TransformSystem;
@@ -117,7 +118,7 @@ namespace NE::ECS {
         std::unique_ptr<EntityManager> m_entityManager;
         std::unique_ptr<ComponentManager> m_componentManager;
         std::unique_ptr<SystemManager> m_systemManager;
-
+        std::unique_ptr<Core::LUIDRegistry> m_luidRegistry;
     };
 
 }

--- a/NANOEngine/src/ECS/Core/SparseSet.hpp
+++ b/NANOEngine/src/ECS/Core/SparseSet.hpp
@@ -30,7 +30,9 @@ namespace NE::ECS {
             return m_sparseContainer[e] < m_denseContainer.size() && m_denseContainer[m_sparseContainer[e]] == e;
         }
 
-        std::vector<Entity>& GetDenseContainer() { return m_denseContainer; }
+        std::vector<Entity>& GetDenseContainer() { 
+            return m_denseContainer; 
+        }
         const std::vector<Entity>& GetDenseContainer() const { return m_denseContainer; }
 
     private:

--- a/NANOEngine/src/ECS/Core/SystemManager.hpp
+++ b/NANOEngine/src/ECS/Core/SystemManager.hpp
@@ -5,6 +5,10 @@
 #include "Signature.hpp"
 #include "System.hpp"
 
+namespace NE::Core {
+    class LUIDRegistry;
+}
+
 namespace NE::ECS {
 
     class SystemManager {
@@ -23,6 +27,24 @@ namespace NE::ECS {
             std::type_index typeIdx = typeid(T);
             assert(m_systems.find(typeIdx) == m_systems.end() && "System already registered.");
             auto system = std::make_shared<T>(cm, em);
+            m_systems[typeIdx] = system;
+            return system;
+        }
+
+        template<typename T>
+        std::shared_ptr<T> RegisterSystem(ComponentManager* cm, Core::LUIDRegistry* lr) {
+            std::type_index typeIdx = typeid(T);
+            assert(m_systems.find(typeIdx) == m_systems.end() && "System already registered.");
+            auto system = std::make_shared<T>(cm, lr);
+            m_systems[typeIdx] = system;
+            return system;
+        }
+
+        template<typename T>
+        std::shared_ptr<T> RegisterSystem(ComponentManager* cm, EntityManager* em, Core::LUIDRegistry* lr) {
+            std::type_index typeIdx = typeid(T);
+            assert(m_systems.find(typeIdx) == m_systems.end() && "System already registered.");
+            auto system = std::make_shared<T>(cm, em, lr);
             m_systems[typeIdx] = system;
             return system;
         }

--- a/NANOEngine/src/ECS/Systems/RenderSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/RenderSystem.cpp
@@ -17,6 +17,7 @@
 #include "ResourceManagement/ResourceManager.hpp"
 #include <glad/glad.h>
 #include "Core/LUIDGenerator.hpp"
+#include "Core/LUIDRegistry.hpp"
 
 using namespace NE::Math;
 using NE::Graphics::Frustum;
@@ -24,12 +25,8 @@ using NE::Graphics::GraphicsManager;
 
 namespace NE::ECS::Systems {
 
-    // temp stuff
-    //static std::shared_ptr<Graphics::IShader> pickingShader;
-    //static std::shared_ptr<Graphics::IPipeline> pickingPipeline;
-    //static std::shared_ptr<Graphics::Material> pickingMaterial;
-
-    RenderSystem::RenderSystem(ComponentManager* cm) : m_componentManager(cm)
+    RenderSystem::RenderSystem(ComponentManager* cm, Core::LUIDRegistry* lr) 
+        : m_componentManager(cm), m_luidRegistry(lr)
     {
     }
 
@@ -45,10 +42,13 @@ namespace NE::ECS::Systems {
 
         if (renderer.luid == 0)
             renderer.luid = Core::LUIDGenerator::Generate("rd");
+
+        m_luidRegistry->Register(renderer.luid, &renderer, entity);
     }
 
-    void RenderSystem::OnEntityRemoved(Entity)
-    {
+    void RenderSystem::OnEntityRemoved(Entity e) {
+        auto& renderer = m_componentManager->GetComponent<Component::Renderer>(e);
+        m_luidRegistry->Unregister(renderer.luid);
     }
 
     void RenderSystem::Init() {

--- a/NANOEngine/src/ECS/Systems/RenderSystem.hpp
+++ b/NANOEngine/src/ECS/Systems/RenderSystem.hpp
@@ -5,11 +5,15 @@
 #include "../../Graphics/Core/Frustum.hpp"
 #include "../../Graphics/Core/EditorCamera.hpp"
 
+namespace NE::Core {
+	class LUIDRegistry;
+}
+
 namespace NE::ECS::Systems {
 
     class RenderSystem final : public System {
     public:
-		explicit RenderSystem(ComponentManager* cm);
+		explicit RenderSystem(ComponentManager* cm, Core::LUIDRegistry* lr);
 
 		void OnEntityAdded(Entity entity) override;
 		void OnEntityRemoved(Entity entity) override;
@@ -20,6 +24,7 @@ namespace NE::ECS::Systems {
 
     private:
         ComponentManager* m_componentManager;
+		Core::LUIDRegistry* m_luidRegistry;
 
 		static NE::Graphics::Frustum BuildFrustum();
 

--- a/NANOEngine/src/ECS/Systems/RigidbodySystem.cpp
+++ b/NANOEngine/src/ECS/Systems/RigidbodySystem.cpp
@@ -5,12 +5,12 @@
 #include "../Components/EntityMeta.hpp"
 #include "Physics/PhysicsManager.hpp"
 #include "Core/LUIDGenerator.hpp"
-
+#include "Core/LUIDRegistry.hpp"
 
 namespace NE::ECS::Systems {
 
-	RigidbodySystem::RigidbodySystem(ComponentManager* cm, EntityManager* em) 
-		: m_componentManager(cm), m_entityManager(em)
+	RigidbodySystem::RigidbodySystem(ComponentManager* cm, EntityManager* em, Core::LUIDRegistry* lr)
+		: m_componentManager(cm), m_entityManager(em), m_luidRegistry(lr)
 	{
 	}
 
@@ -19,10 +19,13 @@ namespace NE::ECS::Systems {
 
 		if (rb.luid == 0)
 			rb.luid = Core::LUIDGenerator::Generate("rb");
+
+		m_luidRegistry->Register(rb.luid, &rb, e);
 	}
 
-	void RigidbodySystem::OnEntityRemoved(Entity entity) {
-
+	void RigidbodySystem::OnEntityRemoved(Entity e) {
+		auto& rb = m_componentManager->GetComponent<Component::Rigidbody>(e);
+		m_luidRegistry->Unregister(rb.luid);
 	}
 
 	void RigidbodySystem::Init() {

--- a/NANOEngine/src/ECS/Systems/RigidbodySystem.hpp
+++ b/NANOEngine/src/ECS/Systems/RigidbodySystem.hpp
@@ -14,11 +14,15 @@
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
 #include <Jolt/Physics/PhysicsSystem.h>
 
+namespace NE::Core {
+	class LUIDRegistry;
+}
+
 namespace NE::ECS::Systems {
 
 	class RigidbodySystem final : public System {
 	public:
-		explicit RigidbodySystem(ComponentManager* cm, EntityManager* em);
+		explicit RigidbodySystem(ComponentManager* cm, EntityManager* em, Core::LUIDRegistry* lr);
 
 		void OnEntityAdded(Entity entity) override;
 		void OnEntityRemoved(Entity entity) override;
@@ -30,6 +34,7 @@ namespace NE::ECS::Systems {
 	private:
 		ComponentManager* m_componentManager;
 		EntityManager* m_entityManager;
+		Core::LUIDRegistry* m_luidRegistry;
 	};
 
 }

--- a/NANOEngine/src/ECS/Systems/TransformSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/TransformSystem.cpp
@@ -4,10 +4,11 @@
 #include "../Components/Hierarchy.hpp"
 #include "Core/Profiler.hpp"
 #include "Core/LUIDGenerator.hpp"
+#include "Core/LUIDRegistry.hpp"
 
 namespace NE::ECS::Systems {
 
-	TransformSystem::TransformSystem(ComponentManager* cm) : m_componentManager(cm) { }
+	TransformSystem::TransformSystem(ComponentManager* cm, Core::LUIDRegistry* lr) : m_componentManager(cm), m_luidRegistry(lr) { }
 
 	void TransformSystem::OnEntityAdded(Entity e) {
 		auto& t = m_componentManager->GetComponent<Component::Transform>(e);
@@ -29,9 +30,13 @@ namespace NE::ECS::Systems {
 
 		if (t.luid == 0)
 			t.luid = Core::LUIDGenerator::Generate("tr");
+
+		m_luidRegistry->Register(t.luid, &t, e);
 	}
 
-	void TransformSystem::OnEntityRemoved(Entity) {
+	void TransformSystem::OnEntityRemoved(Entity e) {
+		auto& t = m_componentManager->GetComponent<Component::Transform>(e);
+		m_luidRegistry->Unregister(t.luid);
 	}
 
 	void TransformSystem::Init() {

--- a/NANOEngine/src/ECS/Systems/TransformSystem.hpp
+++ b/NANOEngine/src/ECS/Systems/TransformSystem.hpp
@@ -5,6 +5,10 @@
 #include <unordered_map>
 #include "../Core/ComponentManager.hpp"
 
+namespace NE::Core {
+	class LUIDRegistry;
+}
+
 namespace NE::Math {
 	struct Mat4;
 }
@@ -12,7 +16,7 @@ namespace NE::Math {
 namespace NE::ECS::Systems {
 	class TransformSystem final : public System {
 	public:
-		explicit TransformSystem(ComponentManager* cm);
+		explicit TransformSystem(ComponentManager* cm, Core::LUIDRegistry* lr);
 
 		void OnEntityAdded(Entity entity) override;
 		void OnEntityRemoved(Entity entity) override;
@@ -27,6 +31,7 @@ namespace NE::ECS::Systems {
 			bool parentWorldDirty);
 
 		ComponentManager* m_componentManager;
+		Core::LUIDRegistry* m_luidRegistry;
 	};
 }
 

--- a/NANOEngine/src/SceneManagement/Scene.cpp
+++ b/NANOEngine/src/SceneManagement/Scene.cpp
@@ -130,8 +130,4 @@ namespace NE::SceneManagement {
 		return m_ecsCoordinator;
 	}
 
-	Core::LUIDRegistry& Scene::GetLuidRegistry() {
-		return m_luidRegistry;
-	}
-
 }

--- a/NANOEngine/src/SceneManagement/Scene.hpp
+++ b/NANOEngine/src/SceneManagement/Scene.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ECS/Core/ECSCoordinator.hpp"
-#include "Core/LUIDRegistry.hpp"
 
 namespace NE::SceneManagement {
 
@@ -20,10 +19,8 @@ namespace NE::SceneManagement {
 		void ScriptStop();
 
 		ECS::ECSCoordinator& GetECSCoordinator();
-		Core::LUIDRegistry& GetLuidRegistry();
 	private:
 		ECS::ECSCoordinator m_ecsCoordinator;
-		Core::LUIDRegistry m_luidRegistry;
 	};
 
 }


### PR DESCRIPTION
LUIDRegistry is now managed by ECSCoordinator and passed to relevant systems (TransformSystem, RenderSystem, RigidbodySystem) via SystemManager. The LuidType enum and related code were removed, and Scene no longer manages its own LUIDRegistry. This centralizes LUID management and simplifies system construction.