### PR TITLE
Refactor asset import settings editors and InspectorPanel

### DIFF
--- a/Editor/src/AssetManagement/AssetManager.cpp
+++ b/Editor/src/AssetManagement/AssetManager.cpp
@@ -207,15 +207,6 @@ namespace Editor::Assets {
             rec.asset = CreateImporterForType(type, uuid, fsSourcePath.filename().string());
         }
 
-        if (rec.type != AssetType::Scene) {
-            if (rec.asset) {
-                const auto cookedPath =
-                    NE::Resource::ComputeArtifactPathFromUUID(uuid, GetResourceTypeFromAssetType(type));
-                rec.asset->Cook(fsSourcePath.string(), cookedPath);
-                rec.isLoaded = true;
-            }
-        }
-
         Document outDoc;
         outDoc.SetObject();
         auto& a = outDoc.GetAllocator();
@@ -242,6 +233,17 @@ namespace Editor::Assets {
         PrettyWriter<OStreamWrapper> writer(osw);
         writer.SetIndent(' ', 4);
         outDoc.Accept(writer);
+
+        if (rec.type != AssetType::Scene) {
+            if (rec.asset) {
+                rec.asset->SaveImportSettings(sourcePath); // create and save default settings first
+
+                const auto cookedPath =
+                    NE::Resource::ComputeArtifactPathFromUUID(uuid, GetResourceTypeFromAssetType(type));
+                rec.asset->Cook(fsSourcePath.string(), cookedPath);
+                rec.isLoaded = true;
+            }
+        }
     }
 
     void AssetManager::ReimportAsset(const std::string& sourcePathOrMeta) {

--- a/Editor/src/AssetManagement/Assets/ModelAsset.cpp
+++ b/Editor/src/AssetManagement/Assets/ModelAsset.cpp
@@ -9,10 +9,13 @@
 #include <rapidjson/document.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <rapidjson/prettywriter.h>
+#include <rapidjson/istreamwrapper.h>
 
 #include <ResourceManagement/BinaryHeaders/NanoModelHeader.hpp>
 #include <Serialisation/ReflectionJson.hpp>
 #include <Math/Vec3.hpp>
+
+#include "../../Serialization/JSONReflection.hpp"
 
 namespace Editor::Assets {
 	namespace {
@@ -24,211 +27,225 @@ namespace Editor::Assets {
 	}
 
 	bool ModelAsset::Cook(const std::string& sourcePath, const std::string& outPath) const {
-		//std::filesystem::path out = outPath;
-		//std::filesystem::create_directories(out.parent_path());
+		std::filesystem::path out = outPath;
+		std::filesystem::create_directories(out.parent_path());
 
-		//Assimp::Importer importer;
-		//const aiScene* scene = importer.ReadFile(sourcePath,
-		//	aiProcess_Triangulate |
-		//	aiProcess_JoinIdenticalVertices |
-		//	aiProcess_FlipUVs |
-		//	aiProcess_GenSmoothNormals |
-		//	aiProcess_CalcTangentSpace);
+		Assimp::Importer importer;
+		const aiScene* scene = importer.ReadFile(sourcePath,
+			aiProcess_Triangulate |
+			aiProcess_JoinIdenticalVertices |
+			aiProcess_FlipUVs |
+			aiProcess_GenSmoothNormals |
+			aiProcess_CalcTangentSpace);
 
-		//if (!scene || !scene->HasMeshes()) {
-		//	std::fprintf(stderr, "[CookMesh] Failed to load %s\n", sourcePath.c_str());
-		//	return false;
-		//}
+		if (!scene || !scene->HasMeshes()) {
+			std::fprintf(stderr, "[CookMesh] Failed to load %s\n", sourcePath.c_str());
+			return false;
+		}
 
-		//// one desc per mesh
-		//std::vector<NE::Resource::NanoSubmeshDesc> subdescs(scene->mNumMeshes);
+		// one desc per mesh
+		std::vector<NE::Resource::NanoSubmeshDesc> subdescs(scene->mNumMeshes);
 
-		//// temp storage for actual vertex/index bytes
-		//struct RawBlob {
-		//	std::vector<uint8_t> vertices;
-		//	std::vector<uint8_t> indices;
-		//};
-		//std::vector<RawBlob> blobs(scene->mNumMeshes);
+		// temp storage for actual vertex/index bytes
+		struct RawBlob {
+			std::vector<uint8_t> vertices;
+			std::vector<uint8_t> indices;
+		};
+		std::vector<RawBlob> blobs(scene->mNumMeshes);
 
-		//// bounds
-		//bool hasBounds = false;
-		//NE::Math::Vec3 minP(FLT_MAX, FLT_MAX, FLT_MAX);
-		//NE::Math::Vec3 maxP(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+		// bounds
+		bool hasBounds = false;
+		NE::Math::Vec3 minP(FLT_MAX, FLT_MAX, FLT_MAX);
+		NE::Math::Vec3 maxP(-FLT_MAX, -FLT_MAX, -FLT_MAX);
 
-		//for (unsigned m = 0; m < scene->mNumMeshes; ++m) {
-		//	const aiMesh* mesh = scene->mMeshes[m];
+		for (unsigned m = 0; m < scene->mNumMeshes; ++m) {
+			const aiMesh* mesh = scene->mMeshes[m];
 
-		//	RawBlob& rb = blobs[m];
-		//	rb.vertices.resize(mesh->mNumVertices * sizeof(CookVertex));
-		//	auto* vout = reinterpret_cast<CookVertex*>(rb.vertices.data());
+			RawBlob& rb = blobs[m];
+			rb.vertices.resize(mesh->mNumVertices * sizeof(CookVertex));
+			auto* vout = reinterpret_cast<CookVertex*>(rb.vertices.data());
 
-		//	for (unsigned i = 0; i < mesh->mNumVertices; ++i) {
-		//		CookVertex v{};
-		//		v.px = mesh->mVertices[i].x;
-		//		v.py = mesh->mVertices[i].y;
-		//		v.pz = mesh->mVertices[i].z;
+			for (unsigned i = 0; i < mesh->mNumVertices; ++i) {
+				CookVertex v{};
+				v.px = mesh->mVertices[i].x;
+				v.py = mesh->mVertices[i].y;
+				v.pz = mesh->mVertices[i].z;
 
-		//		if (mesh->HasNormals()) {
-		//			v.nx = mesh->mNormals[i].x;
-		//			v.ny = mesh->mNormals[i].y;
-		//			v.nz = mesh->mNormals[i].z;
-		//		} else {
-		//			v.nx = v.ny = v.nz = 0.0f;
-		//		}
+				if (mesh->HasNormals()) {
+					v.nx = mesh->mNormals[i].x;
+					v.ny = mesh->mNormals[i].y;
+					v.nz = mesh->mNormals[i].z;
+				} else {
+					v.nx = v.ny = v.nz = 0.0f;
+				}
 
-		//		if (mesh->HasTextureCoords(0)) {
-		//			v.u = mesh->mTextureCoords[0][i].x;
-		//			v.v = mesh->mTextureCoords[0][i].y;
-		//		} else {
-		//			v.u = v.v = 0.0f;
-		//		}
+				if (mesh->HasTextureCoords(0)) {
+					v.u = mesh->mTextureCoords[0][i].x;
+					v.v = mesh->mTextureCoords[0][i].y;
+				} else {
+					v.u = v.v = 0.0f;
+				}
 
-		//		vout[i] = v;
+				vout[i] = v;
 
-		//		// expand bounds
-		//		minP.x = std::min(minP.x, v.px);
-		//		minP.y = std::min(minP.y, v.py);
-		//		minP.z = std::min(minP.z, v.pz);
-		//		maxP.x = std::max(maxP.x, v.px);
-		//		maxP.y = std::max(maxP.y, v.py);
-		//		maxP.z = std::max(maxP.z, v.pz);
-		//		hasBounds = true;
-		//	}
+				// expand bounds
+				minP.x = std::min(minP.x, v.px);
+				minP.y = std::min(minP.y, v.py);
+				minP.z = std::min(minP.z, v.pz);
+				maxP.x = std::max(maxP.x, v.px);
+				maxP.y = std::max(maxP.y, v.py);
+				maxP.z = std::max(maxP.z, v.pz);
+				hasBounds = true;
+			}
 
-		//	// indices
-		//	std::vector<uint32_t> idx;
-		//	idx.reserve(mesh->mNumFaces * 3);
-		//	for (unsigned f = 0; f < mesh->mNumFaces; ++f) {
-		//		const aiFace& face = mesh->mFaces[f];
-		//		for (unsigned j = 0; j < face.mNumIndices; ++j)
-		//			idx.push_back(face.mIndices[j]);
-		//	}
-		//	rb.indices.resize(idx.size() * sizeof(uint32_t));
-		//	std::memcpy(rb.indices.data(), idx.data(), rb.indices.size());
+			// indices
+			std::vector<uint32_t> idx;
+			idx.reserve(mesh->mNumFaces * 3);
+			for (unsigned f = 0; f < mesh->mNumFaces; ++f) {
+				const aiFace& face = mesh->mFaces[f];
+				for (unsigned j = 0; j < face.mNumIndices; ++j)
+					idx.push_back(face.mIndices[j]);
+			}
+			rb.indices.resize(idx.size() * sizeof(uint32_t));
+			std::memcpy(rb.indices.data(), idx.data(), rb.indices.size());
 
-		//	subdescs[m].vertexCount = mesh->mNumVertices;
-		//	subdescs[m].indexCount = static_cast<uint32_t>(idx.size());
-		//}
+			subdescs[m].vertexCount = mesh->mNumVertices;
+			subdescs[m].indexCount = static_cast<uint32_t>(idx.size());
+		}
 
-		//// compute sphere from AABB
-		////NE::Math::Vec3 center(0, 0, 0);
-		////float radius = 0.0f;
-		////if (hasBounds) {
-		////    center = (minP + maxP) * 0.5f;
-		////    NE::Math::Vec3 ext = maxP - center;
-		////    radius = std::max(std::max(ext.x, ext.y), ext.z);
-		////}s
+		// compute sphere from AABB
+		//NE::Math::Vec3 center(0, 0, 0);
+		//float radius = 0.0f;
+		//if (hasBounds) {
+		//    center = (minP + maxP) * 0.5f;
+		//    NE::Math::Vec3 ext = maxP - center;
+		//    radius = std::max(std::max(ext.x, ext.y), ext.z);
+		//}s
 
-		//std::ofstream ofs(outPath, std::ios::binary);
-		//if (!ofs) return false;
+		std::ofstream ofs(outPath, std::ios::binary);
+		if (!ofs) return false;
 
-		//NE::Resource::NanoMeshHeader header{};
-		//header.submeshCount = static_cast<uint16_t>(scene->mNumMeshes);
+		NE::Resource::NanoMeshHeader header{};
+		header.submeshCount = static_cast<uint16_t>(scene->mNumMeshes);
 
-		////header.sphereCenter[0] = center.x;
-		////header.sphereCenter[1] = center.y;
-		////header.sphereCenter[2] = center.z;
-		////header.sphereRadius = radius;
+		//header.sphereCenter[0] = center.x;
+		//header.sphereCenter[1] = center.y;
+		//header.sphereCenter[2] = center.z;
+		//header.sphereRadius = radius;
 
-		//ofs.write(reinterpret_cast<const char*>(&header), sizeof(header));
+		ofs.write(reinterpret_cast<const char*>(&header), sizeof(header));
 
-		//// placeholder submesh table
-		//const std::streamoff subTablePos = ofs.tellp();
-		//ofs.write(reinterpret_cast<const char*>(subdescs.data()),
-		//	subdescs.size() * sizeof(NE::Resource::NanoSubmeshDesc));
+		// placeholder submesh table
+		const std::streamoff subTablePos = ofs.tellp();
+		ofs.write(reinterpret_cast<const char*>(subdescs.data()),
+			subdescs.size() * sizeof(NE::Resource::NanoSubmeshDesc));
 
-		//// actual data + capture offsets
-		//for (size_t m = 0; m < blobs.size(); ++m) {
-		//	auto& rb = blobs[m];
+		// actual data + capture offsets
+		for (size_t m = 0; m < blobs.size(); ++m) {
+			auto& rb = blobs[m];
 
-		//	uint32_t vertexOffset = static_cast<uint32_t>(ofs.tellp());
-		//	ofs.write(reinterpret_cast<const char*>(rb.vertices.data()), rb.vertices.size());
+			uint32_t vertexOffset = static_cast<uint32_t>(ofs.tellp());
+			ofs.write(reinterpret_cast<const char*>(rb.vertices.data()), rb.vertices.size());
 
-		//	uint32_t indexOffset = static_cast<uint32_t>(ofs.tellp());
-		//	ofs.write(reinterpret_cast<const char*>(rb.indices.data()), rb.indices.size());
+			uint32_t indexOffset = static_cast<uint32_t>(ofs.tellp());
+			ofs.write(reinterpret_cast<const char*>(rb.indices.data()), rb.indices.size());
 
-		//	subdescs[m].vertexDataOffset = vertexOffset;
-		//	subdescs[m].indexDataOffset = indexOffset;
-		//}
+			subdescs[m].vertexDataOffset = vertexOffset;
+			subdescs[m].indexDataOffset = indexOffset;
+		}
 
-		//// go back and patch submesh table
-		//ofs.seekp(subTablePos, std::ios::beg);
-		//ofs.write(reinterpret_cast<const char*>(subdescs.data()),
-		//	subdescs.size() * sizeof(NE::Resource::NanoSubmeshDesc));
+		// go back and patch submesh table
+		ofs.seekp(subTablePos, std::ios::beg);
+		ofs.write(reinterpret_cast<const char*>(subdescs.data()),
+			subdescs.size() * sizeof(NE::Resource::NanoSubmeshDesc));
 
-		//std::printf("[CookMesh] wrote %s\n", outPath.c_str());
+		std::printf("[CookMesh] wrote %s\n", outPath.c_str());
 		return true;
 	}
 
 	bool ModelAsset::LoadImportSettings(const std::string& sourcePath) {
-		//using namespace rapidjson;
-		//using namespace NE::Serialization;
+		if (importSettings.has_value()) return true;
 
-		//if (!std::filesystem::exists(metaPath))
-		//	return false;
+		using rapidjson::IStreamWrapper;
+		using rapidjson::Document;
 
-		//std::ifstream ifs(metaPath);
-		//if (!ifs) {
-		//	SPD_WARNING("Failed to read meta file: " << metaPath);
-		//	return false;
-		//}
+		std::string metaPath = sourcePath + ".meta";
 
-		//IStreamWrapper isw(ifs);
-		//Document doc;
-		//doc.ParseStream(isw);
+		if (!std::filesystem::exists(metaPath))
+			return false;
 
-		//if (doc.HasParseError() || !doc.IsObject()) {
-		//	SPD_WARNING("Failed to parse JSON in meta file: " << metaPath);
-		//	return false;
-		//}
+		std::ifstream ifs(metaPath);
+		if (!ifs) {
+			SPD_WARNING("Failed to read meta file: " << metaPath);
+			return false;
+		}
 
-		//if (!doc.HasMember("modelImport") || !doc["modelImport"].IsObject())
-		//	return true;
+		IStreamWrapper isw(ifs);
+		Document doc;
+		doc.ParseStream(isw);
 
-		//const auto& jSettings = doc["modelImport"];
-		//from_json(jSettings, settings);
+		if (doc.HasParseError() || !doc.IsObject()) {
+			SPD_WARNING("Failed to parse JSON in meta file: " << metaPath);
+			return false;
+		}
+
+		if (!doc.HasMember("modelImport") || !doc["modelImport"].IsObject())
+			return true;
+
+		const auto& jSettings = doc["modelImport"];
+
+		if (!importSettings)
+			importSettings.emplace();
+
+		Deserialization::FromJSON(jSettings, *importSettings);
 
 		return true;
 	}
 
 	bool ModelAsset::SaveImportSettings(const std::string& sourcePath) {
-		//rapidjson::Document doc;
-		//doc.SetObject();
+		using rapidjson::Value;
 
-		//// Try to load existing meta to preserve other unrelated fields (uuid, assetType, etc.)
-		//if (std::filesystem::exists(metaPath)) {
-		//	std::ifstream ifs(metaPath);
-		//	if (ifs) {
-		//		rapidjson::IStreamWrapper isw(ifs);
-		//		doc.ParseStream(isw);
-		//		if (doc.HasParseError() || !doc.IsObject()) {
-		//			doc.SetObject(); // Reset on failure
-		//		}
-		//	}
-		//}
+		std::string metaPath = sourcePath + ".meta";
 
-		//auto& alloc = doc.GetAllocator();
+		rapidjson::Document doc;
+		doc.SetObject();
 
-		//// Serialize settings via reflection
-		//NE::Serialization::RJson jSettings = NE::Serialization::to_json(settings, alloc); // object with { scene, mesh, rig, animation, material }
+		if (std::filesystem::exists(metaPath)) {
+			std::ifstream ifs(metaPath);
+			if (ifs) {
+				rapidjson::IStreamWrapper isw(ifs);
+				doc.ParseStream(isw);
+				if (doc.HasParseError() || !doc.IsObject()) {
+					doc.SetObject();
+				}
+			}
+		}
 
-		//// Attach / replace "modelImport" in the root doc
-		//if (doc.HasMember("modelImport"))
-		//	doc["modelImport"].CopyFrom(jSettings, alloc);
-		//else
-		//	doc.AddMember("modelImport", jSettings, alloc);
+		auto& alloc = doc.GetAllocator();
 
-		//std::ofstream ofs(metaPath);
-		//if (!ofs) {
-		//	SPD_WARNING("Failed to write meta file: " << metaPath);
-		//	return false;
-		//}
+		if (!importSettings) importSettings.emplace();
+		auto jSettings = Serialization::ToJSON(*importSettings, alloc);
 
-		//rapidjson::OStreamWrapper osw(ofs);
-		//rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(osw);
-		//writer.SetIndent(' ', 4);
-		//doc.Accept(writer);
+		if (doc.HasMember("modelImport"))
+			doc["modelImport"].CopyFrom(jSettings, alloc);
+		else
+			doc.AddMember("modelImport", jSettings, alloc);
+
+		std::ofstream ofs(metaPath);
+		if (!ofs) {
+			SPD_WARNING("Failed to write meta file: " << metaPath);
+			return false;
+		}
+
+		rapidjson::OStreamWrapper osw(ofs);
+		rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(osw);
+		writer.SetIndent(' ', 4);
+		doc.Accept(writer);
 
 		return true;
+	}
+
+	ModelImportSettings& ModelAsset::GetImportSettings() {
+		return *importSettings;
 	}
 }

--- a/Editor/src/AssetManagement/Assets/ModelAsset.hpp
+++ b/Editor/src/AssetManagement/Assets/ModelAsset.hpp
@@ -16,6 +16,8 @@ namespace Editor::Assets {
 		bool LoadImportSettings(const std::string& sourcePath) override;
 		bool SaveImportSettings(const std::string& sourcePath) override;
 
+		ModelImportSettings& GetImportSettings();
+
 	private:
 		std::optional<ModelImportSettings> importSettings;
 	};

--- a/Editor/src/AssetManagement/Assets/TextureAsset.cpp
+++ b/Editor/src/AssetManagement/Assets/TextureAsset.cpp
@@ -7,12 +7,12 @@
 #include <stb_image/stb_image.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/prettywriter.h>
+#include <rapidjson/ostreamwrapper.h>
 
+#include <Core/SpdLogger.hpp>
 #include <ResourceManagement/BinaryHeaders/NanoTexHeader.hpp>
 
-#include "../Settings/TextureImportSettings.hpp"
-#include <rapidjson/ostreamwrapper.h>
-#include <Serialisation/ReflectionJson.hpp>
+#include "../../Serialization/JSONReflection.hpp"
 
 namespace Editor::Assets {
 	namespace {
@@ -241,7 +241,7 @@ namespace Editor::Assets {
 			importSettings.emplace();
 
 		const auto& jSettings = doc["textureImport"];
-		NE::Serialization::from_json(jSettings, *importSettings);
+		Deserialization::FromJSON(jSettings, *importSettings);
 
 		return true;
 	}
@@ -253,42 +253,78 @@ namespace Editor::Assets {
 		using rapidjson::OStreamWrapper;
 		using rapidjson::PrettyWriter;
 
-		if (!importSettings) {
-			return true;
+		//fs::path metaPath = fs::path(sourcePath).concat(".meta");
+		//if (!fs::exists(metaPath)) {
+		//	SPD_WARNING("TextureAsset::SaveImportSettings - meta does not exist: "
+		//		<< metaPath.string());
+		//	return false;
+		//}
+
+		//std::ifstream ifs(metaPath);
+		//if (!ifs)
+		//	return false;
+
+		//IStreamWrapper isw(ifs);
+		//Document doc;
+		//doc.ParseStream(isw);
+		//if (doc.HasParseError() || !doc.IsObject())
+		//	return false;
+
+		//auto& alloc = doc.GetAllocator();
+
+		//if (!importSettings) importSettings.emplace();
+		//auto texImportJson = Serialization::ToJSON(*importSettings, alloc);
+
+		//if (doc.HasMember("textureImport") && doc["textureImport"].IsObject()) {
+		//	doc["textureImport"].CopyFrom(texImportJson, alloc);
+		//} else {
+		//	doc.AddMember("textureImport", texImportJson, alloc);
+		//}
+
+		//std::ofstream ofs(metaPath, std::ios::trunc);
+		//if (!ofs)
+		//	return false;
+
+		//OStreamWrapper osw(ofs);
+		//PrettyWriter<OStreamWrapper> writer(osw);
+		//writer.SetIndent(' ', 4);
+		//doc.Accept(writer);
+
+		//return true;
+		std::string metaPath = sourcePath + ".meta";
+
+		rapidjson::Document doc;
+		doc.SetObject();
+
+		if (std::filesystem::exists(metaPath)) {
+			std::ifstream ifs(metaPath);
+			if (ifs) {
+				rapidjson::IStreamWrapper isw(ifs);
+				doc.ParseStream(isw);
+				if (doc.HasParseError() || !doc.IsObject()) {
+					doc.SetObject();
+				}
+			}
 		}
-
-		fs::path metaPath = fs::path(sourcePath).concat(".meta");
-		if (!fs::exists(metaPath)) {
-			SPD_WARNING("TextureAsset::SaveImportSettings - meta does not exist: "
-				<< metaPath.string());
-			return false;
-		}
-
-		std::ifstream ifs(metaPath);
-		if (!ifs)
-			return false;
-
-		IStreamWrapper isw(ifs);
-		Document doc;
-		doc.ParseStream(isw);
-		if (doc.HasParseError() || !doc.IsObject())
-			return false;
 
 		auto& alloc = doc.GetAllocator();
-		auto texImportJson = NE::Serialization::to_json(*importSettings, alloc);
 
-		if (doc.HasMember("textureImport") && doc["textureImport"].IsObject()) {
-			doc["textureImport"].CopyFrom(texImportJson, alloc);
-		} else {
-			doc.AddMember("textureImport", texImportJson, alloc);
+		if (!importSettings) importSettings.emplace();
+		auto jSettings = Serialization::ToJSON(*importSettings, alloc);
+
+		if (doc.HasMember("textureImport"))
+			doc["textureImport"].CopyFrom(jSettings, alloc);
+		else
+			doc.AddMember("textureImport", jSettings, alloc);
+
+		std::ofstream ofs(metaPath);
+		if (!ofs) {
+			SPD_WARNING("Failed to write meta file: " << metaPath);
+			return false;
 		}
 
-		std::ofstream ofs(metaPath, std::ios::trunc);
-		if (!ofs)
-			return false;
-
-		OStreamWrapper osw(ofs);
-		PrettyWriter<OStreamWrapper> writer(osw);
+		rapidjson::OStreamWrapper osw(ofs);
+		rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(osw);
 		writer.SetIndent(' ', 4);
 		doc.Accept(writer);
 

--- a/Editor/src/AssetManagement/Interfaces/ModelSettingsEditor.cpp
+++ b/Editor/src/AssetManagement/Interfaces/ModelSettingsEditor.cpp
@@ -1,1 +1,179 @@
 #include "ModelSettingsEditor.hpp"
+
+#include <imgui/imgui.h>
+
+#include "../AssetManager.hpp"
+#include "../../EditorUI.hpp"
+
+namespace Editor {
+	bool ModelSettingsEditor::LoadModelSettings(std::string filePath, std::string uuid) {
+		m_path = filePath;
+
+		auto* record = Assets::AssetManager::GetInstance().GetRecord(uuid);
+
+		if (!record) return false;
+		if (!record->asset) return false;
+
+		m_model = dynamic_cast<Assets::ModelAsset*>(record->asset.get());
+		if (!m_model) return false;
+
+		if (!m_model->LoadImportSettings(m_path)) return false;
+
+		return true;
+	}
+
+	void ModelSettingsEditor::RenderSettings() {
+		auto& settings = m_model->GetImportSettings();
+
+		static int s_CurrentImportTab = 0;
+
+		const char* tabNames[] = { "Model", "Rig", "Animation", "Materials" };
+		constexpr int tabCount = IM_ARRAYSIZE(tabNames);
+
+		ImGuiStyle& style = ImGui::GetStyle();
+		float fullWidth = ImGui::GetContentRegionAvail().x;
+
+		float totalButtonsWidth = 0.0f;
+		for (int i = 0; i < tabCount; ++i) {
+			ImVec2 textSize = ImGui::CalcTextSize(tabNames[i]);
+			float btnWidth = textSize.x + style.FramePadding.x * 2.0f;
+			totalButtonsWidth += btnWidth;
+			if (i + 1 < tabCount)
+				totalButtonsWidth += style.ItemInnerSpacing.x;
+		}
+
+		float cursorX = (fullWidth - totalButtonsWidth) * 0.5f;
+		if (cursorX < 0.0f) cursorX = 0.0f;
+		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cursorX);
+
+		for (int i = 0; i < tabCount; ++i) {
+			bool isActive = (s_CurrentImportTab == i);
+
+			if (isActive)
+				ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[ImGuiCol_ButtonActive]);
+			else
+				ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[ImGuiCol_Button]);
+
+			if (ImGui::Button(tabNames[i]))
+				s_CurrentImportTab = i;
+
+			ImGui::PopStyleColor();
+
+			if (i + 1 < tabCount)
+				ImGui::SameLine();
+		}
+
+		ImGui::Separator();
+
+		auto DrawComboEnum = [](const char* label, int& currentIndex, const char* const* names, int count) {
+			ImGui::Combo(label, &currentIndex, names, count);
+			};
+
+		switch (s_CurrentImportTab) {
+		case 0:
+		{
+			if (ImGui::CollapsingHeader("Scene##Header", ImGuiTreeNodeFlags_DefaultOpen)) {
+				// SceneImportSettings
+				ImGui::DragFloat("Scale Factor", &settings.scene.scaleFactor, 0.01f, 0.0001f, 100.0f);
+				Editor::DrawCheckbox("Convert Units", settings.scene.convertUnits);
+				Editor::DrawCheckbox("Import Blend Shapes", settings.scene.importBlendShapes);
+				Editor::DrawCheckbox("Import Cameras", settings.scene.importCameras);
+				Editor::DrawCheckbox("Import Lights", settings.scene.importLights);
+				Editor::DrawCheckbox("Preserve Hierarchy", settings.scene.preserveHierarchy);
+			}
+
+			if (ImGui::CollapsingHeader("Mesh##Header", ImGuiTreeNodeFlags_DefaultOpen)) {
+				// MeshImportSettings
+				const char* MeshOptNames[] = { "None", "Everything", "Polygon Order", "Vertex Order" };
+				int meshOptIndex = static_cast<int>(settings.mesh.meshOptimizationMode);
+				DrawComboEnum("Mesh Optimization", meshOptIndex, MeshOptNames, IM_ARRAYSIZE(MeshOptNames));
+				settings.mesh.meshOptimizationMode =
+					static_cast<Assets::MeshImportSettings::MeshOptimizationMode>(meshOptIndex);
+
+				Editor::DrawCheckbox("Generate Colliders", settings.mesh.generateColliders);
+				Editor::DrawCheckbox("Generate Mesh LODs", settings.mesh.generateMeshLODs);
+
+				Editor::DrawCheckbox("Keep Quads", settings.mesh.keepQuads);
+				Editor::DrawCheckbox("Weld Vertices", settings.mesh.weldVertices);
+
+				const char* IndexFormatNames[] = { "Auto", "UInt16", "UInt32" };
+				int indexFmtIndex = static_cast<int>(settings.mesh.indexFormat);
+				DrawComboEnum("Index Format", indexFmtIndex, IndexFormatNames, IM_ARRAYSIZE(IndexFormatNames));
+				settings.mesh.indexFormat = static_cast<Assets::MeshImportSettings::IndexFormat>(indexFmtIndex);
+
+				const char* NormalModeNames[] = { "Import", "Calculate", "None" };
+				int normalIndex = static_cast<int>(settings.mesh.normalMode);
+				DrawComboEnum("Normals", normalIndex, NormalModeNames, IM_ARRAYSIZE(NormalModeNames));
+				settings.mesh.normalMode = static_cast<Assets::MeshImportSettings::NormalMode>(normalIndex);
+
+				ImGui::DragFloat("Smoothing Angle", &settings.mesh.smoothingAngle, 1.0f, 0.0f, 180.0f);
+
+				const char* TangentModeNames[] = { "Import", "Calculate (MikkTSpace)", "None" };
+				int tangentIndex = static_cast<int>(settings.mesh.tangentMode);
+				DrawComboEnum("Tangents", tangentIndex, TangentModeNames, IM_ARRAYSIZE(TangentModeNames));
+				settings.mesh.tangentMode = static_cast<Assets::MeshImportSettings::TangentMode>(tangentIndex);
+
+				Editor::DrawCheckbox("Swap UVs", settings.mesh.swapUVs);
+			}
+			break;
+		}
+
+		case 1: // ----- RIG -----
+		{
+			if (ImGui::CollapsingHeader("Rig##Header", ImGuiTreeNodeFlags_DefaultOpen)) {
+				const char* AnimTypeNames[] = { "None", "Generic", "Humanoid" };
+				int animTypeIndex = static_cast<int>(settings.rig.animationType);
+				DrawComboEnum("Animation Type", animTypeIndex, AnimTypeNames, IM_ARRAYSIZE(AnimTypeNames));
+				settings.rig.animationType = static_cast<Assets::RigImportSettings::AnimationType>(animTypeIndex);
+
+				Editor::DrawCheckbox("Strip Unused Bones", settings.rig.stripBones);
+			}
+			break;
+		}
+
+		case 2: // ----- ANIMATION -----
+		{
+			if (ImGui::CollapsingHeader("Animation##Header", ImGuiTreeNodeFlags_DefaultOpen)) {
+				Editor::DrawCheckbox("Import Animations", settings.animation.importAnimations);
+				Editor::DrawCheckbox("Import Constraints", settings.animation.importConstraints);
+				Editor::DrawCheckbox("Import Animated Custom Properties", settings.animation.importAnimatedCustomProperties);
+				Editor::DrawCheckbox("Auto Split Clips", settings.animation.autoSplitClips);
+
+				ImGui::DragFloat("Sample Rate", &settings.animation.sampleRate, 1.0f, 0.0f, 480.0f, "%.1f");
+
+				Editor::DrawCheckbox("Import Root Motion", settings.animation.importRootMotion);
+				Editor::DrawCheckbox("Lock Root Position XZ", settings.animation.lockRootPositionXZ);
+				Editor::DrawCheckbox("Lock Root Rotation Y", settings.animation.lockRootRotationY);
+			}
+			break;
+		}
+
+		case 3: // ----- MATERIALS -----
+		{
+			if (ImGui::CollapsingHeader("Materials##Header", ImGuiTreeNodeFlags_DefaultOpen)) {
+				Editor::DrawCheckbox("Import Materials", settings.material.importMaterials);
+				Editor::DrawCheckbox("Try Reuse Existing Materials", settings.material.tryReuseExistingMaterials);
+
+				const char* MaterialModeNames[] = { "Per Submesh", "Per Mesh", "Per File" };
+				int matModeIndex = static_cast<int>(settings.material.creationMode);
+				DrawComboEnum("Material Creation", matModeIndex, MaterialModeNames, IM_ARRAYSIZE(MaterialModeNames));
+				settings.material.creationMode =
+					static_cast<Assets::MaterialImportSettings::MaterialCreationMode>(matModeIndex);
+			}
+			break;
+		}
+		}
+
+		ImGui::Spacing();
+		ImGui::Separator();
+
+		if (ImGui::Button("Apply")) {
+			Save();
+		}
+	}
+
+	void ModelSettingsEditor::Save() {
+		m_model->SaveImportSettings(m_path);
+		Assets::AssetManager::GetInstance().ReimportAsset(m_path);
+	}
+}

--- a/Editor/src/AssetManagement/Interfaces/ModelSettingsEditor.hpp
+++ b/Editor/src/AssetManagement/Interfaces/ModelSettingsEditor.hpp
@@ -1,4 +1,18 @@
 #pragma once
-class ModelSettingsEditor {
-};
+#include <string>
+#include "../Assets/ModelAsset.hpp"
 
+namespace Editor {
+
+	class ModelSettingsEditor {
+	public:
+		bool LoadModelSettings(std::string filePath, std::string uuid);
+		void RenderSettings();
+		void Save();
+
+	private:
+		Assets::ModelAsset* m_model;
+		std::string m_path;
+	};
+
+}

--- a/Editor/src/AssetManagement/Interfaces/TextureSettingsEditor.cpp
+++ b/Editor/src/AssetManagement/Interfaces/TextureSettingsEditor.cpp
@@ -1,1 +1,107 @@
 #include "TextureSettingsEditor.hpp"
+
+#include <imgui/imgui.h>
+
+#include "../AssetManager.hpp"
+#include "../../EditorUI.hpp"
+
+namespace Editor {
+	bool TextureSettingsEditor::LoadTextureSettings(std::string filePath, std::string uuid) {
+		m_path = filePath;
+
+		auto* record = Assets::AssetManager::GetInstance().GetRecord(uuid);
+
+		if (!record) return false;
+		if (!record->asset) return false;
+
+		m_texture = dynamic_cast<Assets::TextureAsset*>(record->asset.get());
+		if (!m_texture) return false;
+
+		if (!m_texture->LoadImportSettings(m_path)) return false;
+
+		return true;
+	}
+
+	void TextureSettingsEditor::RenderSettings() {
+		auto& settings = m_texture->GetImportSettings(m_path);
+		static bool s_dirty = false;
+
+		static const char* TextureTypeNames[] = { "Default", "Normal Map", "Sprite" };
+		static const char* TextureShapeNames[] = { "2D", "Cube", "2D Array" };
+		static const char* TextureWrapMode[] = { "Repeat", "Clamp", "Mirror", "MirrorOnce", "PerAxis" };
+		static const char* TextureFilterMode[] = { "Point", "Bilinear", "Trilinear" };
+		static const char* AlphaSourceNames[] = { "InputTextureAlpha", "GrayscaleSource", "None" };
+
+		// ----- Texture Type -----
+		int currentType = static_cast<int>(settings.type); // assuming enum starts at 0
+		if (ImGui::Combo("Texture Type", &currentType, TextureTypeNames, IM_ARRAYSIZE(TextureTypeNames))) {
+			settings.type = static_cast<Assets::TexType>(currentType);
+			s_dirty = true;
+		}
+
+		// ----- Shape -----
+		int currentShape = static_cast<int>(settings.shape); // TextureShape enum
+		if (ImGui::Combo("Texture Shape", &currentShape, TextureShapeNames, IM_ARRAYSIZE(TextureShapeNames))) {
+			settings.shape = static_cast<Assets::TexShape>(currentShape);
+			s_dirty = true;
+		}
+
+		// ----- sRGB -----
+		bool isSRGB = settings.sRGB;
+		if (Editor::DrawCheckbox("sRGB (Color Texture)", isSRGB)) {
+			settings.sRGB = isSRGB;
+			s_dirty = true;
+		}
+
+		// ----- Alpha Source -----
+		int currentAlpha = static_cast<int>(settings.alphaSource); // AlphaSource enum
+		if (ImGui::Combo("Alpha Source", &currentAlpha, AlphaSourceNames, IM_ARRAYSIZE(AlphaSourceNames))) {
+			settings.alphaSource = static_cast<Assets::TexAlphaSource>(currentAlpha);
+			s_dirty = true;
+		}
+
+		// ----- Advanced -----
+		if (ImGui::TreeNode("Advanced")) {
+			bool generateMips = settings.mips.generateMipmap;
+			bool preserveCoverage = settings.mips.preserveCoverage;
+
+			if (Editor::DrawCheckbox("Generate Mipmaps", generateMips)) {
+				settings.mips.generateMipmap = generateMips;
+				s_dirty = true;
+			}
+
+			if (Editor::DrawCheckbox("Preserve Coverage", preserveCoverage)) {
+				settings.mips.preserveCoverage = preserveCoverage;
+				s_dirty = true;
+			}
+
+			ImGui::TreePop();
+		}
+
+		// ----- Filter -----
+		int currentFilter = static_cast<int>(settings.filterMode); // FilterMode enum
+		if (ImGui::Combo("Filter Mode", &currentFilter, TextureFilterMode, IM_ARRAYSIZE(TextureFilterMode))) {
+			settings.filterMode = static_cast<Assets::TexFilterMode>(currentFilter);
+			s_dirty = true;
+		}
+
+		// ----- Wrap -----
+		int currentWrap = static_cast<int>(settings.wrapMode); // WrapMode enum
+		if (ImGui::Combo("Wrap Mode", &currentWrap, TextureWrapMode, IM_ARRAYSIZE(TextureWrapMode))) {
+			settings.wrapMode = static_cast<Assets::TexWrapMode>(currentWrap);
+			s_dirty = true;
+		}
+
+		ImGui::BeginDisabled(!s_dirty);
+		if (ImGui::Button("Apply")) {
+			Save();
+			s_dirty = false;
+		}
+		ImGui::EndDisabled();
+	}
+
+	void TextureSettingsEditor::Save() {
+		m_texture->SaveImportSettings(m_path);
+		Assets::AssetManager::GetInstance().ReimportAsset(m_path);
+	}
+}

--- a/Editor/src/AssetManagement/Interfaces/TextureSettingsEditor.hpp
+++ b/Editor/src/AssetManagement/Interfaces/TextureSettingsEditor.hpp
@@ -1,4 +1,16 @@
 #pragma once
-class TextureSettingsEditor {
-};
+#include <string>
+#include "../Assets/TextureAsset.hpp"
 
+namespace Editor {
+	class TextureSettingsEditor {
+	public:
+		bool LoadTextureSettings(std::string filePath, std::string uuid);
+		void RenderSettings();
+		void Save();
+
+	private:
+		Assets::TextureAsset* m_texture;
+		std::string m_path;
+	};
+}

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -23,7 +23,6 @@
 #include <Math/Vec3.hpp>
 #include "Math/Vec4.hpp"
 #include "../EditorScene.hpp"
-//#include <Engine.hpp>
 #include <imgui/widgets/imsearch/imsearch.h>
 #include "../EditorUI.hpp"
 #include "../Command/EditorSetFieldCommand.hpp"
@@ -206,68 +205,6 @@ namespace {
 			return a == b;
 		}
 	}
-
-	bool LoadModelImportSettings(std::string metaPath, Editor::Assets::ModelImportSettings& settings) {
-		using namespace rapidjson;
-		using namespace NE::Serialization;
-
-		if (!std::filesystem::exists(metaPath))
-			return false;
-
-		std::ifstream ifs(metaPath);
-		if (!ifs) {
-			SPD_WARNING("Failed to read meta file: " << metaPath);
-			return false;
-		}
-
-		IStreamWrapper isw(ifs);
-		Document doc;
-		doc.ParseStream(isw);
-
-		if (doc.HasParseError() || !doc.IsObject()) {
-			SPD_WARNING("Failed to parse JSON in meta file: " << metaPath);
-			return false;
-		}
-
-		if (!doc.HasMember("modelImport") || !doc["modelImport"].IsObject())
-			return true;
-
-		const auto& jSettings = doc["modelImport"];
-		from_json(jSettings, settings);
-
-		return true;
-	}
-
-	//bool LoadTextureImportSettings(std::string metaPath, Editor::Assets::TextureImportSettings& settings) {
-	//	using namespace rapidjson;
-	//	using namespace NE::Serialization;
-
-	//	if (!std::filesystem::exists(metaPath))
-	//		return false;
-
-	//	std::ifstream ifs(metaPath);
-	//	if (!ifs) {
-	//		SPD_WARNING("Failed to read meta file: " << metaPath);
-	//		return false;
-	//	}
-
-	//	IStreamWrapper isw(ifs);
-	//	Document doc;
-	//	doc.ParseStream(isw);
-
-	//	if (doc.HasParseError() || !doc.IsObject()) {
-	//		SPD_WARNING("Failed to parse JSON in meta file: " << metaPath);
-	//		return false;
-	//	}
-
-	//	if (!doc.HasMember("textureImport") || !doc["textureImport"].IsObject())
-	//		return true;
-
-	//	const auto& jSettings = doc["textureImport"];
-	//	from_json(jSettings, settings);
-
-	//	return true;
-	//}
 
 	// temp
 	// Returns true if layer changed
@@ -472,7 +409,7 @@ namespace Editor {
 			ImGui::SetCursorPosX(centeredPosX);
 
 			if (ImGui::Button("Add Component")) {
-				ImGui::OpenPopup("ComponentList"); 
+				ImGui::OpenPopup("ComponentList");
 			}
 
 			if (ImGui::BeginPopup("ComponentList")) { // automate this next time with a registry
@@ -504,18 +441,36 @@ namespace Editor {
 
 				ImGui::EndPopup();
 			}
-		}
-		else if (EditorScene::selectedAsset != "") {
+		} else if (EditorScene::selectedAsset != "") {
 			std::filesystem::path assetPath = EditorScene::selectedAsset;
 
 			if (assetPath.extension() == ".png" || assetPath.extension() == ".jpg") {
-				RenderTextureImportSettings(assetPath.string() + ".meta");
-			}
-			else if (assetPath.extension() == ".obj" || assetPath.extension() == ".fbx") {
-				RenderModelImportSettings(assetPath.string() + ".meta");
-			}
-			else if (assetPath.extension() == ".nanomat") {
-				//RenderMaterialSettings();
+				if (!m_textureEditor || m_lastPath != assetPath.string()) {
+					m_textureEditor = std::make_unique<TextureSettingsEditor>();
+					if (m_textureEditor->LoadTextureSettings(assetPath.string(), Assets::AssetManager::GetInstance().RetrieveUUID(assetPath.string())))
+						m_lastPath = assetPath.string();
+					else {
+						ImGui::TextUnformatted("Failed to load texture import settings.");
+						m_textureEditor.reset();
+					}
+				}
+
+				if (m_textureEditor)
+					m_textureEditor->RenderSettings();
+			} else if (assetPath.extension() == ".obj" || assetPath.extension() == ".fbx") {
+				if (!m_modelEditor || m_lastPath != assetPath.string()) {
+					m_modelEditor = std::make_unique<ModelSettingsEditor>();
+					if (m_modelEditor->LoadModelSettings(assetPath.string(), Assets::AssetManager::GetInstance().RetrieveUUID(assetPath.string())))
+						m_lastPath = assetPath.string();
+					else {
+						ImGui::TextUnformatted("Failed to load model import settings.");
+						m_modelEditor.reset();
+					}
+				}
+
+				if (m_modelEditor)
+					m_modelEditor->RenderSettings();
+			} else if (assetPath.extension() == ".nanomat") {
 				if (!m_materialEditor || m_lastPath != assetPath.string()) {
 					m_materialEditor = std::make_unique<MaterialEditor>();
 					if (m_materialEditor->LoadMaterial(assetPath.string(), Assets::AssetManager::GetInstance().RetrieveUUID(assetPath.string())))
@@ -535,260 +490,6 @@ namespace Editor {
 		}
 		ImGui::End();
 
-	}
-
-	void InspectorPanel::RenderTextureImportSettings(std::string metaPath) {
-		//static std::string s_LastMetaPath;
-		//static TextureImportSettings s_Settings{};
-		//static bool s_Loaded = false;
-		//static bool s_dirty = false;
-
-		//if (!s_Loaded || metaPath != s_LastMetaPath) {
-		//	if (!LoadTextureImportSettings(metaPath, s_Settings)) {
-		//		ImGui::TextUnformatted("Failed to load texture import settings.");
-		//		return;
-		//	}
-
-		//	s_LastMetaPath = metaPath;
-		//	s_Loaded = true;
-		//}
-
-		//static const char* TextureTypeNames[] = { "Default", "Normal Map", "Sprite" };
-		//static const char* TextureShapeNames[] = { "2D", "Cube", "2D Array" };
-		//static const char* TextureWrapMode[] = { "Repeat", "Clamp", "Mirror", "MirrorOnce", "PerAxis" };
-		//static const char* TextureFilterMode[] = { "Point", "Bilinear", "Trilinear" };
-		//static const char* AlphaSourceNames[] = { "InputTextureAlpha", "GrayscaleSource", "None" };
-
-		//// ----- Texture Type -----
-		//int currentType = static_cast<int>(s_Settings.type); // assuming enum starts at 0
-		//if (ImGui::Combo("Texture Type", &currentType, TextureTypeNames, IM_ARRAYSIZE(TextureTypeNames))) {
-		//	s_Settings.type = static_cast<TexType>(currentType);
-		//	s_dirty = true;
-		//}
-
-		//// ----- Shape -----
-		//int currentShape = static_cast<int>(s_Settings.shape); // TextureShape enum
-		//if (ImGui::Combo("Texture Shape", &currentShape, TextureShapeNames, IM_ARRAYSIZE(TextureShapeNames))) {
-		//	s_Settings.shape = static_cast<TexShape>(currentShape);
-		//	s_dirty = true;
-		//}
-
-		//// ----- sRGB -----
-		//bool isSRGB = s_Settings.sRGB;
-		//if (Editor::DrawCheckbox("sRGB (Color Texture)", isSRGB)) {
-		//	s_Settings.sRGB = isSRGB;
-		//	s_dirty = true;
-		//}
-
-		//// ----- Alpha Source -----
-		//int currentAlpha = static_cast<int>(s_Settings.alphaSource); // AlphaSource enum
-		//if (ImGui::Combo("Alpha Source", &currentAlpha, AlphaSourceNames, IM_ARRAYSIZE(AlphaSourceNames))) {
-		//	s_Settings.alphaSource = static_cast<TexAlphaSource>(currentAlpha);
-		//	s_dirty = true;
-		//}
-
-		//// ----- Advanced -----
-		//if (ImGui::TreeNode("Advanced")) {
-		//	bool generateMips = s_Settings.mips.generateMipmap;
-		//	bool preserveCoverage = s_Settings.mips.preserveCoverage;
-
-		//	if (Editor::DrawCheckbox("Generate Mipmaps", generateMips)) {
-		//		s_Settings.mips.generateMipmap = generateMips;
-		//		s_dirty = true;
-		//	}
-
-		//	if (Editor::DrawCheckbox("Preserve Coverage", preserveCoverage)) {
-		//		s_Settings.mips.preserveCoverage = preserveCoverage;
-		//		s_dirty = true;
-		//	}
-
-		//	ImGui::TreePop();
-		//}
-
-		//// ----- Filter -----
-		//int currentFilter = static_cast<int>(s_Settings.filterMode); // FilterMode enum
-		//if (ImGui::Combo("Filter Mode", &currentFilter, TextureFilterMode, IM_ARRAYSIZE(TextureFilterMode))) {
-		//	s_Settings.filterMode = static_cast<TexFilterMode>(currentFilter);
-		//	s_dirty = true;
-		//}
-
-		//// ----- Wrap -----
-		//int currentWrap = static_cast<int>(s_Settings.wrapMode); // WrapMode enum
-		//if (ImGui::Combo("Wrap Mode", &currentWrap, TextureWrapMode, IM_ARRAYSIZE(TextureWrapMode))) {
-		//	s_Settings.wrapMode = static_cast<TexWrapMode>(currentWrap);
-		//	s_dirty = true;
-		//}
-
-		//ImGui::BeginDisabled(!s_dirty);
-		//if (ImGui::Button("Apply")) {
-		//	if (!AssetManager::GetInstance().SaveTextureImportSettings(metaPath, s_Settings)) {
-		//		SPD_WARNING("Failed to save texture import settings for: " << metaPath);
-		//	}
-		//	else {
-		//		AssetManager::GetInstance().ReimportAsset(metaPath);
-		//	}
-
-		//	s_dirty = false;
-		//}
-		//ImGui::EndDisabled();
-	}
-
-	void InspectorPanel::RenderModelImportSettings(const std::string& metaPath) {
-		//static std::string s_LastMetaPath;
-		//static ModelImportSettings s_Settings{};
-		//static bool s_Loaded = false;
-
-		Assets::ModelImportSettings settings{};
-		if (!LoadModelImportSettings(metaPath, settings)) {
-			ImGui::TextUnformatted("Failed to load model import settings.");
-			return;
-		}
-
-		static int s_CurrentImportTab = 0;
-
-		const char* tabNames[] = { "Model", "Rig", "Animation", "Materials" };
-		constexpr int tabCount = IM_ARRAYSIZE(tabNames);
-
-		ImGuiStyle& style = ImGui::GetStyle();
-		float fullWidth = ImGui::GetContentRegionAvail().x;
-
-		float totalButtonsWidth = 0.0f;
-		for (int i = 0; i < tabCount; ++i) {
-			ImVec2 textSize = ImGui::CalcTextSize(tabNames[i]);
-			float btnWidth = textSize.x + style.FramePadding.x * 2.0f;
-			totalButtonsWidth += btnWidth;
-			if (i + 1 < tabCount)
-				totalButtonsWidth += style.ItemInnerSpacing.x;
-		}
-
-		float cursorX = (fullWidth - totalButtonsWidth) * 0.5f;
-		if (cursorX < 0.0f) cursorX = 0.0f;
-		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cursorX);
-
-		for (int i = 0; i < tabCount; ++i) {
-			bool isActive = (s_CurrentImportTab == i);
-
-			if (isActive)
-				ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[ImGuiCol_ButtonActive]);
-			else
-				ImGui::PushStyleColor(ImGuiCol_Button, style.Colors[ImGuiCol_Button]);
-
-			if (ImGui::Button(tabNames[i]))
-				s_CurrentImportTab = i;
-
-			ImGui::PopStyleColor();
-
-			if (i + 1 < tabCount)
-				ImGui::SameLine();
-		}
-
-		ImGui::Separator();
-
-		auto DrawComboEnum = [](const char* label, int& currentIndex, const char* const* names, int count) {
-			ImGui::Combo(label, &currentIndex, names, count);
-			};
-
-		switch (s_CurrentImportTab) {
-		case 0:
-		{
-			if (ImGui::CollapsingHeader("Scene", ImGuiTreeNodeFlags_DefaultOpen)) {
-				// SceneImportSettings
-				ImGui::DragFloat("Scale Factor", &settings.scene.scaleFactor, 0.01f, 0.0001f, 100.0f);
-				Editor::DrawCheckbox("Convert Units", settings.scene.convertUnits);
-				Editor::DrawCheckbox("Import Blend Shapes", settings.scene.importBlendShapes);
-				Editor::DrawCheckbox("Import Cameras", settings.scene.importCameras);
-				Editor::DrawCheckbox("Import Lights", settings.scene.importLights);
-				Editor::DrawCheckbox("Preserve Hierarchy", settings.scene.preserveHierarchy);
-			}
-
-			if (ImGui::CollapsingHeader("Mesh", ImGuiTreeNodeFlags_DefaultOpen)) {
-				// MeshImportSettings
-				const char* MeshOptNames[] = { "None", "Everything", "Polygon Order", "Vertex Order" };
-				int meshOptIndex = static_cast<int>(settings.mesh.meshOptimizationMode);
-				DrawComboEnum("Mesh Optimization", meshOptIndex, MeshOptNames, IM_ARRAYSIZE(MeshOptNames));
-				settings.mesh.meshOptimizationMode =
-					static_cast<Assets::MeshImportSettings::MeshOptimizationMode>(meshOptIndex);
-
-				Editor::DrawCheckbox("Generate Colliders", settings.mesh.generateColliders);
-				Editor::DrawCheckbox("Generate Mesh LODs", settings.mesh.generateMeshLODs);
-
-				Editor::DrawCheckbox("Keep Quads", settings.mesh.keepQuads);
-				Editor::DrawCheckbox("Weld Vertices", settings.mesh.weldVertices);
-
-				const char* IndexFormatNames[] = { "Auto", "UInt16", "UInt32" };
-				int indexFmtIndex = static_cast<int>(settings.mesh.indexFormat);
-				DrawComboEnum("Index Format", indexFmtIndex, IndexFormatNames, IM_ARRAYSIZE(IndexFormatNames));
-				settings.mesh.indexFormat = static_cast<Assets::MeshImportSettings::IndexFormat>(indexFmtIndex);
-
-				const char* NormalModeNames[] = { "Import", "Calculate", "None" };
-				int normalIndex = static_cast<int>(settings.mesh.normalMode);
-				DrawComboEnum("Normals", normalIndex, NormalModeNames, IM_ARRAYSIZE(NormalModeNames));
-				settings.mesh.normalMode = static_cast<Assets::MeshImportSettings::NormalMode>(normalIndex);
-
-				ImGui::DragFloat("Smoothing Angle", &settings.mesh.smoothingAngle, 1.0f, 0.0f, 180.0f);
-
-				const char* TangentModeNames[] = { "Import", "Calculate (MikkTSpace)", "None" };
-				int tangentIndex = static_cast<int>(settings.mesh.tangentMode);
-				DrawComboEnum("Tangents", tangentIndex, TangentModeNames, IM_ARRAYSIZE(TangentModeNames));
-				settings.mesh.tangentMode = static_cast<Assets::MeshImportSettings::TangentMode>(tangentIndex);
-
-				Editor::DrawCheckbox("Swap UVs", settings.mesh.swapUVs);
-			}
-			break;
-		}
-
-		case 1: // ----- RIG -----
-		{
-			if (ImGui::CollapsingHeader("Rig", ImGuiTreeNodeFlags_DefaultOpen)) {
-				const char* AnimTypeNames[] = { "None", "Generic", "Humanoid" };
-				int animTypeIndex = static_cast<int>(settings.rig.animationType);
-				DrawComboEnum("Animation Type", animTypeIndex, AnimTypeNames, IM_ARRAYSIZE(AnimTypeNames));
-				settings.rig.animationType = static_cast<Assets::RigImportSettings::AnimationType>(animTypeIndex);
-
-				Editor::DrawCheckbox("Strip Unused Bones", settings.rig.stripBones);
-			}
-			break;
-		}
-
-		case 2: // ----- ANIMATION -----
-		{
-			if (ImGui::CollapsingHeader("Animation", ImGuiTreeNodeFlags_DefaultOpen)) {
-				Editor::DrawCheckbox("Import Animations", settings.animation.importAnimations);
-				Editor::DrawCheckbox("Import Constraints", settings.animation.importConstraints);
-				Editor::DrawCheckbox("Import Animated Custom Properties", settings.animation.importAnimatedCustomProperties);
-				Editor::DrawCheckbox("Auto Split Clips", settings.animation.autoSplitClips);
-
-				ImGui::DragFloat("Sample Rate", &settings.animation.sampleRate, 1.0f, 0.0f, 480.0f, "%.1f");
-
-				Editor::DrawCheckbox("Import Root Motion", settings.animation.importRootMotion);
-				Editor::DrawCheckbox("Lock Root Position XZ", settings.animation.lockRootPositionXZ);
-				Editor::DrawCheckbox("Lock Root Rotation Y", settings.animation.lockRootRotationY);
-			}
-			break;
-		}
-
-		case 3: // ----- MATERIALS -----
-		{
-			if (ImGui::CollapsingHeader("Materials", ImGuiTreeNodeFlags_DefaultOpen)) {
-				Editor::DrawCheckbox("Import Materials", settings.material.importMaterials);
-				Editor::DrawCheckbox("Try Reuse Existing Materials", settings.material.tryReuseExistingMaterials);
-
-				const char* MaterialModeNames[] = { "Per Submesh", "Per Mesh", "Per File" };
-				int matModeIndex = static_cast<int>(settings.material.creationMode);
-				DrawComboEnum("Material Creation", matModeIndex, MaterialModeNames, IM_ARRAYSIZE(MaterialModeNames));
-				settings.material.creationMode =
-					static_cast<Assets::MaterialImportSettings::MaterialCreationMode>(matModeIndex);
-			}
-			break;
-		}
-		}
-
-		ImGui::Spacing();
-		ImGui::Separator();
-
-		if (ImGui::Button("Apply")) {
-			//SaveModelImportSettings(metaPath, settings);
-		}
 	}
 
 	void InspectorPanel::DrawEntityMetaComponent(uint32_t entity) {

--- a/Editor/src/Panels/InspectorPanel.hpp
+++ b/Editor/src/Panels/InspectorPanel.hpp
@@ -7,8 +7,11 @@
 #include <ECS/Core/Component.hpp>
 #include <Graphics/Core/Material.hpp>
 #include "../AssetManagement/Interfaces/MaterialEditor.hpp"
+#include "../AssetManagement/Interfaces/ModelSettingsEditor.hpp"
+#include "../AssetManagement/Interfaces/TextureSettingsEditor.hpp"
 
 namespace Editor {
+
 	class InspectorPanel : public IPanel {
 	public:
 		InspectorPanel();
@@ -25,9 +28,9 @@ namespace Editor {
 
 		std::vector<Drawer> m_drawers;
 
-		void RenderTextureImportSettings(std::string metaPath);
+		//void RenderTextureImportSettings(std::string metaPath);
 
-		void RenderModelImportSettings(const std::string& metaPath);
+		//void RenderModelImportSettings(const std::string& metaPath);
 
 		void DrawEntityMetaComponent(uint32_t entity);
 		void DrawTransformComponent(uint32_t entity);
@@ -45,6 +48,8 @@ namespace Editor {
 		
 
 		std::unique_ptr<MaterialEditor> m_materialEditor;
+		std::unique_ptr<ModelSettingsEditor> m_modelEditor;
+		std::unique_ptr<TextureSettingsEditor> m_textureEditor;
 		std::string m_lastPath;
 
 	};


### PR DESCRIPTION
Moved model and texture import settings UI logic into dedicated ModelSettingsEditor and TextureSettingsEditor classes. Updated InspectorPanel to use these new editors for asset inspection, removing legacy code for direct settings rendering. Improved asset import settings serialization/deserialization and ensured settings are loaded, edited, and saved through the new interfaces.