### PR TITLE
Persist editor camera and user settings across sessions

### DIFF
--- a/Editor/src/Application.cpp
+++ b/Editor/src/Application.cpp
@@ -102,7 +102,11 @@ namespace Editor {
 
 		editorLayer.AddPanel<AssetBrowserPanel>("Assets/");
 		editorLayer.AddPanel<ScriptsPanel>("../../../ChronoGame/Scripts/");
-		EditorScene::s_currentSceneUUID = Assets::AssetManager::GetInstance().GetRecordBySource(EditorScene::s_currentScenePath)->id;
+		Deserialization::JSON::DeserializeUserSettings();
+		if (EditorScene::s_currentScenePath.empty() || EditorScene::s_currentSceneUUID.empty()) {
+			EditorScene::s_currentScenePath = "Assets/NewScene.scene";
+			EditorScene::s_currentSceneUUID = Assets::AssetManager::GetInstance().GetRecordBySource(EditorScene::s_currentScenePath)->id;
+		}
 		if (!NE::LoadScene(EditorScene::s_currentSceneUUID)) {
 			SPD_ERROR("Failed to load scene binary, attempting fallback deserialization.");
 			NE::CreateSceneFallback(EditorScene::s_currentSceneUUID);
@@ -191,6 +195,7 @@ namespace Editor {
 		ShutdownImGui();
 
 		Serialization::JSON::SerializeProjectSettings();
+		Serialization::JSON::SerializeUserSettings();
 
 		NE::Shutdown();
 	}

--- a/Editor/src/EditorScene.cpp
+++ b/Editor/src/EditorScene.cpp
@@ -6,8 +6,8 @@
 namespace Editor {
     std::vector<NE::ECS::Entity> EditorScene::s_rootOrder;
     EditorSelection EditorScene::s_selection;
-    std::string EditorScene::s_currentSceneUUID;
-    std::string EditorScene::s_currentScenePath("Assets/NewScene.scene"); // temp
+    std::string EditorScene::s_currentSceneUUID("Assets/NewScene.scene");
+    std::string EditorScene::s_currentScenePath; // temp
     Layers::LayerDatabase EditorScene::layerDatabase;
 
     std::string EditorScene::selectedAsset;
@@ -15,6 +15,13 @@ namespace Editor {
     std::vector<uint8_t> EditorScene::clipboard;
 
     NE::Graphics::EditorCamera EditorScene::m_editorCamera;
+    float EditorScene::m_cameraSpeed = 1.0f;
+    bool EditorScene::m_cameraUseEasing = false;
+    bool EditorScene::m_cameraUseAcceleration = false;
+    float EditorScene::m_cameraMinSpeed = 0.01f;
+    float EditorScene::m_cameraMaxSpeed = 2.f;
+    float EditorScene::m_cameraYaw = -90.0f;  // looking along -Z
+    float EditorScene::m_cameraPitch = 0.0f;
 
     bool EditorScene::isDirty = false;
 

--- a/Editor/src/EditorScene.hpp
+++ b/Editor/src/EditorScene.hpp
@@ -23,6 +23,13 @@ namespace Editor {
         static Layers::LayerDatabase layerDatabase;
 
         static NE::Graphics::EditorCamera m_editorCamera;
+        static float m_cameraSpeed;
+        static bool m_cameraUseEasing;
+        static bool m_cameraUseAcceleration;
+        static float m_cameraMinSpeed;
+        static float m_cameraMaxSpeed;
+        static float m_cameraYaw;  // looking along -Z
+        static float m_cameraPitch;
 
         static std::vector<uint8_t> clipboard;
 

--- a/Editor/src/Panels/ScenePanel.cpp
+++ b/Editor/src/Panels/ScenePanel.cpp
@@ -72,9 +72,9 @@ namespace Editor {
 	}
 
 	ScenePanel::ScenePanel() {
-		NE::Math::Vec3 position = { 0.0f, 0.0f, 10.0f };
-		NE::Math::Vec3 target = { 0.0f, 0.0f, 0.0f };
-		NE::Math::Vec3 up = { 0.0f, 1.0f, 0.0f };
+		//NE::Math::Vec3 position = { 0.0f, 0.0f, 10.0f };
+		//NE::Math::Vec3 target = { 0.0f, 0.0f, 0.0f };
+		//NE::Math::Vec3 up = { 0.0f, 1.0f, 0.0f };
 
 		m_fov = 60;
 		m_aspectRatio = 1920.f / 1080.f;
@@ -82,8 +82,8 @@ namespace Editor {
 		m_farPlane = 1000.0f;
 
 		EditorScene::m_editorCamera.SetPerspective(m_fov, m_aspectRatio, m_nearPlane, m_farPlane);
-		EditorScene::m_editorCamera.SetPosition(position);
-		EditorScene::m_editorCamera.LookAt(target, up);
+		//EditorScene::m_editorCamera.SetPosition(position);
+		//EditorScene::m_editorCamera.LookAt(target, up);
 
 		// Give address of the editor camera to the scene camera tweener
 		sceneCameraTweener.SetSceneCamera(&EditorScene::m_editorCamera);
@@ -160,14 +160,14 @@ namespace Editor {
 				}
 
 				ImGui::Text("Navigation");
-				Editor::DrawCheckbox("Camera Easing", m_cameraUseEasing);
-				Editor::DrawCheckbox("Camera Acceleration", m_cameraUseAcceleration);
+				Editor::DrawCheckbox("Camera Easing", EditorScene::m_cameraUseEasing);
+				Editor::DrawCheckbox("Camera Acceleration", EditorScene::m_cameraUseAcceleration);
 				Editor::DrawFloatSliderWithField(
-					"Camera Speed", m_cameraSpeed, m_cameraMinSpeed, m_cameraMaxSpeed, 0.01f, true
+					"Camera Speed", EditorScene::m_cameraSpeed, EditorScene::m_cameraMinSpeed, EditorScene::m_cameraMaxSpeed, 0.01f, true
 				);
 				ImGui::Indent(50.f);
-				Editor::DrawFloatField("Min", m_cameraMinSpeed, 0.01f, true);
-				Editor::DrawFloatField("Max", m_cameraMaxSpeed, 0.01f, true);
+				Editor::DrawFloatField("Min", EditorScene::m_cameraMinSpeed, 0.01f, true);
+				Editor::DrawFloatField("Max", EditorScene::m_cameraMaxSpeed, 0.01f, true);
 				ImGui::Unindent(50.f);
 
 				ImGui::EndPopup();
@@ -450,22 +450,22 @@ namespace Editor {
 				bool boost = ImGui::IsKeyDown(ImGuiKey_LeftShift) || ImGui::IsKeyDown(ImGuiKey_RightShift);
 
 				if (hasInput) {
-					if (m_cameraUseAcceleration) {
+					if (EditorScene::m_cameraUseAcceleration) {
 						if (m_currentMoveSpeed <= 0.0f) {
-							m_currentMoveSpeed = boost ? m_cameraMaxSpeed : m_cameraMinSpeed;
+							m_currentMoveSpeed = boost ? EditorScene::m_cameraMaxSpeed : EditorScene::m_cameraMinSpeed;
 						}
 
 						m_currentMoveSpeed += m_cameraAcceleration * deltaTime;
 
-						if (!boost && m_currentMoveSpeed > m_cameraMaxSpeed) {
-							m_currentMoveSpeed = m_cameraMaxSpeed;
+						if (!boost && m_currentMoveSpeed > EditorScene::m_cameraMaxSpeed) {
+							m_currentMoveSpeed = EditorScene::m_cameraMaxSpeed;
 						}
 					} else {
-						m_currentMoveSpeed = boost ? m_cameraMaxSpeed : m_cameraSpeed;
+						m_currentMoveSpeed = boost ? EditorScene::m_cameraMaxSpeed : EditorScene::m_cameraSpeed;
 					}
 				} else {
 					// No input but RMB still held
-					if (m_cameraUseEasing) {
+					if (EditorScene::m_cameraUseEasing) {
 						m_currentMoveSpeed -= m_cameraDeceleration * deltaTime;
 						if (m_currentMoveSpeed < 0.0f)
 							m_currentMoveSpeed = 0.0f;
@@ -497,11 +497,11 @@ namespace Editor {
 				ImVec2 delta = { io.MousePos.x - m_lastMousePos.x, io.MousePos.y - m_lastMousePos.y };
 				m_lastMousePos = io.MousePos;
 
-				m_cameraYaw += delta.x * m_mouseSensitivity;
-				m_cameraPitch -= delta.y * m_mouseSensitivity;
+				EditorScene::m_cameraYaw += delta.x * m_mouseSensitivity;
+				EditorScene::m_cameraPitch -= delta.y * m_mouseSensitivity;
 
-				if (m_cameraPitch > 89.0f) m_cameraPitch = 89.0f;
-				if (m_cameraPitch < -89.0f) m_cameraPitch = -89.0f;
+				if (EditorScene::m_cameraPitch > 89.0f) EditorScene::m_cameraPitch = 89.0f;
+				if (EditorScene::m_cameraPitch < -89.0f) EditorScene::m_cameraPitch = -89.0f;
 			} else {
 				m_rightMouseHeld = false;
 				m_currentMoveSpeed = 0.0f;
@@ -741,9 +741,9 @@ namespace Editor {
 
 		// Calculate camera's look direction regardless of input
 		Vec3 dir;
-		dir.x = cosf(Radians(m_cameraYaw)) * cosf(Radians(m_cameraPitch));
-		dir.y = sinf(Radians(m_cameraPitch));
-		dir.z = sinf(Radians(m_cameraYaw)) * cosf(Radians(m_cameraPitch));
+		dir.x = cosf(Radians(EditorScene::m_cameraYaw)) * cosf(Radians(EditorScene::m_cameraPitch));
+		dir.y = sinf(Radians(EditorScene::m_cameraPitch));
+		dir.z = sinf(Radians(EditorScene::m_cameraYaw)) * cosf(Radians(EditorScene::m_cameraPitch));
 		EditorScene::m_editorCamera.LookAt(EditorScene::m_editorCamera.GetPosition() + dir, Vec3(0, 1, 0));
 
 		NE::UpdateEditorCameraData();

--- a/Editor/src/Panels/ScenePanel.hpp
+++ b/Editor/src/Panels/ScenePanel.hpp
@@ -19,14 +19,14 @@ namespace Editor {
 			ImVec2 panelPos,
 			ImVec2 panelSize);
 
-		float m_cameraYaw = -90.0f;  // looking along -Z
-		float m_cameraPitch = 0.0f;
+		//float m_cameraYaw = -90.0f;  // looking along -Z
+		//float m_cameraPitch = 0.0f;
 
-		float m_cameraSpeed = 1.0f;
-		bool m_cameraUseEasing = false;
-		bool m_cameraUseAcceleration = false;
-		float m_cameraMinSpeed = 0.01f;
-		float m_cameraMaxSpeed = 2.f;
+		//float m_cameraSpeed = 1.0f;
+		//bool m_cameraUseEasing = false;
+		//bool m_cameraUseAcceleration = false;
+		//float m_cameraMinSpeed = 0.01f;
+		//float m_cameraMaxSpeed = 2.f;
 		NE::Math::Vec3 m_lastMoveDir{ 0.0f, 0.0f, 0.0f };
 		// Accel behaviour
 		float m_cameraAcceleration = 1.5f;  // units/sec^2

--- a/Editor/src/Serialization/Serializer.cpp
+++ b/Editor/src/Serialization/Serializer.cpp
@@ -61,8 +61,11 @@ namespace Editor {
 
 		std::string projectSettingsLoc = "ProjectSettings/";
 		std::string layerSettingsLoc = projectSettingsLoc + "LayerSettings.json";
-
 		constexpr uint32_t kLayerSettingsVersion = 1;
+
+		std::string userSettingsFolder = "UserSettings/";
+		std::string userSettingsLoc = userSettingsFolder + "UserSettings.json";
+		constexpr uint32_t kUserSettingsVersion = 1;
 
 		bool ReadAllText(const std::filesystem::path& p, std::string& out)
 		{
@@ -273,7 +276,35 @@ namespace Editor {
 			}
 
 			void SerializeUserSettings() {
+				namespace fs = std::filesystem;
 
+				fs::create_directories(userSettingsFolder);
+
+				rapidjson::Document doc;
+				doc.SetObject();
+				auto& a = doc.GetAllocator();
+
+				doc.AddMember("version", kUserSettingsVersion, a);
+				doc.AddMember("sessionScenePath", ToJSON(EditorScene::s_currentScenePath, a), a);
+				doc.AddMember("sessionSceneUUID", ToJSON(EditorScene::s_currentSceneUUID, a), a);
+
+				rapidjson::Value obj(rapidjson::kObjectType);
+				obj.AddMember("position", ToJSON(EditorScene::m_editorCamera.GetPosition(), a), a);
+				obj.AddMember("yaw", ToJSON(EditorScene::m_cameraYaw, a), a);
+				obj.AddMember("pitch", ToJSON(EditorScene::m_cameraPitch, a), a);
+				obj.AddMember("speed", ToJSON(EditorScene::m_cameraSpeed, a), a);
+				obj.AddMember("minSpeed", ToJSON(EditorScene::m_cameraMinSpeed, a), a);
+				obj.AddMember("maxSpeed", ToJSON(EditorScene::m_cameraMaxSpeed, a), a);
+				obj.AddMember("hasEasing", ToJSON(EditorScene::m_cameraUseEasing, a), a);
+				obj.AddMember("hasAcceleration", ToJSON(EditorScene::m_cameraUseAcceleration, a), a);
+
+				doc.AddMember("editorCamera", obj, a);
+
+				rapidjson::StringBuffer sb;
+				rapidjson::PrettyWriter<rapidjson::StringBuffer> w(sb);
+				doc.Accept(w);
+
+				WriteAllText(userSettingsLoc, sb.GetString());
 			}
 		}
 	}
@@ -317,9 +348,11 @@ namespace Editor {
 				for (auto& entVal : doc["Entities"].GetArray()) {
 					NE::ECS::Entity e = NE::ECS::Command::CreateEntityNoComponents();
 
-					uint8_t layer = 0;
-					FromJSON(entVal["Layer"], layer);
-					NE::ECS::Command::SetLayer(e, layer);
+					if (doc.HasMember("Layer")) {
+						uint8_t layer = 0;
+						FromJSON(entVal["Layer"], layer);
+						NE::ECS::Command::SetLayer(e, layer);
+					}
 
 					ForEachComponentType([&]<typename C>() {
 						ReadComponentIfPresent<C>(e, entVal);
@@ -331,7 +364,7 @@ namespace Editor {
 				namespace fs = std::filesystem;
 				using namespace NE::Core;
 
-				fs::create_directories(projectSettingsLoc);
+				//fs::create_directories(projectSettingsLoc);
 
 				Editor::Layers::LayerDatabase db;
 
@@ -405,6 +438,52 @@ namespace Editor {
 
 				for (LayerID i = 0; i < MAX_LAYERS; ++i)
 					db.SetCollisionMask(i, symMasks[i]);
+			}
+
+			void DeserializeUserSettings() {
+				namespace fs = std::filesystem;
+
+				if (!fs::exists(userSettingsLoc)) {
+					Serialization::JSON::SerializeUserSettings();
+					return;
+				}
+				std::string text;
+				if (!ReadAllText(userSettingsLoc, text))
+					return;
+
+				rapidjson::Document doc;
+				doc.Parse(text.c_str());
+				if (doc.HasParseError() || !doc.IsObject())
+					return;
+
+				if (doc.HasMember("sessionScenePath") && doc["sessionScenePath"].IsString())
+					EditorScene::s_currentScenePath = doc["sessionScenePath"].GetString();
+
+				if (doc.HasMember("sessionSceneUUID") && doc["sessionSceneUUID"].IsString())
+					EditorScene::s_currentSceneUUID = doc["sessionSceneUUID"].GetString();
+
+				if (doc.HasMember("editorCamera") && doc["editorCamera"].IsObject()) {
+					auto& camObj = doc["editorCamera"];
+					if (camObj.HasMember("position")) {
+						NE::Math::Vec3 position{ 0.f, 0.f, 0.f };
+						FromJSON(camObj["position"], position);
+						EditorScene::m_editorCamera.SetPosition(position);
+					}
+					if (camObj.HasMember("yaw"))
+						FromJSON(camObj["yaw"], EditorScene::m_cameraYaw);
+					if (camObj.HasMember("pitch"))
+						FromJSON(camObj["pitch"], EditorScene::m_cameraPitch);
+					if (camObj.HasMember("speed"))
+						FromJSON(camObj["speed"], EditorScene::m_cameraSpeed);
+					if (camObj.HasMember("minSpeed"))
+						FromJSON(camObj["minSpeed"], EditorScene::m_cameraMinSpeed);
+					if (camObj.HasMember("maxSpeed"))
+						FromJSON(camObj["maxSpeed"], EditorScene::m_cameraMaxSpeed);
+					if (camObj.HasMember("hasEasing"))
+						FromJSON(camObj["hasEasing"], EditorScene::m_cameraUseEasing);
+					if (camObj.HasMember("hasAcceleration"))
+						FromJSON(camObj["hasAcceleration"], EditorScene::m_cameraUseAcceleration);
+				}
 			}
 		}
 	}

--- a/NANOEngine/src/Graphics/Core/EditorCamera.hpp
+++ b/NANOEngine/src/Graphics/Core/EditorCamera.hpp
@@ -31,7 +31,6 @@ namespace NE::Graphics {
         const float& GetNearPlane() const;
 		const float& GetFarPlane() const;
         Vec3 GetForward() const;
-
     private:
         Vec3 m_position;
         Vec3 m_target;


### PR DESCRIPTION
Introduces serialization and deserialization of user settings, including editor camera parameters (position, yaw, pitch, speed, etc.) and session scene info. Moves camera navigation state from ScenePanel to EditorScene for global access and persistence. Updates initialization and shutdown logic to load and save user settings, ensuring a consistent user experience between sessions.