### PR TITLE
Fixed reloading prefab

### DIFF
--- a/NANOEngine/src/Serialisation/Serializer.cpp
+++ b/NANOEngine/src/Serialisation/Serializer.cpp
@@ -578,8 +578,12 @@ namespace NE {
 				const bool skipFirst = (i == 0);
 
 				ECS::Entity e = ECS::Component::INVALID_PARENT;
+				uint8_t layer;
+				ReadT(it, end, layer);
+
 				if (!skipFirst) {
 					e = ecs.CreateEntity();
+					ecs.GetEntityManager().SetLayer(e, layer);
 					created.push_back(e);
 				}
 


### PR DESCRIPTION
Cause: Misaligned binary due to missing layer deserialization

Fix: Added deserialization of layer into reload prefab