### PR TITLE
Add LayerRef script field type and editor dropdown support

### DIFF
--- a/ChronoGame/GameEntry.cpp
+++ b/ChronoGame/GameEntry.cpp
@@ -30,6 +30,9 @@
 // GameObject Reference Test Scripts
 #include "Scripts/GameObjectTest.hpp"
 
+// LayerRef Test Script
+#include "Scripts/LayerRefTestScript.hpp"
+
 
 
 // extern "C" ensures C linkage so the Engine DLL can find this function
@@ -126,6 +129,11 @@ extern "C" {
         // GameObject Reference Test Script
         registrar->RegisterScript("GameObjectTest", []() -> NE::Scripting::IScript* {
             return new GameObjectTest();
+            });
+
+        // LayerRef Test Script
+        registrar->RegisterScript("LayerRefTestScript", []() -> NE::Scripting::IScript* {
+            return new LayerRefTestScript();
             });
 
         }

--- a/ChronoGame/Scripts/EngineAPI.hpp
+++ b/ChronoGame/Scripts/EngineAPI.hpp
@@ -163,6 +163,11 @@ using String = ScriptFieldType::String;
 #define SCRIPT_FIELD_LAYERMASK(fieldName) \
     RegisterLayerMaskField(#fieldName, &this->fieldName)
 
+// SCRIPT_FIELD_LAYERREF macro - registers LayerRef fields with layer dropdown
+// Usage: SCRIPT_FIELD_LAYERREF(targetLayer)
+#define SCRIPT_FIELD_LAYERREF(fieldName) \
+    RegisterLayerRefField(#fieldName, &this->fieldName)
+
 // ============ CONVENIENCE NAMESPACES (GLOBAL SCOPE) ============
 // Similar pattern to Input, Events, Coroutines namespaces in ScriptAPI.h
 
@@ -295,6 +300,7 @@ using Entity = NE::Scripting::Entity;
 using IScript = NE::Scripting::IScript;
 using RaycastHit = NE::Scripting::RaycastHit;
 using LayerMask = NE::Scripting::LayerMask;
+using LayerRef = NE::Scripting::LayerRef;
 using GameObject = NE::Scripting::GameObject;
 
 // Component reference types

--- a/ChronoGame/Scripts/LayerRefTestScript.hpp
+++ b/ChronoGame/Scripts/LayerRefTestScript.hpp
@@ -1,0 +1,117 @@
+#pragma once
+#include "EngineAPI.hpp"
+#include <iostream>
+
+/**
+ * LayerRefTestScript - Test script to demonstrate LayerRef functionality
+ *
+ * This script shows how to use LayerRef fields which display a dropdown
+ * in the Inspector showing all available layers from the LayerDatabase.
+ *
+ * HOW TO TEST:
+ * 1. Build the project
+ * 2. Attach this script to any entity
+ * 3. In the Inspector, you should see:
+ *    - "targetLayer" field with a dropdown showing available layers
+ *    - "raycastLayer" field with another layer dropdown
+ *    - "rayDistance" float field
+ * 4. Click the dropdown to see all activated layers (e.g., "0: Default", "1: Player", etc.)
+ * 5. Select different layers and observe the console output
+ *
+ * EXPECTED INSPECTOR APPEARANCE:
+ * +------------------------------------------+
+ * | LayerRefTestScript                       |
+ * +------------------------------------------+
+ * | [x] Enabled                              |
+ * | Entity ID: 42                            |
+ * |------------------------------------------|
+ * | --- Script Fields ---                    |
+ * |                                          |
+ * | targetLayer    [v 0: Default        ]   | <-- Dropdown!
+ * | raycastLayer   [v 0: Default        ]   | <-- Dropdown!
+ * | rayDistance    [       50.0         ]   |
+ * | showDebugInfo  [x]                       |
+ * +------------------------------------------+
+ *
+ * When you click the dropdown, it expands to show:
+ * +------------------------+
+ * | 0: Default             |
+ * | 1: Player              |
+ * | 2: Enemy               |
+ * | 3: Ground              |
+ * | ... (other layers)     |
+ * +------------------------+
+ */
+
+class LayerRefTestScript : public IScript {
+public:
+    LayerRefTestScript() {
+        // Register LayerRef fields - these will show as dropdowns in the Inspector
+        SCRIPT_FIELD_LAYERREF(targetLayer);
+        SCRIPT_FIELD_LAYERREF(raycastLayer);
+
+        // Register other fields for comparison
+        SCRIPT_FIELD(rayDistance, Float);
+        SCRIPT_FIELD(showDebugInfo, Bool);
+    }
+
+    void Initialize(Entity entity) override {
+        std::cout << "[LayerRefTestScript] Initialized!" << std::endl;
+        std::cout << "  Target Layer ID: " << (int)targetLayer.GetID() << std::endl;
+        std::cout << "  Raycast Layer ID: " << (int)raycastLayer.GetID() << std::endl;
+    }
+
+    void Update(double deltaTime) override {
+        // Example: Use the layer for raycasting
+        if (showDebugInfo) {
+            // Print every 2 seconds
+            static float timer = 0.0f;
+            timer += static_cast<float>(deltaTime);
+            if (timer >= 2.0f) {
+                timer = 0.0f;
+
+                std::cout << "[LayerRefTestScript] Current settings:" << std::endl;
+                std::cout << "  Target Layer ID: " << (int)targetLayer.GetID() << std::endl;
+                std::cout << "  Target Layer Mask: " << targetLayer.ToMask() << std::endl;
+                std::cout << "  Raycast Layer ID: " << (int)raycastLayer.GetID() << std::endl;
+                std::cout << "  Raycast Layer Mask: " << raycastLayer.ToMask() << std::endl;
+            }
+        }
+
+        // Example: Perform a raycast using the selected layer
+        if (Input::WasKeyPressed('L')) {
+            uint32_t layerMask = raycastLayer.ToMask();
+
+            std::cout << "[LayerRefTestScript] Raycasting on layer " << (int)raycastLayer.GetID()
+                      << " (mask: " << layerMask << ")" << std::endl;
+
+            RaycastHit hit = Raycast(GetPosition(), GetForward(), rayDistance, layerMask);
+
+            if (hit.hasHit) {
+                std::cout << "  HIT! Entity: " << hit.entity
+                          << " at distance: " << hit.distance << std::endl;
+            } else {
+                std::cout << "  No hit on this layer." << std::endl;
+            }
+        }
+    }
+
+    const char* GetTypeName() const override {
+        return "LayerRefTestScript";
+    }
+
+    // Required interface methods
+    void OnCollisionEnter(Entity other) override {}
+    void OnCollisionExit(Entity other) override {}
+    void OnTriggerEnter(Entity other) override {}
+    void OnTriggerExit(Entity other) override {}
+
+private:
+    // LayerRef fields - these show as DROPDOWNS in the Inspector!
+    LayerRef targetLayer;      // Shows dropdown with all available layers
+    LayerRef raycastLayer;     // Another layer dropdown
+
+    // Regular fields for comparison
+    float rayDistance = 50.0f;
+    bool showDebugInfo = true;
+};

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -1536,6 +1536,48 @@ namespace Editor {
 
 							ImGui::PopID();
 						}
+						else if (ftype == "layerref") {
+							// Layer reference field - show layer dropdown from LayerDatabase
+							NE::Core::LayerID currentLayerId = 0;
+							if (!fval.empty()) {
+								try {
+									currentLayerId = static_cast<NE::Core::LayerID>(std::stoi(fval));
+								} catch (...) {
+									currentLayerId = 0;
+								}
+							}
+
+							// Get layer name for preview
+							std::string_view layerName = EditorScene::layerDatabase.GetName(currentLayerId);
+							std::string preview = layerName.empty() ? "<Unassigned>" : std::string(layerName);
+
+							ImGui::PushID((fname + "_layerref").c_str());
+
+							ImGui::Text("%s", fname.c_str());
+							ImGui::SameLine();
+
+							ImGui::PushItemWidth(140.0f);
+							if (Editor::BeginPillCombo("##layercombo", preview.c_str())) {
+								EditorScene::layerDatabase.ForEachUsed([&](NE::Core::LayerID id, std::string_view name) {
+									const bool selected = (id == currentLayerId);
+
+									std::string label = std::to_string(static_cast<int>(id));
+									label += ": ";
+									label += name;
+
+									if (ImGui::Selectable(label.c_str(), selected)) {
+										UpdateFieldValue(fname, std::to_string(static_cast<int>(id)));
+										fieldChanged = true;
+									}
+									if (selected) ImGui::SetItemDefaultFocus();
+								});
+
+								Editor::EndPillCombo();
+							}
+							ImGui::PopItemWidth();
+
+							ImGui::PopID();
+						}
 						else if (ftype.starts_with("vector<")) {
 							// Array/Vector support
 							size_t arraySize = scriptInstance->GetArraySize(fname);

--- a/NANOEngine/include/ScriptSDK/ScriptAPI.h
+++ b/NANOEngine/include/ScriptSDK/ScriptAPI.h
@@ -583,6 +583,7 @@ namespace Scripting {
         void RegisterMaterialRefField(const std::string& name, MaterialRef* memberPtr);
         void RegisterPrefabRefField(const std::string& name, PrefabRef* memberPtr);
         void RegisterGameObjectRefField(const std::string& name, GameObjectRef* memberPtr);
+        void RegisterLayerRefField(const std::string& name, LayerRef* memberPtr);
 
         // Vector field registration (native support - no override boilerplate needed!)
         void RegisterIntVectorField(const std::string& name, std::vector<int>* memberPtr);

--- a/NANOEngine/include/ScriptSDK/ScriptTypes.h
+++ b/NANOEngine/include/ScriptSDK/ScriptTypes.h
@@ -235,6 +235,57 @@ namespace Scripting {
     };
 
     //=========================================================================
+    // LAYER REFERENCE (For referencing a single layer from LayerRegistry)
+    //=========================================================================
+
+    /**
+     * @struct LayerRef
+     * @brief Reference to a single layer from the LayerRegistry
+     *
+     * Use this field type to reference a layer in your scripts.
+     * In the editor, this will show a dropdown of all available layers.
+     *
+     * Example:
+     * @code
+     * class EnemyScript : public IScript {
+     *     LayerRef targetLayer;  // Select layer from dropdown in editor
+     *
+     *     void Initialize(Entity entity) override {
+     *         RegisterLayerRefField("Target Layer", &targetLayer);
+     *     }
+     *
+     *     void Update(double deltaTime) override {
+     *         // Use targetLayer.GetID() for raycasting layer mask, etc.
+     *         uint32_t mask = 1u << targetLayer.GetID();
+     *         RaycastHit hit = Raycast(GetPosition(), GetForward(), 100.0f, mask);
+     *     }
+     * };
+     * @endcode
+     */
+    struct LayerRef {
+        uint8_t layerID = 0;  // Layer ID (0-31, corresponds to LayerRegistry slots)
+
+        LayerRef() = default;
+        explicit LayerRef(uint8_t id) : layerID(id) {}
+
+        // Get the layer ID
+        uint8_t GetID() const { return layerID; }
+
+        // Set the layer ID
+        void SetID(uint8_t id) { layerID = id; }
+
+        // Convert to layer mask bit
+        uint32_t ToMask() const { return 1u << static_cast<uint32_t>(layerID); }
+
+        // Check if this references a valid layer (ID within range)
+        bool IsValid() const { return layerID < 32; }
+
+        // Comparison operators
+        bool operator==(const LayerRef& other) const { return layerID == other.layerID; }
+        bool operator!=(const LayerRef& other) const { return layerID != other.layerID; }
+    };
+
+    //=========================================================================
     // GAME OBJECT WRAPPER (Script-to-Script Communication)
     //=========================================================================
 

--- a/NANOEngine/src/Scripting/ScriptAPI.cpp
+++ b/NANOEngine/src/Scripting/ScriptAPI.cpp
@@ -1687,6 +1687,41 @@ namespace NE {
 			);
 		}
 
+		void IScript::RegisterLayerRefField(const std::string& name, LayerRef* memberPtr) {
+			RegisterFieldInternal(
+				name,
+				"layerref",
+				memberPtr,
+				[memberPtr]() -> std::string {
+					// Store the layer ID as a string
+					return std::to_string(static_cast<int>(memberPtr->GetID()));
+				},
+				[memberPtr, name](const std::string& value) -> bool {
+					try {
+						// Parse layer ID from string
+						uint8_t layerId = 0;
+						if (!value.empty()) {
+							try {
+								int parsed = std::stoi(value);
+								// Clamp to valid layer range (0-31)
+								if (parsed < 0) parsed = 0;
+								if (parsed > 31) parsed = 31;
+								layerId = static_cast<uint8_t>(parsed);
+							} catch (...) {
+								layerId = 0;
+							}
+						}
+
+						memberPtr->SetID(layerId);
+						return true;
+					} catch (const std::exception& e) {
+						SPD_ERROR("[LayerRef] setValue exception for field " << name << ": " << e.what());
+						return false;
+					}
+				}
+			);
+		}
+
 		void IScript::RegisterMaterialRefVectorField(const std::string& name, std::vector<MaterialRef>* memberPtr) {
 			if (!m_fieldRegistry) {
 				m_fieldRegistry = new FieldRegistry();


### PR DESCRIPTION
This pull request introduces a new `LayerRef` script field type, enabling scripts to reference a single layer via a dropdown in the Inspector UI. This improves usability for scripts that need to interact with specific layers, such as for raycasting or filtering. The changes include the definition of the `LayerRef` type, registration macros and functions, Inspector UI support, and a test script demonstrating its usage.

**LayerRef Script Field Support**

* Added the `LayerRef` struct to `ScriptTypes.h`, providing a type-safe way to reference a single layer, including utility methods for ID and mask conversion.
* Implemented `RegisterLayerRefField` in `IScript`, allowing scripts to register `LayerRef` fields for Inspector editing. [[1]](diffhunk://#diff-814fa9a80c1863ae10dfaebaa84ac205959ef606bebe343e8feaed6e86479c8eR586) [[2]](diffhunk://#diff-08a15bb2998e4b0274385dc0794354456e87fe93654dbd9323bde6937a5d682eR1690-R1724)
* Added the `SCRIPT_FIELD_LAYERREF` macro and `using LayerRef` alias in `EngineAPI.hpp` for easier script integration. [[1]](diffhunk://#diff-c30ac01a07ceeee942f9767d45c8344ef5759aab22c979678670ee747c8d970dR166-R170) [[2]](diffhunk://#diff-c30ac01a07ceeee942f9767d45c8344ef5759aab22c979678670ee747c8d970dR303)

**Inspector UI Integration**

* Updated the Inspector panel to recognize `layerref` fields and render them as dropdowns populated from the layer database, allowing users to select layers by name.

**Testing and Documentation**

* Added `LayerRefTestScript.hpp`, a sample script that demonstrates the use of `LayerRef` fields, including Inspector integration and runtime usage.
* Registered the test script in `GameEntry.cpp` for easy access and testing. 