### PR TITLE
Fix selection clearing and mouse capture in panels

### DIFF
--- a/Editor/src/Panels/AssetBrowserPanel.cpp
+++ b/Editor/src/Panels/AssetBrowserPanel.cpp
@@ -137,6 +137,7 @@ namespace Editor {
             ImGui::Separator();
 
             if (ImGui::Button("Yes")) {
+                EditorScene::s_selection.Clear();
                 auto uuid = Assets::AssetManager::GetInstance().RetrieveUUID(m_selectedPath.string());
                 NE::LoadScene(uuid);
                 EditorScene::BuildRoot();

--- a/Editor/src/Panels/ScenePanel.cpp
+++ b/Editor/src/Panels/ScenePanel.cpp
@@ -378,7 +378,7 @@ namespace Editor {
 				mousePos.x >= panelPos.x && mousePos.x < panelPos.x + panelSize.x &&
 				mousePos.y >= panelPos.y && mousePos.y < panelPos.y + panelSize.y;
 
-			if (insideScene) {
+			if (insideScene && !io.WantCaptureMouseUnlessPopupClose) {
 				if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
 					m_dragSelecting = true;
 					m_dragStartScreen = mousePos;


### PR DESCRIPTION
Cause: Clicking on the scene change popup selects entity behind in the scenepanel as well, causing a crash due to a selection reference to null entity