### PR TITLE
Fixed bug of camera not following parent transform

### DIFF
--- a/NANOEngine/src/ECS/Systems/CameraSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/CameraSystem.cpp
@@ -162,25 +162,7 @@ namespace NE::ECS::Systems {
 		//cam.projectionMtx = Mat4::BuildOrtho(left, right, bottom, top, nearPlane, farPlane);
 	}
 
-	void CameraSystem::BuildView(Camera& cam, Transform& transform)
-	{
-		const Vec3 eye = transform.worldMatrix.GetTranslation();
-		const Vec3 fwd = ForwardFromEuler(transform.localRotationEuler);
-		const Vec3 target = eye + fwd;
-		const Vec3 up = Vec3{ 0.0f, 1.0f, 0.0f };
-
-		cam.viewMtx = Mat4::BuildViewMtx(eye, target, up);
-	}
-
-	inline Vec3 CameraSystem::ForwardFromEuler(const Vec3& euler)
-	{
-		float pitch = euler.x * Math::DEG_TO_RAD;
-		float yaw = euler.y * Math::DEG_TO_RAD;
-
-		Vec3 forward;
-		forward.x = std::cos(yaw) * std::cos(pitch);
-		forward.y = std::sin(pitch);
-		forward.z = std::sin(yaw) * std::cos(pitch);
-		return forward.Normalize();
+	void CameraSystem::BuildView(Camera& cam, Transform& transform) {
+		cam.viewMtx = transform.worldMatrix.Inverse();
 	}
 }

--- a/NANOEngine/src/ECS/Systems/CameraSystem.hpp
+++ b/NANOEngine/src/ECS/Systems/CameraSystem.hpp
@@ -36,7 +36,6 @@ namespace NE::ECS::Systems {
 		// Helper functions for camera management
 		void BuildProjection(Camera& cam);
 		void BuildView(Camera& cam, Transform& transform);		
-		inline Vec3 ForwardFromEuler(const Vec3& euler);
 
 		std::optional<Entity> m_mainCameraEntity; // Track main camera entity
 		


### PR DESCRIPTION
Cause: View built using localEuler

Fix: Use worldMatrix.Inverse()