### PR TITLE
Add JSON to binary prefab conversion and update serialization

### DIFF
--- a/Editor/Editor.vcxproj
+++ b/Editor/Editor.vcxproj
@@ -226,6 +226,7 @@
     <ClInclude Include="src\EditorState.hpp" />
     <ClInclude Include="src\Layers\LayerModal.hpp" />
     <ClInclude Include="src\Serialization\JSONReflection.hpp" />
+    <ClInclude Include="src\Serialization\ReflectionConverter.hpp" />
     <ClInclude Include="src\Serialization\Serializer.hpp" />
     <ClInclude Include="src\AssetManagement\AssetManager.hpp" />
     <ClInclude Include="resource.h" />

--- a/Editor/Editor.vcxproj.filters
+++ b/Editor/Editor.vcxproj.filters
@@ -377,6 +377,9 @@
     <ClInclude Include="src\Layers\LayerModal.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\Serialization\ReflectionConverter.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Editor.rc">

--- a/Editor/src/AssetManagement/Assets/PrefabAsset.cpp
+++ b/Editor/src/AssetManagement/Assets/PrefabAsset.cpp
@@ -3,6 +3,22 @@
 #include <Engine.hpp>
 #include <ResourceManagement/ResourcePaths.hpp>
 
+// Components
+#include <ECS/Components/EntityMeta.hpp>
+#include <ECS/Components/Transform.hpp>
+#include <ECS/Components/Renderer.hpp>
+#include <ECS/Components/Light.hpp>
+#include <ECS/Components/Collider.hpp>
+#include <ECS/Components/Rigidbody.hpp>
+#include <ECS/Components/NativeScript.hpp>
+#include <ECS/Components/Camera.hpp>
+#include <ECS/Components/UIRectTransform.hpp>
+#include <ECS/Components/UICanvas.hpp>
+#include <ECS/Components/UIImage.hpp>
+#include <ECS/Components/Hierarchy.hpp>
+#include <ECS/Components/PrefabLink.hpp>
+#include <ECS/Components/PrefabInstance.hpp>
+#include <ECS/Components/CharacterController.hpp>
 
 #include "../../EditorScene.hpp"
 #include "../../Serialization/Serializer.hpp"
@@ -10,19 +26,54 @@
 
 
 namespace Editor::Assets {
+	namespace {
+		using ComponentTypes = std::tuple<
+			NE::ECS::Component::EntityMeta,
+			NE::ECS::Component::Hierarchy,
+			NE::ECS::Component::PrefabInstance,
+			NE::ECS::Component::PrefabLink,
+			NE::ECS::Component::Transform,
+			NE::ECS::Component::Renderer,
+			NE::ECS::Component::Light,
+			NE::ECS::Component::Collider,
+			NE::ECS::Component::Rigidbody,
+			NE::ECS::Component::NativeScript,
+			NE::ECS::Component::Camera,
+			NE::ECS::Component::UIRectTransform,
+			NE::ECS::Component::UICanvas,
+			NE::ECS::Component::UIImage,
+			NE::ECS::Component::CharacterController
+		>;
+
+		template <class F>
+		void ForEachComponentType(F&& f) {
+			std::apply([&](auto&&... t) {
+				(f.template operator() < std::decay_t<decltype(t)> > (), ...);
+				}, ComponentTypes{});
+		}
+	}
 
 	bool PrefabAsset::Cook(const std::string& sourcePath,
 		const std::string& outPath) const {
 
-		if (EditorScene::s_selection.GetLastDropped() == NE::ECS::NO_ENTITY && !m_isScene) {
-			SPD_ERROR("No entity selected to cook prefab from: {}", sourcePath);
-			return false;
-		}
+		return Serialization::JSON::CookPrefabToBinary(sourcePath, outPath);
 
-		if (m_isScene)
-			NE::CookPrefab(EditorScene::s_rootOrder[0], outPath);
-		else
-			NE::CookPrefab(EditorScene::s_selection.GetLastDropped(), outPath);
+		//bool success = Editor::Utils::JSONToBinaryFile<MyLevelData>(
+		//	"assets/level1.json",
+		//	"assets/level1.bin"
+		//);
+
+		//if (EditorScene::s_selection.GetLastDropped() == NE::ECS::NO_ENTITY && !m_isScene) {
+		//	SPD_ERROR("No entity selected to cook prefab from: {}", sourcePath);
+		//	return false;
+		//}
+
+		//if (m_isScene)
+		//	NE::CookPrefab(EditorScene::s_rootOrder[0], outPath);
+		//else
+		//	NE::CookPrefab(EditorScene::s_selection.GetLastDropped(), outPath);
+
+
 		return true;
 	}
 
@@ -47,7 +98,7 @@ namespace Editor::Assets {
 
 		Serialization::JSON::SerializePrefab(outPath, isScene);
 
-		return Cook({}, path);
+		return Cook(outPath, path);
 	}
 
 }

--- a/Editor/src/Serialization/ReflectionConverter.hpp
+++ b/Editor/src/Serialization/ReflectionConverter.hpp
@@ -1,0 +1,46 @@
+#include <fstream>
+#include <string>
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+
+#include <Core/SpdLogger.hpp>
+#include <Serialisation/BinaryReflection.hpp>
+
+#include "JSONReflection.hpp"
+
+namespace Editor::Utils {
+
+    template <NE::Core::Reflectable T>
+    inline bool JSONToBinaryFile(const std::filesystem::path& jsonPath, const std::filesystem::path& binaryPath) {
+        std::ifstream ifs(jsonPath);
+        if (!ifs.is_open()) {
+            SPD_ERROR("Failed to open JSON file: " << jsonPath);
+            return false;
+        }
+
+        rapidjson::IStreamWrapper isw(ifs);
+        rapidjson::Document doc;
+        doc.ParseStream(isw);
+
+        if (doc.HasParseError()) {
+            SPD_ERROR("JSON Parse Error: " << doc.GetParseError());
+            return false;
+        }
+
+        T objectInstance;
+        Deserialization::FromJSON(doc, objectInstance);
+
+        NE::ByteBuffer buffer;
+        NE::Serialization::ToBinary(buffer, objectInstance);
+
+        std::ofstream ofs(binaryPath, std::ios::binary);
+        if (!ofs.is_open()) {
+            SPD_ERROR("Failed to open output binary file: " << binaryPath);
+            return false;
+        }
+
+        ofs.write(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+        return true;
+    }
+}

--- a/Editor/src/Serialization/Serializer.cpp
+++ b/Editor/src/Serialization/Serializer.cpp
@@ -33,9 +33,13 @@
 #include "JSONReflection.hpp"
 #include "../EditorScene.hpp"
 #include <Scripting/ScriptingEngine.hpp>
+#include <Serialisation/BinaryReflection.hpp>
 
 namespace Editor {
 	namespace {
+		inline constexpr uint32_t NFAB_MAGIC = 0x4E464142;
+		inline constexpr int CURRENT_NANOPREFAB_FORMAT_VERSION = 1;
+
 		using ComponentTypes = std::tuple<
 			NE::ECS::Component::EntityMeta,
 			NE::ECS::Component::Hierarchy,
@@ -230,6 +234,61 @@ namespace Editor {
 
 				std::ofstream out(path, std::ios::binary);
 				if (out) out.write(sb.GetString(), static_cast<std::streamsize>(sb.GetSize()));
+			}
+
+			bool CookPrefabToBinary(const std::string& jsonPath, const std::string& binPath) {
+				std::string jsonContent;
+				if (!ReadAllText(jsonPath, jsonContent)) return false;
+
+				rapidjson::Document doc;
+				doc.Parse(jsonContent.c_str());
+				if (doc.HasParseError() || !doc.HasMember("Entities")) return false;
+
+				NE::ByteBuffer outputBuffer;
+
+				NE::Serialization::ToBinary(outputBuffer, static_cast<uint64_t>(NFAB_MAGIC));
+				NE::Serialization::ToBinary(outputBuffer, static_cast<uint64_t>(CURRENT_NANOPREFAB_FORMAT_VERSION));
+
+				const auto& entities = doc["Entities"].GetArray();
+				uint64_t entityCount = static_cast<uint64_t>(entities.Size());
+				NE::Serialization::ToBinary(outputBuffer, entityCount);
+
+				for (const auto& entVal : entities) {
+					uint8_t layer = 0;
+					if (entVal.HasMember("Layer")) {
+						Deserialization::FromJSON(entVal["Layer"], layer);
+					}
+					NE::Serialization::ToBinary(outputBuffer, layer);
+
+					uint64_t mask = 0;
+					uint32_t bitIdx = 0;
+					ForEachComponentType([&]<typename C>() {
+						if (entVal.HasMember(ComponentKey<C>::value)) {
+							mask |= (uint64_t(1) << bitIdx);
+						}
+						bitIdx++;
+					});
+
+					NE::Serialization::ToBinary(outputBuffer, mask);
+
+					ForEachComponentType([&]<typename C>() {
+						const char* key = ComponentKey<C>::value;
+						if (entVal.HasMember(key)) {
+							C tempComp{};
+							Deserialization::FromJSON(entVal[key], tempComp);
+
+							if constexpr (!std::is_same_v<C, NE::ECS::Component::NativeScript>) {
+								NE::Serialization::ToBinary(outputBuffer, tempComp);
+							}
+						}
+					});
+				}
+
+				std::ofstream ofs(binPath, std::ios::binary);
+				if (!ofs.is_open()) return false;
+				ofs.write(reinterpret_cast<const char*>(outputBuffer.data()), outputBuffer.size());
+
+				return true;
 			}
 
 			void SerializeProjectSettings() {

--- a/Editor/src/Serialization/Serializer.hpp
+++ b/Editor/src/Serialization/Serializer.hpp
@@ -7,6 +7,7 @@ namespace Editor {
 		namespace JSON {
 			void SerializeScene(const std::string& path);
 			void SerializePrefab(const std::string& path, bool isScene = false);
+			bool CookPrefabToBinary(const std::string& jsonPath, const std::string& binPath);
 			void SerializeProjectSettings();
 			void SerializeUserSettings();
 		}

--- a/NANOEngine/src/Engine.cpp
+++ b/NANOEngine/src/Engine.cpp
@@ -187,7 +187,7 @@ namespace NE {
 	}
 
 	void CookPrefab(const ECS::Entity rootNode, const std::string& _artifactPath) {
-		NE::Serialization::SerializePrefab(GetScene().GetECSCoordinator(), rootNode, _artifactPath);
+		//NE::Serialization::SerializePrefab(GetScene().GetECSCoordinator(), rootNode, _artifactPath);
 	}
 
 	uint32_t LoadPrefab(const std::string& _uuid) {

--- a/NANOEngine/src/Serialisation/Serializer.hpp
+++ b/NANOEngine/src/Serialisation/Serializer.hpp
@@ -11,6 +11,8 @@ namespace NE::ECS { class ECSCoordinator; }
 namespace NE {
 	namespace Serialization {
 		void SerializeScene(ECS::ECSCoordinator& ecs, const std::vector<ECS::Entity>& rootNodes, const std::string& path);
+
+		[[deprecated("No longer being used due to instability")]]
 		void SerializePrefab(ECS::ECSCoordinator& ecs, const ECS::Entity rootNodes, const std::string& path);
 		void SerializeEntitiesToMemory(ECS::ECSCoordinator& ecs, const uint32_t rootEnt, std::vector<uint8_t>& outBuffer);
 	}


### PR DESCRIPTION
Introduces a new ReflectionConverter utility for converting JSON to binary using reflection. Adds CookPrefabToBinary to the serialization system and updates PrefabAsset to use this new method. Deprecates the old SerializePrefab in the engine and marks it as unused. Updates project files to include the new header.