### PR TITLE
Add generic (de)serialization for unordered_map/set

### DIFF
--- a/Editor/src/AssetManagement/Assets/PrefabAsset.cpp
+++ b/Editor/src/AssetManagement/Assets/PrefabAsset.cpp
@@ -57,24 +57,6 @@ namespace Editor::Assets {
 		const std::string& outPath) const {
 
 		return Serialization::JSON::CookPrefabToBinary(sourcePath, outPath);
-
-		//bool success = Editor::Utils::JSONToBinaryFile<MyLevelData>(
-		//	"assets/level1.json",
-		//	"assets/level1.bin"
-		//);
-
-		//if (EditorScene::s_selection.GetLastDropped() == NE::ECS::NO_ENTITY && !m_isScene) {
-		//	SPD_ERROR("No entity selected to cook prefab from: {}", sourcePath);
-		//	return false;
-		//}
-
-		//if (m_isScene)
-		//	NE::CookPrefab(EditorScene::s_rootOrder[0], outPath);
-		//else
-		//	NE::CookPrefab(EditorScene::s_selection.GetLastDropped(), outPath);
-
-
-		return true;
 	}
 
 	bool PrefabAsset::LoadImportSettings(const std::string& /*sourcePath*/) { // No Import Settings

--- a/Editor/src/Serialization/JSONReflection.hpp
+++ b/Editor/src/Serialization/JSONReflection.hpp
@@ -3,6 +3,8 @@
 #include <rapidjson/document.h>
 #include <filesystem>
 #include <variant>
+#include <unordered_map>
+#include <unordered_set>
 
 #include <Math/Vec2.hpp>
 #include <Math/Vec3.hpp>
@@ -14,6 +16,24 @@ namespace Editor {
 	using rapidjson::Value;
 
     namespace Serialization {
+
+        namespace Detail {
+            template <typename K>
+            inline bool KeyAsString(const K&) { return false; }
+
+            inline bool KeyAsString(const std::string&) { return true; }
+            inline bool KeyAsString(std::string_view) { return true; }
+            inline bool KeyAsString(const char*) { return true; }
+            inline bool KeyAsString(const std::filesystem::path&) { return true; }
+
+            inline Value KeyToJSONString(const std::string& k, Alloc& a) { return Value(k.c_str(), a); }
+            inline Value KeyToJSONString(std::string_view k, Alloc& a) { return Value(k.data(), static_cast<rapidjson::SizeType>(k.size()), a); }
+            inline Value KeyToJSONString(const char* k, Alloc& a) { return Value(k ? k : "", a); }
+            inline Value KeyToJSONString(const std::filesystem::path& k, Alloc& a) {
+                const std::string s = k.string();
+                return Value(s.c_str(), a);
+            }
+        }
 
         // forward decl for ToJson using Reflectable
         template <NE::Core::Reflectable T>
@@ -29,7 +49,7 @@ namespace Editor {
         }
 
         inline Value ToJSON(const std::string& s, Alloc& a) { return Value(s.c_str(), a); }
-        inline Value ToJSON(std::string_view s, Alloc& a) { return Value(s.data(), a); }
+        inline Value ToJSON(std::string_view s, Alloc& a) { return Value(s.data(), static_cast<rapidjson::SizeType>(s.size()), a); }
         inline Value ToJSON(const char* s, Alloc& a) { return Value(s, a); }
         inline Value ToJSON(const std::filesystem::path& p, Alloc& a) { return Value(p.string().c_str(), a); }
         inline Value ToJSON(const uint64_t& v, Alloc&) {
@@ -65,6 +85,48 @@ namespace Editor {
 
             obj.AddMember("value", payload, a);
             return obj;
+        }
+        
+		// unordered_map
+        template <typename K, typename V, typename Hash, typename Eq, typename AllocT>
+        Value ToJSON(const std::unordered_map<K, V, Hash, Eq, AllocT>& map, Alloc& a) {
+            // If key is string-like, write as JSON object for readability.
+            if constexpr (
+                std::is_same_v<K, std::string> ||
+                std::is_same_v<K, std::string_view> ||
+                std::is_same_v<K, const char*> ||
+                std::is_same_v<K, std::filesystem::path>
+                ) {
+                Value obj(rapidjson::kObjectType);
+
+                for (const auto& [k, v] : map) {
+                    Value key = Detail::KeyToJSONString(k, a);
+                    obj.AddMember(key, ToJSON(v, a), a);
+                }
+
+                return obj;
+            } else {
+                Value arr(rapidjson::kArrayType);
+
+                for (const auto& [k, v] : map) {
+                    Value pair(rapidjson::kObjectType);
+                    pair.AddMember("k", ToJSON(k, a), a);
+                    pair.AddMember("v", ToJSON(v, a), a);
+                    arr.PushBack(pair, a);
+                }
+
+                return arr;
+            }
+        }
+
+        // unordered_set
+        template <typename T, typename Hash, typename Eq, typename AllocT>
+        Value ToJSON(const std::unordered_set<T, Hash, Eq, AllocT>& set, Alloc& a) {
+            Value arr(rapidjson::kArrayType);
+            for (const auto& e : set) {
+                arr.PushBack(ToJSON(e, a), a);
+            }
+            return arr;
         }
 
         // enums
@@ -113,6 +175,20 @@ namespace Editor {
     }
 
     namespace Deserialization {
+        namespace Detail {
+            template <typename K>
+            inline void KeyFromJSONString(const Value& /*v*/, K& /*out*/) {
+            }
+
+            inline void KeyFromJSONString(const Value& v, std::string& out) {
+                out = v.GetString();
+            }
+
+            inline void KeyFromJSONString(const Value& v, std::filesystem::path& out) {
+                out = v.GetString();
+            }
+        }
+
         // forward decl
         template <NE::Core::Reflectable T>
         void FromJSON(const Value& v, T& out);
@@ -178,6 +254,65 @@ namespace Editor {
             }(std::make_index_sequence<sizeof...(Ts)>{});
         }
 
+		// unordered_map
+        template <typename K, typename V, typename Hash, typename Eq, typename AllocT>
+        void FromJSON(const Value& v, std::unordered_map<K, V, Hash, Eq, AllocT>& out) {
+            out.clear();
+
+            if (v.IsObject()) {
+                if constexpr (std::is_same_v<K, std::string> || std::is_same_v<K, std::filesystem::path>) {
+                    out.reserve(v.MemberCount());
+
+                    for (auto it = v.MemberBegin(); it != v.MemberEnd(); ++it) {
+                        K key{};
+                        // it->name is a JSON string
+                        Detail::KeyFromJSONString(it->name, key);
+
+                        V value{};
+                        FromJSON(it->value, value);
+
+                        out.insert_or_assign(std::move(key), std::move(value));
+                    }
+                    return;
+                } else {
+                    // If K isn't string-like but we received object form, ignore.
+                    // (or you could assert/log here)
+                    return;
+                }
+            }
+
+            if (v.IsArray()) {
+                out.reserve(v.Size());
+
+                for (const auto& item : v.GetArray()) {
+                    if (!item.IsObject()) continue;
+                    if (!item.HasMember("k") || !item.HasMember("v")) continue;
+
+                    K key{};
+                    V value{};
+
+                    FromJSON(item["k"], key);
+                    FromJSON(item["v"], value);
+
+                    out.insert_or_assign(std::move(key), std::move(value));
+                }
+            }
+        }
+
+		// unordered_set
+        template <typename T, typename Hash, typename Eq, typename AllocT>
+        void FromJSON(const Value& v, std::unordered_set<T, Hash, Eq, AllocT>& out) {
+            out.clear();
+            if (!v.IsArray()) return;
+
+            out.reserve(v.Size());
+
+            for (const auto& item : v.GetArray()) {
+                T value{};
+                FromJSON(item, value);
+                out.insert(std::move(value));
+            }
+        }
 
         // enums
         template <typename E>

--- a/Editor/src/Serialization/Serializer.cpp
+++ b/Editor/src/Serialization/Serializer.cpp
@@ -38,7 +38,7 @@
 namespace Editor {
 	namespace {
 		inline constexpr uint32_t NFAB_MAGIC = 0x4E464142;
-		inline constexpr int CURRENT_NANOPREFAB_FORMAT_VERSION = 1;
+		inline constexpr int CURRENT_NANOPREFAB_FORMAT_VERSION = 2;
 
 		using ComponentTypes = std::tuple<
 			NE::ECS::Component::EntityMeta,
@@ -137,7 +137,12 @@ namespace Editor {
 				void WriteComponentIfPresent(NE::ECS::Entity e,
 					rapidjson::Value& ent, rapidjson::Document::AllocatorType& a) {
 					if (!NE::ECS::Query::HasComponent<C>(e)) return;
-					auto& c = NE::ECS::Query::GetComponent<C>(e);
+					auto& c = NE::ECS::Command::GetComponent<C>(e);
+
+					if constexpr (!std::is_same_v<C, NE::ECS::Component::Hierarchy>) {
+						if constexpr (requires(C x) { x.luid; }) c.luid = 0;
+					}
+
 					ent.AddMember(rapidjson::Value(ComponentKey<C>::value, a), ToJSON(c, a), a);
 				}
 
@@ -174,12 +179,12 @@ namespace Editor {
 				auto& componentManager = coordinator.GetComponentManager();
 				auto& allEntities = coordinator.GetUsedEntities();
 
-				for (NE::ECS::Entity entity : allEntities) {
-					if (componentManager.HasComponent<NE::ECS::Component::NativeScript>(entity)) {
-						auto& nsc = componentManager.GetComponent<NE::ECS::Component::NativeScript>(entity);
-						NE::Scripting::ScriptingEngine::GetInstance().SaveSerializedFields(entity, nsc);
-					}
-				}
+				//for (NE::ECS::Entity entity : allEntities) {
+				//	if (componentManager.HasComponent<NE::ECS::Component::NativeScript>(entity)) {
+				//		auto& nsc = componentManager.GetComponent<NE::ECS::Component::NativeScript>(entity);
+				//		NE::Scripting::ScriptingEngine::GetInstance().SaveSerializedFields(entity, nsc);
+				//	}
+				//}
 
 				Document doc;
 				doc.SetObject();
@@ -210,10 +215,6 @@ namespace Editor {
 				using rapidjson::Document;
 				using rapidjson::StringBuffer;
 				using rapidjson::PrettyWriter;
-
-				// Save all script instance field values to components before serialization
-				//auto& coordinator = NE::GetScene().GetECSCoordinator();
-				//auto& componentManager = coordinator.GetComponentManager();
 
 				Document doc;
 				doc.SetObject();
@@ -276,10 +277,7 @@ namespace Editor {
 						if (entVal.HasMember(key)) {
 							C tempComp{};
 							Deserialization::FromJSON(entVal[key], tempComp);
-
-							if constexpr (!std::is_same_v<C, NE::ECS::Component::NativeScript>) {
-								NE::Serialization::ToBinary(outputBuffer, tempComp);
-							}
+							NE::Serialization::ToBinary(outputBuffer, tempComp);
 						}
 					});
 				}

--- a/NANOEngine/src/ECS/Components/NativeScript.hpp
+++ b/NANOEngine/src/ECS/Components/NativeScript.hpp
@@ -72,11 +72,10 @@ namespace NE::ECS::Component {
         }
 
         NE_REFLECT_BEGIN(NativeScript)
-            NE_REFLECT_FIELD(ScriptNames)
-            // NOTE: SerializedFields and EntityReferenceFields use custom serialization
-            // See ReflectionJson.hpp to_json/from_json(NativeScript) for JSON/LUID conversion
-            // See BinaryReflection.hpp ToBinary/FromBinary(NativeScript) for binary serialization
-            // They are intentionally excluded from reflection macro (unsupported types)
+            NE_REFLECT_FIELD(ScriptNames),
+            NE_REFLECT_FIELD_HIDDEN(SerializedFields),
+            NE_REFLECT_FIELD_HIDDEN(EntityReferenceFields),
+            NE_REFLECT_FIELD_HIDDEN(luid)
         NE_REFLECT_END()
     };
 }

--- a/NANOEngine/src/EditorInterface/ECSExports.cpp
+++ b/NANOEngine/src/EditorInterface/ECSExports.cpp
@@ -825,12 +825,25 @@ namespace NE::ECS {
 		Component::UICanvas& GetUICanvas(uint32_t e) {
 			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::UICanvas>(e);
 		}
+
+		Component::Hierarchy& GetEntityHierarchy(uint32_t e) {
+			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::Hierarchy>(e);
+		}
+
+		Component::Animator& GetEntityAnimator(uint32_t e) {
+			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::Animator>(e);
+		}
+
 		Component::Camera& GetEntityCamera(uint32_t e) {
 			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::Camera>(e);
 		}
 
-		Component::Hierarchy& GetEntityHierarchy(uint32_t e) {
-			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::Hierarchy>(e);
+		Component::PrefabLink& GetPrefabLink(uint32_t e) {
+			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::PrefabLink>(e);
+		}
+
+		Component::PrefabInstance& GetPrefabInstance(uint32_t e) {
+			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::PrefabInstance>(e);
 		}
 
 		Component::CharacterController& GetCharacterController(uint32_t e) {
@@ -962,10 +975,6 @@ namespace NE::ECS {
 			if (GetScene().GetECSCoordinator().HasComponent<ECS::Component::Animator>(e))
 				return;
 			GetScene().GetECSCoordinator().AddComponent(e, ECS::Component::Animator{});
-		}
-
-		Component::Animator& GetEntityAnimator(uint32_t e) {
-			return NE::GetScene().GetECSCoordinator().GetComponent<NE::ECS::Component::Animator>(e);
 		}
 
 		void SetLayer(Entity e, Core::LayerID layer) {

--- a/NANOEngine/src/EditorInterface/ECSExports.hpp
+++ b/NANOEngine/src/EditorInterface/ECSExports.hpp
@@ -227,6 +227,21 @@ namespace NE::ECS {
 		NANOENGINE_API void RemoveCameraComponent(uint32_t e);
 
 		// --- Editor Component Mutators --- //
+		//NANOENGINE_API Component::EntityMeta& GetEntityMeta(uint32_t e);
+		//NANOENGINE_API Component::Transform& GetEntityTransform(uint32_t e);
+		//NANOENGINE_API Component::Renderer& GetEntityRenderer(uint32_t e);
+		//NANOENGINE_API Component::Light& GetEntityLight(uint32_t e);
+		//NANOENGINE_API Component::Rigidbody& GetEntityRigidbody(uint32_t e);
+		//NANOENGINE_API Component::Collider& GetEntityCollider(uint32_t e);
+		//NANOENGINE_API Component::AudioSource& GetEntityAudioSource(uint32_t e);
+		//NANOENGINE_API Component::NativeScript& GetEntityScript(uint32_t e);
+		//NANOENGINE_API Component::UIRectTransform& GetUIRectTransform(uint32_t e);
+		//NANOENGINE_API Component::UIImage& GetUIImage(uint32_t e);
+		//NANOENGINE_API Component::UICanvas& GetUICanvas(uint32_t e);
+		//NANOENGINE_API Component::Camera& GetEntityCamera(uint32_t e);
+		//NANOENGINE_API Component::Hierarchy& GetEntityHierarchy(uint32_t e);
+		//NANOENGINE_API Component::CharacterController& GetCharacterController(uint32_t e);
+
 		NANOENGINE_API Component::EntityMeta& GetEntityMeta(uint32_t e);
 		NANOENGINE_API Component::Transform& GetEntityTransform(uint32_t e);
 		NANOENGINE_API Component::Renderer& GetEntityRenderer(uint32_t e);
@@ -238,9 +253,32 @@ namespace NE::ECS {
 		NANOENGINE_API Component::UIRectTransform& GetUIRectTransform(uint32_t e);
 		NANOENGINE_API Component::UIImage& GetUIImage(uint32_t e);
 		NANOENGINE_API Component::UICanvas& GetUICanvas(uint32_t e);
-		NANOENGINE_API Component::Camera& GetEntityCamera(uint32_t e);
 		NANOENGINE_API Component::Hierarchy& GetEntityHierarchy(uint32_t e);
+		NANOENGINE_API Component::Animator& GetEntityAnimator(uint32_t e);
+		NANOENGINE_API Component::Camera& GetEntityCamera(uint32_t e);
+		NANOENGINE_API Component::PrefabLink& GetPrefabLink(uint32_t e);
+		NANOENGINE_API Component::PrefabInstance& GetPrefabInstance(uint32_t e);
 		NANOENGINE_API Component::CharacterController& GetCharacterController(uint32_t e);
+
+		template <typename C>
+		C& GetComponent(Entity e);
+
+		template<> inline Component::EntityMeta& GetComponent<Component::EntityMeta>(uint32_t e) { return GetEntityMeta(e); }
+		template<> inline Component::Transform& GetComponent<Component::Transform>(uint32_t e) { return GetEntityTransform(e); }
+		template<> inline Component::Renderer& GetComponent<Component::Renderer>(uint32_t e) { return GetEntityRenderer(e); }
+		template<> inline Component::Light& GetComponent<Component::Light>(uint32_t e) { return GetEntityLight(e); }
+		template<> inline Component::Rigidbody& GetComponent<Component::Rigidbody>(uint32_t e) { return GetEntityRigidbody(e); }
+		template<> inline Component::Collider& GetComponent<Component::Collider>(uint32_t e) { return GetEntityCollider(e); }
+		template<> inline Component::NativeScript& GetComponent<Component::NativeScript>(uint32_t e) { return GetEntityScript(e); }
+		template<> inline Component::UIRectTransform& GetComponent<Component::UIRectTransform>(uint32_t e) { return GetUIRectTransform(e); }
+		template<> inline Component::UIImage& GetComponent<Component::UIImage>(uint32_t e) { return GetUIImage(e); }
+		template<> inline Component::UICanvas& GetComponent<Component::UICanvas>(uint32_t e) { return GetUICanvas(e); }
+		template<> inline Component::Hierarchy& GetComponent<Component::Hierarchy>(uint32_t e) { return GetEntityHierarchy(e); }
+		template<> inline Component::Camera& GetComponent<Component::Camera>(uint32_t e) { return GetEntityCamera(e); }
+		template<> inline Component::Animator& GetComponent<Component::Animator>(uint32_t e) { return GetEntityAnimator(e); }
+		template<> inline Component::PrefabLink& GetComponent<Component::PrefabLink>(uint32_t e) { return GetPrefabLink(e); }
+		template<> inline Component::PrefabInstance& GetComponent<Component::PrefabInstance>(uint32_t e) { return GetPrefabInstance(e); }
+		template<> inline Component::CharacterController& GetComponent<Component::CharacterController>(uint32_t e) { return GetCharacterController(e); }
 
 		// --- Script Management ---
 		NANOENGINE_API std::vector<std::string> GetRegisteredScriptNames();

--- a/NANOEngine/src/Engine.cpp
+++ b/NANOEngine/src/Engine.cpp
@@ -97,7 +97,7 @@ namespace NE {
 
 		Graphics::GraphicsManager::Init();
 		Physics::PhysicsManager::GetInstance().Init();
-		Scripting::ScriptingEngine::GetInstance().Initialize();
+		Scripting::ScriptingEngine::GetInstance().Initialize(gSceneManager);
 	}
 
 	void Run(double dt) {

--- a/NANOEngine/src/Serialisation/BinaryReflection.hpp
+++ b/NANOEngine/src/Serialisation/BinaryReflection.hpp
@@ -21,335 +21,403 @@ namespace NE::ECS::Component {
 }
 
 namespace NE {
-
 	using ByteBuffer = std::vector<uint8_t>;
 
-    namespace Serialization {
-        // low-level helpers
-        inline void AppendBytes(ByteBuffer& out, const void* data, size_t size) {
-            const auto* p = static_cast<const std::uint8_t*>(data);
-            out.insert(out.end(), p, p + size);
-        }
-
-        // uint64 to little-endian
-        inline void AppendU64LE(ByteBuffer& out, std::uint64_t v) {
-            std::uint8_t b[8];
-            b[0] = (std::uint8_t)((v >> 0) & 0xFF);
-            b[1] = (std::uint8_t)((v >> 8) & 0xFF);
-            b[2] = (std::uint8_t)((v >> 16) & 0xFF);
-            b[3] = (std::uint8_t)((v >> 24) & 0xFF);
-            b[4] = (std::uint8_t)((v >> 32) & 0xFF);
-            b[5] = (std::uint8_t)((v >> 40) & 0xFF);
-            b[6] = (std::uint8_t)((v >> 48) & 0xFF);
-            b[7] = (std::uint8_t)((v >> 56) & 0xFF);
-            AppendBytes(out, b, sizeof(b));
-        }
-
-        template <NE::Core::Reflectable T>
-        inline size_t ToBinary(ByteBuffer& out, const T& obj);
-
-	    // Primitives and std types
-        inline size_t ToBinary(ByteBuffer& out, const std::uint64_t& v) {
-            const size_t before = out.size();
-            AppendU64LE(out, v);
-            return out.size() - before;
-        }
-
-        inline size_t ToBinary(ByteBuffer& out, std::string_view s) {
-            const size_t before = out.size();
-
-            AppendU64LE(out, static_cast<std::uint64_t>(s.size()));
-
-            if (!s.empty())
-                AppendBytes(out, s.data(), s.size());
-
-            return out.size() - before;
-        }
-
-        inline size_t ToBinary(ByteBuffer& out, const std::string& s) {
-            return ToBinary(out, std::string_view{ s });
-        }
-
-        inline size_t ToBinary(ByteBuffer& out, const char* s) {
-            return ToBinary(out, s ? std::string_view{ s } : std::string_view{});
-        }
-
-        inline size_t ToBinary(ByteBuffer& out, const std::filesystem::path& p) {
-            const auto u8 = p.u8string();
-            std::string_view bytes(reinterpret_cast<const char*>(u8.data()), u8.size());
-            return ToBinary(out, bytes);
-        }
-
-        template <typename T>
-        inline size_t ToBinary(ByteBuffer& out, const T& v) requires std::is_arithmetic_v<T> {
-            const size_t before = out.size();
-
-            if constexpr (std::is_floating_point_v<T>) {
-                const double d = static_cast<double>(v);
-                const std::uint64_t bits = std::bit_cast<std::uint64_t>(d);
-                AppendU64LE(out, bits);
-            } else {
-                const std::int64_t i = static_cast<std::int64_t>(v);
-                AppendU64LE(out, static_cast<std::uint64_t>(i));
-            }
-
-            return out.size() - before;
-        }
-
-        template <typename T>
-        inline size_t ToBinary(ByteBuffer& out, const std::vector<T>& vec) {
-            const size_t before = out.size();
-
-            AppendU64LE(out, static_cast<std::uint64_t>(vec.size()));
-
-            if constexpr (std::is_trivially_copyable_v<T>) {
-                if (!vec.empty())
-                    AppendBytes(out, vec.data(), vec.size() * sizeof(T));
-            } else {
-                for (const auto& e : vec)
-                    ToBinary(out, e);
-            }
-
-            return out.size() - before;
-        }
-
-        template <typename... Ts>
-        inline size_t ToBinary(ByteBuffer& out, const std::variant<Ts...>& v) {
-            const size_t before = out.size();
-
-            uint32_t index = static_cast<uint32_t>(v.index());
-            ToBinary(out, index);
-
-            std::visit([&](auto&& alt) {
-                using T = std::remove_cvref_t<decltype(alt)>;
-
-                if constexpr (NE::Core::Reflectable<T>) {
-                    ToBinary(out, alt);
-                }
-            }, v);
-
-            return out.size() - before;
-        }
-
-        template <typename E>
-        inline size_t ToBinary(ByteBuffer& out, E e) requires std::is_enum_v<E> {
-            using U = std::underlying_type_t<E>;
-            return ToBinary(out, static_cast<U>(e));
-        }
-
-        // Math types
-        inline size_t ToBinary(ByteBuffer& out, const NE::Math::Vec2& v) {
-            const size_t before = out.size();
-            ToBinary(out, v.x);
-            ToBinary(out, v.y);
-            return out.size() - before;
-        }
-
-        inline size_t ToBinary(ByteBuffer& out, const NE::Math::Vec3& v) {
-            const size_t before = out.size();
-            ToBinary(out, v.x);
-            ToBinary(out, v.y);
-            ToBinary(out, v.z);
-            return out.size() - before;
-        }
-
-        inline size_t ToBinary(ByteBuffer& out, const NE::Math::Vec4& v) {
-            const size_t before = out.size();
-            ToBinary(out, v.x);
-            ToBinary(out, v.y);
-            ToBinary(out, v.z);
-            ToBinary(out, v.w);
-            return out.size() - before;
-        }
-
-        template <NE::Core::Reflectable T>
-        inline size_t ToBinary(ByteBuffer& out, const T& obj) {
-            const size_t before = out.size();
-
-            NE::Core::ForEachFieldView(obj, [&](auto&& /*desc*/, auto&& field) {
-                ToBinary(out, field);
-                });
-
-            return out.size() - before;
-        }
-
-        // Custom serialization for NativeScript (includes SerializedFields and EntityReferenceFields)
-        size_t ToBinary(ByteBuffer& out, const NE::ECS::Component::NativeScript& nsc);
-    }
-
-    namespace Deserialization {
-        inline bool ReadBytes(const uint8_t*& it, const uint8_t* end, void* out, size_t size) {
-            if (it + size > end)
-                return false;
-
-            std::memcpy(out, it, size);
-            it += size;
-            return true;
-        }
-
-        inline bool ReadU64LE(const uint8_t*& it, const uint8_t* end, std::uint64_t& out) {
-            if (it + 8 > end)
-                return false;
-
-            out =
-                (std::uint64_t(it[0]) << 0) |
-                (std::uint64_t(it[1]) << 8) |
-                (std::uint64_t(it[2]) << 16) |
-                (std::uint64_t(it[3]) << 24) |
-                (std::uint64_t(it[4]) << 32) |
-                (std::uint64_t(it[5]) << 40) |
-                (std::uint64_t(it[6]) << 48) |
-                (std::uint64_t(it[7]) << 56);
-
-            it += 8;
-            return true;
-        }
-
-        template <NE::Core::Reflectable T>
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, T& obj);
-
-        // primitives and std types
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::uint64_t& v) {
-            return ReadU64LE(it, end, v);
-        }
-
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::string& s) {
-            std::uint64_t size = 0;
-            if (!ReadU64LE(it, end, size))
-                return false;
-
-            if (it + size > end)
-                return false;
-
-            s.assign(reinterpret_cast<const char*>(it), size);
-            it += size;
-            return true;
-        }
-
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::filesystem::path& p) {
-            std::string s;
-            if (!FromBinary(it, end, s))
-                return false;
-
-            p = std::filesystem::path(std::u8string(
-                reinterpret_cast<const char8_t*>(s.data()),
-                reinterpret_cast<const char8_t*>(s.data() + s.size())
-            ));
-            return true;
-        }
-
-        // arithmetic
-        template <typename T>
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, T& v) requires std::is_arithmetic_v<T> {
-            std::uint64_t raw = 0;
-            if (!ReadU64LE(it, end, raw))
-                return false;
-
-            if constexpr (std::is_floating_point_v<T>) {
-                const double d = std::bit_cast<double>(raw);
-                v = static_cast<T>(d);
-            } else {
-                const std::int64_t i = static_cast<std::int64_t>(raw);
-                v = static_cast<T>(i);
-            }
-
-            return true;
-        }
-
-        // std::vector
-        template <typename T>
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::vector<T>& vec) {
-            std::uint64_t count = 0;
-            if (!ReadU64LE(it, end, count))
-                return false;
-
-            vec.clear();
-            vec.resize(static_cast<size_t>(count));
-
-            if constexpr (std::is_trivially_copyable_v<T>) {
-                const size_t bytes = vec.size() * sizeof(T);
-                return ReadBytes(it, end, vec.data(), bytes);
-            } else {
-                for (auto& e : vec)
-                    if (!FromBinary(it, end, e))
-                        return false;
-                return true;
-            }
-        }
-
-        // std::variant
-        template <typename... Ts>
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::variant<Ts...>& v) {
-            uint32_t index = 0;
-            if (!FromBinary(it, end, index) || index >= sizeof...(Ts))
-                return false;
-
-            bool success = false;
-
-            [&] <std::size_t... Is>(std::index_sequence<Is...>) {
-                ((index == Is ? (v.template emplace<Is>(), success = true, false) : false) || ...);
-            }(std::make_index_sequence<sizeof...(Ts)>{});
-
-            if (!success)
-                return false;
-
-            return std::visit([&](auto&& value) -> bool {
-                using T = std::remove_cvref_t<decltype(value)>;
-
-                if constexpr (NE::Core::Reflectable<T>) {
-                    return FromBinary(it, end, value);
-                }
-
-            }, v);
-        }
-
-        // enums
-        template <typename E>
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, E& e) requires std::is_enum_v<E> {
-            using U = std::underlying_type_t<E>;
-            U v{};
-            if (!FromBinary(it, end, v))
-                return false;
-
-            e = static_cast<E>(v);
-            return true;
-        }
-
-        // math
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::Math::Vec2& v) {
-            return FromBinary(it, end, v.x)
-                && FromBinary(it, end, v.y);
-        }
-
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::Math::Vec3& v) {
-            return FromBinary(it, end, v.x)
-                && FromBinary(it, end, v.y)
-                && FromBinary(it, end, v.z);
-        }
-
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::Math::Vec4& v) {
-            return FromBinary(it, end, v.x)
-                && FromBinary(it, end, v.y)
-                && FromBinary(it, end, v.z)
-                && FromBinary(it, end, v.w);
-        }
-
-        template <NE::Core::Reflectable T>
-        inline bool FromBinary(const uint8_t*& it, const uint8_t* end, T& obj) {
-            bool ok = true;
-
-            NE::Core::ForEachField(obj, [&](auto&& /*desc*/, auto&& field) {
-                if (!ok) return;
-                ok = FromBinary(it, end, field);
-                });
-
-            return ok;
-        }
-
-        // Custom deserialization for NativeScript (includes SerializedFields and EntityReferenceFields)
-        bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::ECS::Component::NativeScript& nsc);
-    }
-
+	namespace Serialization {
+		// low-level helpers
+		inline void AppendBytes(ByteBuffer& out, const void* data, size_t size) {
+			const auto* p = static_cast<const std::uint8_t*>(data);
+			out.insert(out.end(), p, p + size);
+		}
+
+		// uint64 to little-endian
+		inline void AppendU64LE(ByteBuffer& out, std::uint64_t v) {
+			std::uint8_t b[8];
+			b[0] = (std::uint8_t)((v >> 0) & 0xFF);
+			b[1] = (std::uint8_t)((v >> 8) & 0xFF);
+			b[2] = (std::uint8_t)((v >> 16) & 0xFF);
+			b[3] = (std::uint8_t)((v >> 24) & 0xFF);
+			b[4] = (std::uint8_t)((v >> 32) & 0xFF);
+			b[5] = (std::uint8_t)((v >> 40) & 0xFF);
+			b[6] = (std::uint8_t)((v >> 48) & 0xFF);
+			b[7] = (std::uint8_t)((v >> 56) & 0xFF);
+			AppendBytes(out, b, sizeof(b));
+		}
+
+		template <NE::Core::Reflectable T>
+		inline size_t ToBinary(ByteBuffer& out, const T& obj);
+
+		// Primitives and std types
+		inline size_t ToBinary(ByteBuffer& out, const std::uint64_t& v) {
+			const size_t before = out.size();
+			AppendU64LE(out, v);
+			return out.size() - before;
+		}
+
+		inline size_t ToBinary(ByteBuffer& out, std::string_view s) {
+			const size_t before = out.size();
+
+			AppendU64LE(out, static_cast<std::uint64_t>(s.size()));
+
+			if (!s.empty())
+				AppendBytes(out, s.data(), s.size());
+
+			return out.size() - before;
+		}
+
+		inline size_t ToBinary(ByteBuffer& out, const std::string& s) {
+			return ToBinary(out, std::string_view{ s });
+		}
+
+		inline size_t ToBinary(ByteBuffer& out, const char* s) {
+			return ToBinary(out, s ? std::string_view{ s } : std::string_view{});
+		}
+
+		inline size_t ToBinary(ByteBuffer& out, const std::filesystem::path& p) {
+			const auto u8 = p.u8string();
+			std::string_view bytes(reinterpret_cast<const char*>(u8.data()), u8.size());
+			return ToBinary(out, bytes);
+		}
+
+		template <typename T>
+		inline size_t ToBinary(ByteBuffer& out, const T& v) requires std::is_arithmetic_v<T> {
+			const size_t before = out.size();
+
+			if constexpr (std::is_floating_point_v<T>) {
+				const double d = static_cast<double>(v);
+				const std::uint64_t bits = std::bit_cast<std::uint64_t>(d);
+				AppendU64LE(out, bits);
+			} else {
+				const std::int64_t i = static_cast<std::int64_t>(v);
+				AppendU64LE(out, static_cast<std::uint64_t>(i));
+			}
+
+			return out.size() - before;
+		}
+
+		template <typename T>
+		inline size_t ToBinary(ByteBuffer& out, const std::vector<T>& vec) {
+			const size_t before = out.size();
+
+			AppendU64LE(out, static_cast<std::uint64_t>(vec.size()));
+
+			if constexpr (std::is_trivially_copyable_v<T>) {
+				if (!vec.empty())
+					AppendBytes(out, vec.data(), vec.size() * sizeof(T));
+			} else {
+				for (const auto& e : vec)
+					ToBinary(out, e);
+			}
+
+			return out.size() - before;
+		}
+
+		template <typename... Ts>
+		inline size_t ToBinary(ByteBuffer& out, const std::variant<Ts...>& v) {
+			const size_t before = out.size();
+
+			uint32_t index = static_cast<uint32_t>(v.index());
+			ToBinary(out, index);
+
+			std::visit([&](auto&& alt) {
+				using T = std::remove_cvref_t<decltype(alt)>;
+
+				if constexpr (NE::Core::Reflectable<T>) {
+					ToBinary(out, alt);
+				}
+				}, v);
+
+			return out.size() - before;
+		}
+
+		// unordered_map
+		template <typename K, typename V, typename Hash, typename Eq, typename Alloc>
+		inline size_t ToBinary(ByteBuffer& out, const std::unordered_map<K, V, Hash, Eq, Alloc>& map) {
+			const size_t before = out.size();
+
+			AppendU64LE(out, static_cast<std::uint64_t>(map.size()));
+
+			for (const auto& [k, v] : map) {
+				ToBinary(out, k);
+				ToBinary(out, v);
+			}
+
+			return out.size() - before;
+		}
+
+		// unordered_set
+		template <typename T, typename Hash, typename Eq, typename Alloc>
+		inline size_t ToBinary(ByteBuffer& out, const std::unordered_set<T, Hash, Eq, Alloc>& set) {
+			const size_t before = out.size();
+
+			AppendU64LE(out, static_cast<std::uint64_t>(set.size()));
+
+			for (const auto& e : set) {
+				ToBinary(out, e);
+			}
+
+			return out.size() - before;
+		}
+
+		// enums
+		template <typename E>
+		inline size_t ToBinary(ByteBuffer& out, E e) requires std::is_enum_v<E> {
+			using U = std::underlying_type_t<E>;
+			return ToBinary(out, static_cast<U>(e));
+		}
+
+		// Math types
+		inline size_t ToBinary(ByteBuffer& out, const NE::Math::Vec2& v) {
+			const size_t before = out.size();
+			ToBinary(out, v.x);
+			ToBinary(out, v.y);
+			return out.size() - before;
+		}
+
+		inline size_t ToBinary(ByteBuffer& out, const NE::Math::Vec3& v) {
+			const size_t before = out.size();
+			ToBinary(out, v.x);
+			ToBinary(out, v.y);
+			ToBinary(out, v.z);
+			return out.size() - before;
+		}
+
+		inline size_t ToBinary(ByteBuffer& out, const NE::Math::Vec4& v) {
+			const size_t before = out.size();
+			ToBinary(out, v.x);
+			ToBinary(out, v.y);
+			ToBinary(out, v.z);
+			ToBinary(out, v.w);
+			return out.size() - before;
+		}
+
+		template <NE::Core::Reflectable T>
+		inline size_t ToBinary(ByteBuffer& out, const T& obj) {
+			const size_t before = out.size();
+
+			NE::Core::ForEachFieldView(obj, [&](auto&& /*desc*/, auto&& field) {
+				ToBinary(out, field);
+				});
+
+			return out.size() - before;
+		}
+	}
+
+	namespace Deserialization {
+		inline bool ReadBytes(const uint8_t*& it, const uint8_t* end, void* out, size_t size) {
+			if (it + size > end)
+				return false;
+
+			std::memcpy(out, it, size);
+			it += size;
+			return true;
+		}
+
+		inline bool ReadU64LE(const uint8_t*& it, const uint8_t* end, std::uint64_t& out) {
+			if (it + 8 > end)
+				return false;
+
+			out =
+				(std::uint64_t(it[0]) << 0) |
+				(std::uint64_t(it[1]) << 8) |
+				(std::uint64_t(it[2]) << 16) |
+				(std::uint64_t(it[3]) << 24) |
+				(std::uint64_t(it[4]) << 32) |
+				(std::uint64_t(it[5]) << 40) |
+				(std::uint64_t(it[6]) << 48) |
+				(std::uint64_t(it[7]) << 56);
+
+			it += 8;
+			return true;
+		}
+
+		template <NE::Core::Reflectable T>
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, T& obj);
+
+		// primitives and std types
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::uint64_t& v) {
+			return ReadU64LE(it, end, v);
+		}
+
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::string& s) {
+			std::uint64_t size = 0;
+			if (!ReadU64LE(it, end, size))
+				return false;
+
+			if (it + size > end)
+				return false;
+
+			s.assign(reinterpret_cast<const char*>(it), size);
+			it += size;
+			return true;
+		}
+
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::filesystem::path& p) {
+			std::string s;
+			if (!FromBinary(it, end, s))
+				return false;
+
+			p = std::filesystem::path(std::u8string(
+				reinterpret_cast<const char8_t*>(s.data()),
+				reinterpret_cast<const char8_t*>(s.data() + s.size())
+			));
+			return true;
+		}
+
+		// arithmetic
+		template <typename T>
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, T& v) requires std::is_arithmetic_v<T> {
+			std::uint64_t raw = 0;
+			if (!ReadU64LE(it, end, raw))
+				return false;
+
+			if constexpr (std::is_floating_point_v<T>) {
+				const double d = std::bit_cast<double>(raw);
+				v = static_cast<T>(d);
+			} else {
+				const std::int64_t i = static_cast<std::int64_t>(raw);
+				v = static_cast<T>(i);
+			}
+
+			return true;
+		}
+
+		// std::vector
+		template <typename T>
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::vector<T>& vec) {
+			std::uint64_t count = 0;
+			if (!ReadU64LE(it, end, count))
+				return false;
+
+			vec.clear();
+			vec.resize(static_cast<size_t>(count));
+
+			if constexpr (std::is_trivially_copyable_v<T>) {
+				const size_t bytes = vec.size() * sizeof(T);
+				return ReadBytes(it, end, vec.data(), bytes);
+			} else {
+				for (auto& e : vec)
+					if (!FromBinary(it, end, e))
+						return false;
+				return true;
+			}
+		}
+
+		// std::variant
+		template <typename... Ts>
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, std::variant<Ts...>& v) {
+			uint32_t index = 0;
+			if (!FromBinary(it, end, index) || index >= sizeof...(Ts))
+				return false;
+
+			bool success = false;
+
+			[&] <std::size_t... Is>(std::index_sequence<Is...>) {
+				((index == Is ? (v.template emplace<Is>(), success = true, false) : false) || ...);
+			}(std::make_index_sequence<sizeof...(Ts)>{});
+
+			if (!success)
+				return false;
+
+			return std::visit([&](auto&& value) -> bool {
+				using T = std::remove_cvref_t<decltype(value)>;
+
+				if constexpr (NE::Core::Reflectable<T>) {
+					return FromBinary(it, end, value);
+				}
+				}, v);
+		}
+
+		// unordered_map
+		template <typename K, typename V, typename Hash, typename Eq, typename Alloc>
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end,
+			std::unordered_map<K, V, Hash, Eq, Alloc>& map) {
+			std::uint64_t count = 0;
+			if (!ReadU64LE(it, end, count))
+				return false;
+
+			map.clear();
+			map.reserve(static_cast<size_t>(count));
+
+			for (std::uint64_t i = 0; i < count; ++i) {
+				K key{};
+				V value{};
+
+				if (!FromBinary(it, end, key))   return false;
+				if (!FromBinary(it, end, value)) return false;
+
+				// If stream contains duplicate keys, last one wins:
+				map.insert_or_assign(std::move(key), std::move(value));
+			}
+
+			return true;
+		}
+
+		// unordered_set
+		template <typename T, typename Hash, typename Eq, typename Alloc>
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end,
+			std::unordered_set<T, Hash, Eq, Alloc>& set) {
+			std::uint64_t count = 0;
+			if (!ReadU64LE(it, end, count))
+				return false;
+
+			set.clear();
+			set.reserve(static_cast<size_t>(count));
+
+			for (std::uint64_t i = 0; i < count; ++i) {
+				T value{};
+				if (!FromBinary(it, end, value))
+					return false;
+
+				set.insert(std::move(value));
+			}
+
+			return true;
+		}
+
+		// enums
+		template <typename E>
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, E& e) requires std::is_enum_v<E> {
+			using U = std::underlying_type_t<E>;
+			U v{};
+			if (!FromBinary(it, end, v))
+				return false;
+
+			e = static_cast<E>(v);
+			return true;
+		}
+
+		// math
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::Math::Vec2& v) {
+			return FromBinary(it, end, v.x)
+				&& FromBinary(it, end, v.y);
+		}
+
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::Math::Vec3& v) {
+			return FromBinary(it, end, v.x)
+				&& FromBinary(it, end, v.y)
+				&& FromBinary(it, end, v.z);
+		}
+
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::Math::Vec4& v) {
+			return FromBinary(it, end, v.x)
+				&& FromBinary(it, end, v.y)
+				&& FromBinary(it, end, v.z)
+				&& FromBinary(it, end, v.w);
+		}
+
+		template <NE::Core::Reflectable T>
+		inline bool FromBinary(const uint8_t*& it, const uint8_t* end, T& obj) {
+			bool ok = true;
+
+			NE::Core::ForEachField(obj, [&](auto&& /*desc*/, auto&& field) {
+				if (!ok) return;
+				ok = FromBinary(it, end, field);
+				});
+
+			return ok;
+		}
+	}
 }
 
 #endif // !BINARY_REFLECTION_HPP

--- a/NANOEngine/src/Serialisation/Serializer.cpp
+++ b/NANOEngine/src/Serialisation/Serializer.cpp
@@ -57,7 +57,7 @@ namespace NE {
 		inline constexpr int CURRENT_NANOSCENE_FORMAT_VERSION = 2;
 
 		inline constexpr uint32_t NFAB_MAGIC = 0x4E464142;
-		inline constexpr int CURRENT_NANOPREFAB_FORMAT_VERSION = 1;
+		inline constexpr int CURRENT_NANOPREFAB_FORMAT_VERSION = 2;
 
 		void AppendPreorder(ECS::ECSCoordinator& ecs, ECS::Entity e, std::vector<ECS::Entity>& out) {
 			out.push_back(e);
@@ -278,65 +278,65 @@ namespace NE {
 			outBuffer.assign(buf.data(), buf.data() + buf.size());
 		}
 
-		// Custom binary serialization for NativeScript component
-		size_t ToBinary(ByteBuffer& out, const NE::ECS::Component::NativeScript& nsc) {
-			const size_t before = out.size();
+		//// Custom binary serialization for NativeScript component
+		//size_t ToBinary(ByteBuffer& out, const NE::ECS::Component::NativeScript& nsc) {
+		//	const size_t before = out.size();
 
-			// Serialize ScriptNames using reflection
-			ToBinary(out, nsc.ScriptNames);
+		//	// Serialize ScriptNames using reflection
+		//	ToBinary(out, nsc.ScriptNames);
 
-			// Serialize SerializedFields (unordered_map<string, string>)
-			AppendU64LE(out, static_cast<uint64_t>(nsc.SerializedFields.size()));
-			for (const auto& [key, value] : nsc.SerializedFields) {
-				ToBinary(out, key);
-				ToBinary(out, value);
-			}
+		//	// Serialize SerializedFields (unordered_map<string, string>)
+		//	AppendU64LE(out, static_cast<uint64_t>(nsc.SerializedFields.size()));
+		//	for (const auto& [key, value] : nsc.SerializedFields) {
+		//		ToBinary(out, key);
+		//		ToBinary(out, value);
+		//	}
 
-			// Serialize EntityReferenceFields (unordered_set<string>)
-			AppendU64LE(out, static_cast<uint64_t>(nsc.EntityReferenceFields.size()));
-			for (const auto& field : nsc.EntityReferenceFields) {
-				ToBinary(out, field);
-			}
+		//	// Serialize EntityReferenceFields (unordered_set<string>)
+		//	AppendU64LE(out, static_cast<uint64_t>(nsc.EntityReferenceFields.size()));
+		//	for (const auto& field : nsc.EntityReferenceFields) {
+		//		ToBinary(out, field);
+		//	}
 
-			return out.size() - before;
-		}
+		//	return out.size() - before;
+		//}
 	}
 
 	namespace Deserialization {
 		// Custom deserialization for NativeScript component (must be BEFORE DeserializeScene)
-		bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::ECS::Component::NativeScript& nsc) {
-			// Deserialize ScriptNames using reflection
-			if (!FromBinary(it, end, nsc.ScriptNames))
-				return false;
+		//bool FromBinary(const uint8_t*& it, const uint8_t* end, NE::ECS::Component::NativeScript& nsc) {
+		//	// Deserialize ScriptNames using reflection
+		//	if (!FromBinary(it, end, nsc.ScriptNames))
+		//		return false;
 
-			// Deserialize SerializedFields (unordered_map<string, string>)
-			uint64_t fieldsCount = 0;
-			if (!ReadU64LE(it, end, fieldsCount))
-				return false;
+		//	// Deserialize SerializedFields (unordered_map<string, string>)
+		//	uint64_t fieldsCount = 0;
+		//	if (!ReadU64LE(it, end, fieldsCount))
+		//		return false;
 
-			nsc.SerializedFields.clear();
-			for (uint64_t i = 0; i < fieldsCount; ++i) {
-				std::string key, value;
-				if (!FromBinary(it, end, key) || !FromBinary(it, end, value))
-					return false;
-				nsc.SerializedFields[key] = value;
-			}
+		//	nsc.SerializedFields.clear();
+		//	for (uint64_t i = 0; i < fieldsCount; ++i) {
+		//		std::string key, value;
+		//		if (!FromBinary(it, end, key) || !FromBinary(it, end, value))
+		//			return false;
+		//		nsc.SerializedFields[key] = value;
+		//	}
 
-			// Deserialize EntityReferenceFields (unordered_set<string>)
-			uint64_t refFieldsCount = 0;
-			if (!ReadU64LE(it, end, refFieldsCount))
-				return false;
+		//	// Deserialize EntityReferenceFields (unordered_set<string>)
+		//	uint64_t refFieldsCount = 0;
+		//	if (!ReadU64LE(it, end, refFieldsCount))
+		//		return false;
 
-			nsc.EntityReferenceFields.clear();
-			for (uint64_t i = 0; i < refFieldsCount; ++i) {
-				std::string field;
-				if (!FromBinary(it, end, field))
-					return false;
-				nsc.EntityReferenceFields.insert(field);
-			}
+		//	nsc.EntityReferenceFields.clear();
+		//	for (uint64_t i = 0; i < refFieldsCount; ++i) {
+		//		std::string field;
+		//		if (!FromBinary(it, end, field))
+		//			return false;
+		//		nsc.EntityReferenceFields.insert(field);
+		//	}
 
-			return true;
-		}
+		//	return true;
+		//}
 
 		namespace {
 			bool ReadAllBytes(const std::string& path, NE::ByteBuffer& out) {


### PR DESCRIPTION
Implemented generic JSON and binary (de)serialization for std::unordered_map and std::unordered_set in both Editor and engine serialization code. Updated NativeScript reflection to include hidden fields for proper serialization. Refactored ECSExports to add missing component accessors and a generic GetComponent template. Bumped prefab binary format version to 2 and removed custom NativeScript (de)serialization in favor of generic support.