### PR TITLE
Add SceneChangedEvent to reset editor state on scene load

### DIFF
--- a/Editor/src/Command/CommandHistory.cpp
+++ b/Editor/src/Command/CommandHistory.cpp
@@ -104,6 +104,18 @@ namespace Editor {
                 ExecuteCommand(std::make_unique<DeleteEntityCommand>(e.entitiesToBeDeleted));
             }
         );
+
+        NANOEngine::Events::EventBus::Get().Subscribe<Events::SceneChangedEvent>(
+            NANOEngine::Events::EventDomain::Editor,
+            [&](const Events::SceneChangedEvent& e) {
+                ClearHistory();
+            }
+        );
+    }
+
+    void CommandHistory::ClearHistory() {
+        m_undoList.clear();
+		m_redoList.clear();
     }
 
     void CommandHistory::ExecuteCommand(std::unique_ptr<ICommand> command) {

--- a/Editor/src/Command/CommandHistory.hpp
+++ b/Editor/src/Command/CommandHistory.hpp
@@ -22,6 +22,7 @@ namespace Editor {
         CommandHistory();
         ~CommandHistory() = default;
 
+        void ClearHistory();
         std::vector<std::unique_ptr<ICommand>> m_undoList;
         std::vector<std::unique_ptr<ICommand>> m_redoList;
     };

--- a/Editor/src/EditorEvents.hpp
+++ b/Editor/src/EditorEvents.hpp
@@ -57,4 +57,8 @@ namespace Editor::Events {
 	struct GotoAssetPathEvent {
 		std::string assetPath;
 	};
+
+	struct SceneChangedEvent {
+
+	};
 }

--- a/Editor/src/Panels/AssetBrowserPanel.cpp
+++ b/Editor/src/Panels/AssetBrowserPanel.cpp
@@ -136,6 +136,7 @@ namespace Editor {
 
 				if (ImGui::Button("Yes")) {
 					auto uuid = Assets::AssetManager::GetInstance().RetrieveUUID(m_selectedPath.string());
+					EditorScene::s_selection.Clear();
 					NE::CreateSceneFallback(uuid);
 					Deserialization::JSON::DeserializeScene(m_selectedPath.string());
 					NE::StartSceneFallback();
@@ -143,6 +144,11 @@ namespace Editor {
 					EditorScene::s_currentScenePath = m_selectedPath.string();
 					EditorScene::s_currentSceneUUID = uuid;
 					EditorScene::isDirty = false;
+
+					NANOEngine::Events::EventBus::Get().Dispatch(
+						NANOEngine::Events::EventDomain::Editor,
+						Events::SceneChangedEvent{ }
+					);
 
 					m_selectedPath.clear();
 					ImGui::CloseCurrentPopup();

--- a/Editor/src/Panels/HierarchyPanel.cpp
+++ b/Editor/src/Panels/HierarchyPanel.cpp
@@ -103,6 +103,13 @@ namespace Editor {
 
 	HierarchyPanel::HierarchyPanel() {
 		EditorScene::BuildRoot();
+
+		NANOEngine::Events::EventBus::Get().Subscribe<Events::SceneChangedEvent>(
+			NANOEngine::Events::EventDomain::Editor,
+			[&](const Events::SceneChangedEvent& e) {
+				SceneChanged();
+			}
+		);
 	}
 
 	void HierarchyPanel::OnImGuiRender() {
@@ -375,6 +382,20 @@ namespace Editor {
 		}
 
 		ImGui::End();
+	}
+
+	void HierarchyPanel::SceneChanged() {
+		m_lastPrimary = NE::ECS::NO_ENTITY;
+		m_dragRep = NE::ECS::NO_ENTITY;
+		m_previewParentForInsert = NE::ECS::NO_ENTITY;
+		m_clickCandidate = NE::ECS::NO_ENTITY;
+		m_previewAsChild = false;
+
+		m_filtering = false;
+		m_visible.clear();
+
+		m_expanded.clear();
+		m_forceOpen.clear();
 	}
 
 	void HierarchyPanel::DrawEntityNode(NE::ECS::Entity e,

--- a/Editor/src/Panels/HierarchyPanel.hpp
+++ b/Editor/src/Panels/HierarchyPanel.hpp
@@ -16,6 +16,8 @@ namespace Editor {
 		void OnImGuiRender() override;
 
 	private:
+		void SceneChanged();
+
 		void DrawEntityNode(NE::ECS::Entity e, std::vector<NE::ECS::Entity>& preorder, NE::ECS::Entity parent, int indexInParent);
 		void HandleDragSource(NE::ECS::Entity e,
 			const std::vector<NE::ECS::Entity>& preorder);

--- a/Editor/src/Panels/ScenePanel.cpp
+++ b/Editor/src/Panels/ScenePanel.cpp
@@ -391,7 +391,7 @@ namespace Editor {
 				mousePos.x >= panelPos.x && mousePos.x < panelPos.x + panelSize.x &&
 				mousePos.y >= panelPos.y && mousePos.y < panelPos.y + panelSize.y;
 
-			if (insideScene) {
+			if (insideScene && !ImGui::IsAnyItemHovered()) {
 				if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
 					m_dragSelecting = true;
 					m_dragStartScreen = mousePos;


### PR DESCRIPTION
Introduces a SceneChangedEvent and updates CommandHistory, HierarchyPanel, and AssetBrowserPanel to subscribe or dispatch this event. This ensures undo/redo history and selection state are cleared, and the hierarchy panel is reset when a new scene is loaded, improving editor consistency.