### PR TITLE
Infer import settings from file names for assets

### DIFF
--- a/Editor/src/AssetManagement/Assets/ModelAsset.cpp
+++ b/Editor/src/AssetManagement/Assets/ModelAsset.cpp
@@ -1128,6 +1128,7 @@ namespace Editor::Assets {
 	bool ModelAsset::SaveImportSettings(const std::string& sourcePath) {
 		using rapidjson::Value;
 
+		std::filesystem::path srcPath = sourcePath;
 		std::string metaPath = sourcePath + ".meta";
 
 		rapidjson::Document doc;
@@ -1147,6 +1148,8 @@ namespace Editor::Assets {
 		auto& alloc = doc.GetAllocator();
 
 		if (!importSettings) importSettings.emplace();
+		importSettings->scene.scaleFactor = GuessScaleFactorFromExtension(srcPath.extension().string());
+
 		auto jSettings = Serialization::ToJSON(*importSettings, alloc);
 
 		if (doc.HasMember("modelImport"))

--- a/Editor/src/AssetManagement/Assets/TextureAsset.cpp
+++ b/Editor/src/AssetManagement/Assets/TextureAsset.cpp
@@ -16,6 +16,25 @@
 
 namespace Editor::Assets {
 	namespace {
+		void GuessImportSettingsFromNameConvention(TextureImportSettings& importSettings, std::string filename) {
+			for (auto& c : filename) c = (char)std::tolower((unsigned char)c);
+			if (filename.find("_n.") != std::string::npos) {
+				importSettings.type = TexType::NormalMap;
+				importSettings.sRGB = false;
+			}
+			else if (filename.find("_r.") != std::string::npos || 
+				filename.find("_m.") != std::string::npos || 
+				filename.find("_ao.") != std::string::npos || 
+				filename.find("_o.") != std::string::npos || 
+				filename.find("_h.") != std::string::npos) 
+			{
+				importSettings.sRGB = false;
+			}
+			else {
+				importSettings.sRGB = true;
+			}
+		}
+
 		bool CMP_API Progress(float fProgress, CMP_DWORD_PTR, CMP_DWORD_PTR) {
 			std::printf("\r[BC7] %3.0f%%", fProgress);
 			return false;
@@ -253,44 +272,6 @@ namespace Editor::Assets {
 		using rapidjson::OStreamWrapper;
 		using rapidjson::PrettyWriter;
 
-		//fs::path metaPath = fs::path(sourcePath).concat(".meta");
-		//if (!fs::exists(metaPath)) {
-		//	SPD_WARNING("TextureAsset::SaveImportSettings - meta does not exist: "
-		//		<< metaPath.string());
-		//	return false;
-		//}
-
-		//std::ifstream ifs(metaPath);
-		//if (!ifs)
-		//	return false;
-
-		//IStreamWrapper isw(ifs);
-		//Document doc;
-		//doc.ParseStream(isw);
-		//if (doc.HasParseError() || !doc.IsObject())
-		//	return false;
-
-		//auto& alloc = doc.GetAllocator();
-
-		//if (!importSettings) importSettings.emplace();
-		//auto texImportJson = Serialization::ToJSON(*importSettings, alloc);
-
-		//if (doc.HasMember("textureImport") && doc["textureImport"].IsObject()) {
-		//	doc["textureImport"].CopyFrom(texImportJson, alloc);
-		//} else {
-		//	doc.AddMember("textureImport", texImportJson, alloc);
-		//}
-
-		//std::ofstream ofs(metaPath, std::ios::trunc);
-		//if (!ofs)
-		//	return false;
-
-		//OStreamWrapper osw(ofs);
-		//PrettyWriter<OStreamWrapper> writer(osw);
-		//writer.SetIndent(' ', 4);
-		//doc.Accept(writer);
-
-		//return true;
 		std::string metaPath = sourcePath + ".meta";
 
 		rapidjson::Document doc;
@@ -309,7 +290,13 @@ namespace Editor::Assets {
 
 		auto& alloc = doc.GetAllocator();
 
-		if (!importSettings) importSettings.emplace();
+		if (!importSettings) {
+			importSettings.emplace();
+
+			GuessImportSettingsFromNameConvention(*importSettings,
+				std::filesystem::path(sourcePath).filename().string());
+		}
+
 		auto jSettings = Serialization::ToJSON(*importSettings, alloc);
 
 		if (doc.HasMember("textureImport"))


### PR DESCRIPTION
Added logic to guess and set import settings for models and textures based on file name conventions and extensions. This improves automation and consistency when importing new assets.