### PR TITLE
Improve normal mapping and BRDF stability in shader

### DIFF
--- a/binfiles/Library/Shaders/Lit_PBR.nanoshader
+++ b/binfiles/Library/Shaders/Lit_PBR.nanoshader
@@ -337,10 +337,10 @@ mat3 ComputeTBN(vec3 N, vec3 P, vec2 uv){
 vec3 BRDF_GGX_Smith(vec3 N, vec3 V, vec3 L, vec3 albedo, float metallic, float rough){
     vec3 H = normalize(V + L);
     float NdotL = max(dot(N,L),0.0);
-    float NdotV = max(dot(N,V),0.0);
     float NdotH = max(dot(N,H),0.0);
     float VdotH = max(dot(V,H),0.0);
-    if (NdotL<=0.0 || NdotV<=0.0) return vec3(0.0);
+	float NdotV = max(dot(N,V), 1e-4);
+	if (NdotL <= 0.0) return vec3(0.0);
 
     vec3 F0 = mix(vec3(0.04), albedo, metallic);
     float D = DistributionGGX(NdotH,rough);
@@ -503,9 +503,17 @@ void main() {
     if (h_HasNormalMap != 0){
         vec2 enc = texture(u_NormalMap, uv).rg * 2.0 - 1.0;
         float z = sqrt(max(1.0 - dot(enc, enc), 0.0));
-        vec3 n = vec3(enc, z);
-        //mat3 TBN = ComputeTBN(N, v_FragPos, uv);
-        N = normalize(TBN * n);
+		vec3 n = vec3(enc, z);
+		n = normalize(n);
+		N = normalize(TBN * n);
+		
+		//vec2 enc = texture(u_NormalMap, uv).rg * 2.0 - 1.0;
+		//float len2 = dot(enc, enc);
+		//if (len2 > 1.0) enc *= inversesqrt(len2);
+		//float z = sqrt(max(1.0 - dot(enc, enc), 0.0));
+		//vec3 n_ts = normalize(vec3(enc, z));
+		//N = normalize(TBN * n_ts);
+
     }
 
     // Roughness/Metallic


### PR DESCRIPTION
Refines the BRDF_GGX_Smith function to avoid division by zero by clamping NdotV to a small positive value and simplifies the early return condition. Enhances normal mapping by normalizing the tangent-space normal before transforming, and adds commented alternative code for future reference.