### PR TITLE
Add mesh collider support and cooked collider blobs

### DIFF
--- a/Editor/src/AssetManagement/Assets/ModelAsset.cpp
+++ b/Editor/src/AssetManagement/Assets/ModelAsset.cpp
@@ -20,6 +20,7 @@
 #include <ECS/Components/Hierarchy.hpp>
 #include <ECS/Components/Renderer.hpp>
 #include <Graphics/Core/Material.hpp>
+#include <Engine.hpp>
 
 #include "../AssetManager.hpp"
 #include "../../Serialization/JSONReflection.hpp"
@@ -50,6 +51,9 @@ namespace Editor::Assets {
 			float px, py, pz;
 			float nx, ny, nz;
 			float u, v;
+
+			float tx, ty, tz;
+			float tSign; // +1 / -1
 		};
 
 		struct Bounds {
@@ -853,6 +857,7 @@ namespace Editor::Assets {
 		struct RawBlob {
 			std::vector<uint8_t> vertices;
 			std::vector<uint8_t> indices;
+			std::vector<uint8_t> collider;
 		};
 		std::vector<RawBlob> blobs(scene->mNumMeshes);
 
@@ -887,6 +892,27 @@ namespace Editor::Assets {
 					v.u = v.v = 0.0f;
 				}
 
+				if (mesh->HasTangentsAndBitangents()) {
+					auto NormalizeSafe = [](aiVector3D v) {
+						float len2 = v.x * v.x + v.y * v.y + v.z * v.z;
+						if (len2 > 1e-12f) { float inv = 1.0f / std::sqrt(len2); v.x *= inv; v.y *= inv; v.z *= inv; }
+						return v;
+						};
+
+					aiVector3D T = NormalizeSafe(mesh->mTangents[i]);
+					aiVector3D B = NormalizeSafe(mesh->mBitangents[i]);
+					aiVector3D N = NormalizeSafe(mesh->HasNormals() ? mesh->mNormals[i] : aiVector3D(0, 1, 0));
+
+					// Cross product then dot product
+					float sign = ((N ^ T) * B) < 0.0f ? -1.0f : 1.0f;
+
+					v.tx = T.x; v.ty = T.y; v.tz = T.z;
+					v.tSign = sign;
+				} else {
+					v.tx = v.ty = v.tz = 0.0f;
+					v.tSign = 1.0f;
+				}
+
 				vout[i] = v;
 
 				subB.Expand(v.px, v.py, v.pz);
@@ -915,6 +941,21 @@ namespace Editor::Assets {
 				vout[i].px -= submeshPivots[m].x;
 				vout[i].py -= submeshPivots[m].y;
 				vout[i].pz -= submeshPivots[m].z;
+			}
+
+			if (importSettings->mesh.generateColliders) {
+				std::vector<NE::Math::Vec3> physVerts;
+				physVerts.reserve(mesh->mNumVertices);
+				for (uint32_t i = 0; i < mesh->mNumVertices; ++i) {
+					physVerts.push_back({ vout[i].px, vout[i].py, vout[i].pz });
+				}
+
+				rb.collider.clear();
+				bool ok = NE::CookMeshCollider(physVerts, idx, rb.collider);
+				if (!ok) {
+					SPD_WARNING("Collider cook failed for submesh " << m << " (" << sourcePath << "), writing without collider.");
+					rb.collider.clear();
+				}
 			}
 
 			subB.minP = subB.minP - submeshPivots[m];
@@ -948,8 +989,20 @@ namespace Editor::Assets {
 			uint32_t indexOffset = static_cast<uint32_t>(ofs.tellp());
 			ofs.write(reinterpret_cast<const char*>(rb.indices.data()), rb.indices.size());
 
+			uint32_t colliderOffset = 0;
+			uint32_t colliderSize = 0;
+			if (!rb.collider.empty()) {
+				colliderOffset = (uint32_t)ofs.tellp();
+				colliderSize = (uint32_t)rb.collider.size();
+				ofs.write((char*)rb.collider.data(), rb.collider.size());
+			}
+
 			subdescs[m].vertexDataOffset = vertexOffset;
 			subdescs[m].indexDataOffset = indexOffset;
+			subdescs[m].colliderDataOffset = colliderOffset;
+			subdescs[m].colliderDataSize = colliderSize;
+			subdescs[m].colliderType = 1; // triMesh
+			subdescs[m].vertexFlags = 0;
 		}
 
 		ofs.seekp(subTablePos, std::ios::beg);
@@ -1077,7 +1130,7 @@ namespace Editor::Assets {
 
 		rapidjson::OStreamWrapper osw(ofsMeta);
 		rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(osw);
-		writer.SetIndent(' ', 4);
+			writer.SetIndent(' ', 4);
 		doc.Accept(writer);
 
 		return true;

--- a/NANOEngine/NANOEngine.vcxproj
+++ b/NANOEngine/NANOEngine.vcxproj
@@ -193,6 +193,8 @@
     <ClInclude Include="src\Tween\TweenBase.hpp" />
     <ClInclude Include="src\Tween\TweenManager.hpp" />
     <ClInclude Include="src\Core\LUIDGenerator.hpp" />
+    <ClInclude Include="src\Physics\StreamOutImpl.hpp" />
+    <ClInclude Include="src\Physics\StreamInImpl.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Animation\AnimationClip.cpp" />
@@ -279,6 +281,8 @@
     <ClCompile Include="src\Tween\TweenBase.cpp" />
     <ClCompile Include="src\Tween\TweenManager.cpp" />
     <ClCompile Include="src\Core\LUIDGenerator.cpp" />
+    <ClCompile Include="src\Physics\StreamOutImpl.cpp" />
+    <ClCompile Include="src\Physics\StreamInImpl.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>

--- a/NANOEngine/NANOEngine.vcxproj.filters
+++ b/NANOEngine/NANOEngine.vcxproj.filters
@@ -87,6 +87,8 @@
     <ClCompile Include="src\ECS\Systems\CharacterControllerSystem.cpp" />
     <ClCompile Include="src\Animation\AnimationClip.cpp" />
     <ClCompile Include="src\Animation\AnimatorController.cpp" />
+    <ClCompile Include="src\Physics\StreamOutImpl.cpp" />
+    <ClCompile Include="src\Physics\StreamInImpl.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Core\Couroutine.hpp" />
@@ -255,6 +257,8 @@
     <ClInclude Include="src\Animation\AnimationClip.hpp" />
     <ClInclude Include="src\Animation\AnimatorController.hpp" />
     <ClInclude Include="src\ResourceManagement\BinaryHeaders\NanoAnimClipHeader.hpp" />
+    <ClInclude Include="src\Physics\StreamOutImpl.hpp" />
+    <ClInclude Include="src\Physics\StreamInImpl.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Core\Timer.cpp">

--- a/NANOEngine/src/ECS/Systems/ColliderSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/ColliderSystem.cpp
@@ -17,6 +17,7 @@ namespace NE::ECS::Systems {
 	void ColliderSystem::OnEntityAdded(Entity e) {
 		auto& meta = m_componentManager->GetComponent<Component::EntityMeta>(e);
 		auto& col = m_componentManager->GetComponent<Component::Collider>(e);
+		auto& t = m_componentManager->GetComponent<Component::Transform>(e);
 
 		if (col.luid == 0) {
 			col.luid = Core::LUIDGenerator::Generate("co");
@@ -35,7 +36,7 @@ namespace NE::ECS::Systems {
 
 		m_luidRegistry->Register(col.luid, &col, e);
 
-		Physics::PhysicsManager::GetInstance().CreateOrUpdateShape(meta.luid, col);
+		Physics::PhysicsManager::GetInstance().CreateOrUpdateShape(e, meta.luid, col);
 	}
 
 	void ColliderSystem::OnEntityRemoved(Entity e) {
@@ -68,14 +69,9 @@ namespace NE::ECS::Systems {
 			auto& t = m_componentManager->GetComponent<Component::Transform>(e);
 			auto& col = m_componentManager->GetComponent<Component::Collider>(e);
 			if (col.isDirty) {
-				Physics::PhysicsManager::GetInstance().CreateOrUpdateShape(meta.luid, col);
+				Physics::PhysicsManager::GetInstance().CreateOrUpdateShape(e, meta.luid, col);
 				col.isDirty = false;
 			}
-
-			//if (col.type != Component::Collider::ColliderType::Mesh)
-			//	Physics::PhysicsManager::GetInstance().DrawShapeGizmo(meta.luid, t, col);
-			//if (col.type != Component::Collider::ColliderType::Mesh)
-			//	Physics::PhysicsManager::GetInstance().DrawShapeGizmo(meta.luid, t);
 		}
 	}
 

--- a/NANOEngine/src/Engine.cpp
+++ b/NANOEngine/src/Engine.cpp
@@ -383,6 +383,12 @@ namespace NE {
 		Resource::ResourceManager::GetInstance().DestroyGLTexture(id);
 	}
 
+	bool CookMeshCollider(const std::vector<Math::Vec3>& vertices,
+		const std::vector<uint32_t>& indices, std::vector<uint8_t>& outBlob) 
+	{
+		return NE::Physics::PhysicsManager::GetInstance().CookMeshCollider(vertices, indices, outBlob);
+	}
+
 	void PreviewAnimation(uint32_t entity, const Animation::AnimationClip& animClip, float timeInSeconds) {
 		gSceneManager.GetActive()->GetECSCoordinator().m_animatorSystem->ApplyClipAtTime(entity, animClip, timeInSeconds);
 	}

--- a/NANOEngine/src/Engine.hpp
+++ b/NANOEngine/src/Engine.hpp
@@ -80,5 +80,8 @@ namespace NE {
 	NANOENGINE_API unsigned int LoadCookedThumbnailGL(const std::string& uuid);
 	NANOENGINE_API void DestroyGLTexture(unsigned int id);
 
+	NANOENGINE_API bool CookMeshCollider(const std::vector<Math::Vec3>& vertices,
+		const std::vector<uint32_t>& indices, std::vector<uint8_t>& outBlob);
+
 	NANOENGINE_API void PreviewAnimation(uint32_t entity, const Animation::AnimationClip& animClip, float timeInSeconds);
 }

--- a/NANOEngine/src/Graphics/Core/Model.cpp
+++ b/NANOEngine/src/Graphics/Core/Model.cpp
@@ -10,6 +10,9 @@ namespace {
         float px, py, pz;
         float nx, ny, nz;
         float u, v;
+
+        float tx, ty, tz;
+        float tSign;
     };
 }
 
@@ -22,7 +25,7 @@ namespace NE::Graphics {
         if (!hdr) return false;
         if (hdr->magic != Resource::NMOD_MAGIC) return false;
 
-        if (hdr->version != Resource::CURRENT_NANOMODEL_FORMAT_VERSION) return false;
+        if (hdr->version < 2 || hdr->version > Resource::CURRENT_NANOMODEL_FORMAT_VERSION) return false;
 
         const size_t subTableOff = sizeof(Resource::NanoMeshHeader);
         const size_t subTableSize = static_cast<size_t>(hdr->submeshCount) * sizeof(Resource::NanoSubmeshDesc);
@@ -52,11 +55,25 @@ namespace NE::Graphics {
             sm.idata = iptr;
             sm.indexCount = d.indexCount;
 
+            if (hdr->version >= 3 && d.colliderDataSize > 0) {
+                const uint8_t* cptr = blob.at(d.colliderDataOffset, d.colliderDataSize);
+                if (!cptr) return false;
+
+                sm.cdata = cptr;
+                sm.colliderSize = d.colliderDataSize;
+                sm.colliderType = d.colliderType;
+                sm.vertexFlags = d.vertexFlags;
+            } else {
+                sm.cdata = nullptr;
+                sm.colliderSize = 0;
+                sm.colliderType = 0;
+                sm.vertexFlags = 0;
+            }
+
             if (hdr->version >= 2) {
                 sm.localAABB.min = { d.aabbMin[0], d.aabbMin[1], d.aabbMin[2] };
                 sm.localAABB.max = { d.aabbMax[0], d.aabbMax[1], d.aabbMax[2] };
 
-                //sm.localSphere.center = { d.sphereCenter[0], d.sphereCenter[1], d.sphereCenter[2] };
                 sm.localSphere.radius = d.sphereRadius;
             }
 
@@ -97,6 +114,11 @@ namespace NE::Graphics {
 
             sub.buffer = std::make_shared<NE::Graphics::OpenGL::GLGeometryBuffer>(vb, ib);
 
+            if (sm.cdata && sm.colliderSize > 0) {
+                sub.colliderBlob.assign(sm.cdata, sm.cdata + sm.colliderSize);
+                sub.colliderType = sm.colliderType;
+            }
+
             sub.localAABB = sm.localAABB;
             sub.localSphere = sm.localSphere;
 
@@ -106,22 +128,13 @@ namespace NE::Graphics {
         m_staged.clear();
     }
 
-    bool Model::GetPhysicsMesh(std::vector<Math::Vec3>& outVerts, std::vector<uint32_t>& outIndices) const {
-        outVerts.clear();
-        outIndices.clear();
-
-        for (const auto& sm : meshes) {
-            uint32_t base = (uint32_t)outVerts.size();
-
-            // Copy positions
-            for (const auto& v : sm.vertices)
-                outVerts.push_back(v.Position);
-
-            // Copy indices (offset by base)
-            for (auto idx : sm.indices)
-                outIndices.push_back(base + idx);
-        }
-
-        return !outVerts.empty() && !outIndices.empty();
+    bool Model::GetSubmeshColliderBlob(uint32_t submeshIndex, const uint8_t*& outData, uint32_t& outSize, uint8_t& outType) const {
+        if (submeshIndex >= meshes.size()) return false;
+        const SubMesh& sm = meshes[submeshIndex];
+        if (sm.colliderBlob.empty()) return false;
+        outData = sm.colliderBlob.data();
+        outSize = (uint32_t)sm.colliderBlob.size();
+        outType = sm.colliderType;
+        return true;
     }
 }

--- a/NANOEngine/src/Graphics/Core/Model.hpp
+++ b/NANOEngine/src/Graphics/Core/Model.hpp
@@ -24,6 +24,8 @@ namespace NE::Graphics {
         std::vector<Vertex> vertices;
         std::vector<uint32_t> indices;
         std::shared_ptr<IGeometryBuffer> buffer;
+        std::vector<uint8_t> colliderBlob;
+        uint8_t colliderType = 0;
 
         AABB   localAABB;
         Sphere localSphere;
@@ -36,8 +38,10 @@ namespace NE::Graphics {
         bool Preload(Resource::BinaryView blob) override;
         void Finalize() override;
 
-        bool GetPhysicsMesh(std::vector<Math::Vec3>& outVerts,
-            std::vector<uint32_t>& outIndices) const;
+        bool GetSubmeshColliderBlob(uint32_t submeshIndex,
+            const uint8_t*& outData,
+            uint32_t& outSize,
+            uint8_t& outType) const;
 
         static constexpr Resource::ResourceType GetStaticType() { return Resource::ResourceType::Model; }
         Resource::ResourceType GetType() const override { return GetStaticType(); }
@@ -45,9 +49,16 @@ namespace NE::Graphics {
     private:
         struct StagedSubmesh {
             const uint8_t* vdata = nullptr;
-            uint32_t       vertexCount = 0;
+            uint32_t vertexCount = 0;
+
             const uint8_t* idata = nullptr;
-            uint32_t       indexCount = 0;
+            uint32_t indexCount = 0;
+
+            // NEW
+            const uint8_t* cdata = nullptr;
+            uint32_t colliderSize = 0;
+            uint8_t  colliderType = 0;
+            uint8_t  vertexFlags = 0;
 
             AABB   localAABB;
             Sphere localSphere;

--- a/NANOEngine/src/Physics/PhysicsManager.cpp
+++ b/NANOEngine/src/Physics/PhysicsManager.cpp
@@ -39,611 +39,767 @@
 #include "ECS/Components/Rigidbody.hpp"
 #include "ECS/Components/CharacterController.hpp"
 #include "ECS/Components/Transform.hpp"
+#include "ECS/Components/Renderer.hpp"
 #include "ECS/Core/ComponentManager.hpp"
 #include "ObjectLayerPairFilterImpl.hpp"
 #include "BroadPhaseLayerInterfaceImpl.hpp"
 #include "ObjectVsBroadPhaseLayerFilterImpl.hpp"
 #include "ObjectLayerFilterImpl.hpp"
+#include "StreamInImpl.hpp"
+#include "StreamOutImpl.hpp"
 #include "Core/LayerRegistry.hpp"
 #include "Core/Profiler.hpp"
 
 namespace NE::Physics {
-    namespace {
-        // here for now to move to JoltMath
-        JPH::Vec3 ToJoltVec3(const Math::Vec3& v) {
-            return JPH::Vec3(v.x, v.y, v.z);
-        }
-
-        JPH::RMat44 ToJoltRMat44(const Math::Vec3& worldPos) {
-            return JPH::RMat44::sTranslation(ToJoltVec3(worldPos));
-        }
-
-        JPH::EMotionType ToMotionType(const ECS::Component::Rigidbody& rb) {
-            return rb.isKinematic ? JPH::EMotionType::Kinematic : JPH::EMotionType::Dynamic;
-        }
-
-        JPH::ObjectLayer ToObjectLayer(uint8_t layerId, JPH::EMotionType motionType) {
-            uint8_t baseLayer = layerId % 32;
-
-            if (motionType != JPH::EMotionType::Static) {
-                return static_cast<JPH::ObjectLayer>(baseLayer + 32);
-            }
-
-            return static_cast<JPH::ObjectLayer>(baseLayer);
-        }
-
-        NE::Math::Vec3 ToEngineVec3(const JPH::RVec3& v) {
-            return NE::Math::Vec3(v.GetX(), v.GetY(), v.GetZ());
-        }
-
-        NE::Math::Vec3 JQuatToDegreeEuler(const JPH::Quat& q) {
-            JPH::Vec3 angles = q.GetEulerAngles();
-            return NE::Math::Vec3(JPH::RadiansToDegrees(angles.GetX()), JPH::RadiansToDegrees(angles.GetY()), JPH::RadiansToDegrees(angles.GetZ()));
-        }
-
-        static float Wrap360(float deg) {
-            deg = std::fmod(deg, 360.0f);
-            if (deg < 0.0f) deg += 360.0f;
-            return deg;
-        }
-
-        float ExtractYawDegrees(const JPH::Quat& q)  {
-            // Choose your engine's forward. Common is +Z forward.
-            JPH::Vec3 fwd = q * JPH::Vec3(0, 0, 1);
-
-            // Yaw around Y axis (atan2(x, z)) if +Z is forward
-            float yawRad = std::atan2(fwd.GetX(), fwd.GetZ());
-            return JPH::RadiansToDegrees(yawRad);
-        }
-
-        NE::Math::Quat ToEngineQuat(const JPH::Quat& q) {
-            return NE::Math::Quat(q.GetX(), q.GetY(), q.GetZ(), q.GetW());
+	namespace {
+		// here for now to move to JoltMath
+		JPH::Vec3 ToJoltVec3(const Math::Vec3& v) {
+			return JPH::Vec3(v.x, v.y, v.z);
 		}
-    }
 
-    PhysicsManager& PhysicsManager::GetInstance() {
-        static PhysicsManager instance;
-        return instance;
-    }
+		JPH::RMat44 ToJoltRMat44(const Math::Vec3& worldPos) {
+			return JPH::RMat44::sTranslation(ToJoltVec3(worldPos));
+		}
 
-    void PhysicsManager::Init() {
-        JPH::RegisterDefaultAllocator();
-        m_factory = std::make_unique<JPH::Factory>();
-        JPH::Factory::sInstance = m_factory.get();
-        JPH::RegisterTypes();
+		JPH::EMotionType ToMotionType(const ECS::Component::Rigidbody& rb) {
+			return rb.isKinematic ? JPH::EMotionType::Kinematic : JPH::EMotionType::Dynamic;
+		}
 
-        m_physicsSystem = std::make_unique<JPH::PhysicsSystem>();
-        m_tempAllocator = std::make_unique<JPH::TempAllocatorImpl>(10 * 1024 * 1024);
-        m_jobSystem = std::make_unique<JPH::JobSystemSingleThreaded>(JPH::cMaxPhysicsJobs);
+		JPH::ObjectLayer ToObjectLayer(uint8_t layerId, JPH::EMotionType motionType) {
+			uint8_t baseLayer = layerId % 32;
 
-        const auto& layerMatrix = Core::LayerRegistry::GetInstance().GetCollisionMatrix();
-        for (int a = 0; a < Core::MAX_LAYERS; ++a) {
-            m_collisionMatrix[a] = layerMatrix[a];
-        }
+			if (motionType != JPH::EMotionType::Static) {
+				return static_cast<JPH::ObjectLayer>(baseLayer + 32);
+			}
 
-        m_objectLayerPairFilter = std::make_unique<ObjectLayerPairFilterImpl>(m_collisionMatrix);
+			return static_cast<JPH::ObjectLayer>(baseLayer);
+		}
 
-        m_bpLayerInterface = std::make_unique<BroadPhaseLayerInterfaceImpl>();
-        m_objectVsBpFilter = std::make_unique<ObjectVsBroadPhaseLayerFilterImpl>();
+		NE::Math::Vec3 ToEngineVec3(const JPH::RVec3& v) {
+			return NE::Math::Vec3(v.GetX(), v.GetY(), v.GetZ());
+		}
 
-        m_debugRenderer = std::make_unique<JoltDebugRenderer>();
-        JPH::DebugRenderer::sInstance = m_debugRenderer.get();
-        m_debugRenderer->Init();
+		NE::Math::Vec3 JQuatToDegreeEuler(const JPH::Quat& q) {
+			JPH::Vec3 angles = q.GetEulerAngles();
+			return NE::Math::Vec3(JPH::RadiansToDegrees(angles.GetX()), JPH::RadiansToDegrees(angles.GetY()), JPH::RadiansToDegrees(angles.GetZ()));
+		}
 
-        const uint32_t maxBodies = 8192;
-        const uint32_t numBodyMutexes = 0;
-        const uint32_t maxBodyPairs = 65536;
-        const uint32_t maxContactConstraints = 10240;
+		static float Wrap360(float deg) {
+			deg = std::fmod(deg, 360.0f);
+			if (deg < 0.0f) deg += 360.0f;
+			return deg;
+		}
 
-        m_physicsSystem->Init(
-            maxBodies,
-            numBodyMutexes,
-            maxBodyPairs,
-            maxContactConstraints,
-            *m_bpLayerInterface,
-            *m_objectVsBpFilter,
-            *m_objectLayerPairFilter
-        );
+		float ExtractYawDegrees(const JPH::Quat& q) {
+			// Choose your engine's forward. Common is +Z forward.
+			JPH::Vec3 fwd = q * JPH::Vec3(0, 0, 1);
 
-        m_physicsSystem->SetGravity(JPH::Vec3(0.f, -9.81f, 0.f));
-    }
+			// Yaw around Y axis (atan2(x, z)) if +Z is forward
+			float yawRad = std::atan2(fwd.GetX(), fwd.GetZ());
+			return JPH::RadiansToDegrees(yawRad);
+		}
 
-    void PhysicsManager::Update(double dt) {
+		NE::Math::Quat ToEngineQuat(const JPH::Quat& q) {
+			return NE::Math::Quat(q.GetX(), q.GetY(), q.GetZ(), q.GetW());
+		}
+
+		JPH::Quat ToJPHQuat(const NE::Math::Quat& q) {
+			return JPH::Quat(q.x, q.y, q.z, q.w);
+		}
+
+		inline uint32_t FloatBits(float f) {
+			uint32_t u;
+			static_assert(sizeof(u) == sizeof(f));
+			std::memcpy(&u, &f, sizeof(u));
+			return u;
+		}
+
+		inline void HashCombine(uint64_t& h, uint64_t v) {
+			// 64-bit hash combine
+			h ^= v + 0x9e3779b97f4a7c15ull + (h << 6) + (h >> 2);
+		}
+
+		inline uint64_t HashBytes(const void* data, size_t size) {
+			// Simple FNV-1a 64 (good enough for signatures)
+			const uint8_t* p = (const uint8_t*)data;
+			uint64_t h = 1469598103934665603ull;
+			for (size_t i = 0; i < size; ++i) {
+				h ^= p[i];
+				h *= 1099511628211ull;
+			}
+			return h;
+		}
+	}
+
+	PhysicsManager& PhysicsManager::GetInstance() {
+		static PhysicsManager instance;
+		return instance;
+	}
+
+	void PhysicsManager::Init() {
+		JPH::RegisterDefaultAllocator();
+		m_factory = std::make_unique<JPH::Factory>();
+		JPH::Factory::sInstance = m_factory.get();
+		JPH::RegisterTypes();
+
+		m_physicsSystem = std::make_unique<JPH::PhysicsSystem>();
+		m_tempAllocator = std::make_unique<JPH::TempAllocatorImpl>(10 * 1024 * 1024);
+		m_jobSystem = std::make_unique<JPH::JobSystemSingleThreaded>(JPH::cMaxPhysicsJobs);
+
+		const auto& layerMatrix = Core::LayerRegistry::GetInstance().GetCollisionMatrix();
+		for (int a = 0; a < Core::MAX_LAYERS; ++a) {
+			m_collisionMatrix[a] = layerMatrix[a];
+		}
+
+		m_objectLayerPairFilter = std::make_unique<ObjectLayerPairFilterImpl>(m_collisionMatrix);
+
+		m_bpLayerInterface = std::make_unique<BroadPhaseLayerInterfaceImpl>();
+		m_objectVsBpFilter = std::make_unique<ObjectVsBroadPhaseLayerFilterImpl>();
+
+		m_debugRenderer = std::make_unique<JoltDebugRenderer>();
+		JPH::DebugRenderer::sInstance = m_debugRenderer.get();
+		m_debugRenderer->Init();
+
+		const uint32_t maxBodies = 8192;
+		const uint32_t numBodyMutexes = 0;
+		const uint32_t maxBodyPairs = 65536;
+		const uint32_t maxContactConstraints = 10240;
+
+		m_physicsSystem->Init(
+			maxBodies,
+			numBodyMutexes,
+			maxBodyPairs,
+			maxContactConstraints,
+			*m_bpLayerInterface,
+			*m_objectVsBpFilter,
+			*m_objectLayerPairFilter
+		);
+
+		m_physicsSystem->SetGravity(JPH::Vec3(0.f, -9.81f, 0.f));
+	}
+
+	void PhysicsManager::Update(double dt) {
 #ifndef PRODUCTION_BUILD
-        NE_PROFILE_FUNCTION();
+		NE_PROFILE_FUNCTION();
 #endif
 
-        if (!m_physicsSystem)
-            return;
+		if (!m_physicsSystem)
+			return;
 
-        if (dt > m_maxFrameTime)
-            dt = m_maxFrameTime;
+		if (dt > m_maxFrameTime)
+			dt = m_maxFrameTime;
 
-        m_accumulator += dt;
+		m_accumulator += dt;
 
-        while (m_accumulator >= m_fixedDt) {
-            const JPH::EPhysicsUpdateError err = m_physicsSystem->Update(
-                m_fixedDt,
-                m_collisionSteps,
-                m_tempAllocator.get(),
-                m_jobSystem.get()
-            );
+		while (m_accumulator >= m_fixedDt) {
+			const JPH::EPhysicsUpdateError err = m_physicsSystem->Update(
+				m_fixedDt,
+				m_collisionSteps,
+				m_tempAllocator.get(),
+				m_jobSystem.get()
+			);
 
-            UpdateCharacters(m_fixedDt);
+			UpdateCharacters(m_fixedDt);
 
-            // (Optional) handle err; in practice you can log it
-            (void)err;
+			SPD_INFO("Num Shape Refs: " << m_shapes.size());
 
-            m_accumulator -= m_fixedDt;
-        }
-    }
+			// (Optional) handle err; in practice you can log it
+			(void)err;
 
-    void PhysicsManager::Shutdown() {
-        m_physicsSystem.reset();
-        m_jobSystem.reset();
-        m_tempAllocator.reset();
+			m_accumulator -= m_fixedDt;
+		}
+	}
 
-        JPH::UnregisterTypes();
-        JPH::Factory::sInstance = nullptr;
-        m_factory.reset();
-    }
+	void PhysicsManager::Shutdown() {
+		m_physicsSystem.reset();
+		m_jobSystem.reset();
+		m_tempAllocator.reset();
 
-    // TODO split create and update
-    void PhysicsManager::CreateOrUpdateShape(const uint64_t entityLUID, const ECS::Component::Collider& col) {
-        using Collider = ECS::Component::Collider;
+		JPH::UnregisterTypes();
+		JPH::Factory::sInstance = nullptr;
+		m_factory.reset();
+	}
 
-        JPH::ShapeRefC base;
+	uint64_t PhysicsManager::ComputeShapeSignature(uint32_t entity, const ECS::Component::Collider& col) {
+		using Collider = ECS::Component::Collider;
 
-        auto CreateShape = [&](auto&& settings) -> JPH::ShapeRefC {
-            auto result = settings.Create();
-            if (result.HasError()) {
-                SPD_WARNING("Failed to create shape");
-                return nullptr;
-            }
-            return result.Get();
-        };
+		uint64_t h = 0;
+		HashCombine(h, (uint64_t)col.type);
 
-        switch (col.type) {
-        case Collider::ColliderType::Box: {
-            Math::Vec3 halfExtents = std::get<Collider::BoxColliderData>(col.data).halfExtents;
-            JPH::BoxShapeSettings s(JPH::Vec3(halfExtents.x, halfExtents.y, halfExtents.z));
-            
-            base = CreateShape(s);
-        } break;
-        case Collider::ColliderType::Sphere: {
-            JPH::SphereShapeSettings s(std::get<Collider::SphereColliderData>(col.data).radius);
+		// center offset matters (because you wrap with RotatedTranslated)
+		HashCombine(h, FloatBits(col.center.x));
+		HashCombine(h, FloatBits(col.center.y));
+		HashCombine(h, FloatBits(col.center.z));
 
-            base = CreateShape(s);
-        } break;
-        case Collider::ColliderType::Capsule: {
-            auto& data = std::get<Collider::CapsuleColliderData>(col.data);
-            JPH::CapsuleShapeSettings s(data.height * 0.5f, data.radius);
+		switch (col.type) {
+		case Collider::ColliderType::Box:
+		{
+			auto he = std::get<Collider::BoxColliderData>(col.data).halfExtents;
+			HashCombine(h, FloatBits(he.x));
+			HashCombine(h, FloatBits(he.y));
+			HashCombine(h, FloatBits(he.z));
+			break;
+		}
+		case Collider::ColliderType::Sphere:
+		{
+			float r = std::get<Collider::SphereColliderData>(col.data).radius;
+			HashCombine(h, FloatBits(r));
+			break;
+		}
+		case Collider::ColliderType::Capsule:
+		{
+			auto& d = std::get<Collider::CapsuleColliderData>(col.data);
+			HashCombine(h, FloatBits(d.height));
+			HashCombine(h, FloatBits(d.radius));
+			break;
+		}
+		case Collider::ColliderType::Cylinder:
+		{
+			auto& d = std::get<Collider::CylinderColliderData>(col.data);
+			HashCombine(h, FloatBits(d.height));
+			HashCombine(h, FloatBits(d.radius));
+			break;
+		}
+		case Collider::ColliderType::Mesh:
+		{
+			if (!m_componentManager->HasComponent<ECS::Component::Renderer>(entity))
+				return 0;
 
-            base = CreateShape(s);
-        } break;
-        case Collider::ColliderType::Cylinder: {
-            auto& data = std::get<Collider::CylinderColliderData>(col.data);
-            JPH::CylinderShapeSettings s(data.height * 0.5f, data.radius);
+			auto& rend = m_componentManager->GetComponent<ECS::Component::Renderer>(entity);
+			if (!rend.model)
+				return 0;
 
-            base = CreateShape(s);
-        } break;
-        default:
-            return;
-        }
+			const uint8_t* blobData = nullptr;
+			uint32_t blobSize = 0;
+			uint8_t blobType = 0;
 
-        if (!base) return;
+			if (!rend.model->GetSubmeshColliderBlob(rend.subMeshIndex, blobData, blobSize, blobType))
+				return 0;
 
-        JPH::ShapeRefC finalShape = base;
-        if (!col.center.Zero()) {
-            JPH::RotatedTranslatedShapeSettings rt(
-                JPH::Vec3(col.center.x, col.center.y, col.center.z),
-                JPH::Quat::sIdentity(),
-                base
-            );
-            finalShape = CreateShape(rt);
-            if (!finalShape) return;
-        }
+			HashCombine(h, (uint64_t)rend.subMeshIndex);
+			HashCombine(h, (uint64_t)blobType);
+			HashCombine(h, (uint64_t)blobSize);
 
-        m_shapes[entityLUID] = finalShape;
-    }
+			// Most robust: hash the blob bytes (fast enough; blobs aren't huge)
+			HashCombine(h, HashBytes(blobData, blobSize));
 
-    void PhysicsManager::RemoveShape(const uint64_t entityLUID) {
-        m_shapes.erase(entityLUID);
-    }
+			break;
+		}
+		default:
+			return 0;
+		}
 
-    void PhysicsManager::CreateCharacterController(uint32_t entity, uint64_t entityLUID, 
-        const ECS::Component::Transform& t, const ECS::Component::CharacterController& cc, 
-        const ECS::Component::Collider& col, uint8_t layerID) 
-    {
-        JPH::RefConst<JPH::Shape> shape;
+		return h;
+	}
 
-        auto itShape = m_shapes.find(entityLUID);
-        if (itShape != m_shapes.end() && itShape->second) {
-            shape = itShape->second.GetPtr();
-        }
+	// TODO split create and update
+	void PhysicsManager::CreateOrUpdateShape(uint32_t entity, uint64_t entityLUID, const ECS::Component::Collider& col) {
+		uint64_t newSig = ComputeShapeSignature(entity, col);
 
-        if (!shape) {
-            SPD_WARNING("CreateCharacterController failed: missing shape for LUID" << entityLUID);
-            return;
-        }
+		if (newSig == 0) {
+			RemoveShape(entityLUID);
+			return;
+		}
 
-        const Math::Vec3 pos = t.worldMatrix.GetTranslation();
-        const JPH::RVec3 jPos((double)pos.x, (double)pos.y, (double)pos.z);
+		auto it = m_shapes.find(entityLUID);
+		if (it != m_shapes.end() && it->second.signature == newSig)
+			return;
 
-        const float yawRad = JPH::DegreesToRadians(t.localRotationEuler.y);
-        const JPH::Quat jRot = JPH::Quat::sRotation(JPH::Vec3::sAxisY(), yawRad);
+		using Collider = ECS::Component::Collider;
 
-        JPH::CharacterVirtualSettings settings;
-        settings.mShape = shape;
+		JPH::ShapeRefC base;
 
-        settings.mMaxSlopeAngle = JPH::DegreesToRadians(cc.maxSlopeAngleDeg);
-        settings.mMaxStrength = cc.maxStrength;
-        settings.mCharacterPadding = cc.characterPadding;
-        settings.mPenetrationRecoverySpeed = cc.penRecoverySpeed;
-        settings.mPredictiveContactDistance = cc.predictiveContactDistance;
-        settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
-        settings.mSupportingVolume = JPH::Plane(JPH::Vec3::sAxisY(), -cc.supportingVolumeDepth);
-		
-        JPH::Ref<JPH::CharacterVirtual> character = new JPH::CharacterVirtual(
-            &settings,
-            jPos,
-            jRot,
-            m_physicsSystem.get()
-        );
+		auto CreateShape = [&](auto&& settings) -> JPH::ShapeRefC {
+			auto result = settings.Create();
+			if (result.HasError()) {
+				SPD_WARNING("Failed to create shape");
+				return nullptr;
+			}
+			return result.Get();
+			};
 
-        CharacterRuntime rt;
-        rt.controller = character;
-        rt.velocity = JPH::Vec3::sZero();
-        rt.entity = entity;
-        rt.luid = entityLUID;
-        rt.layerID = layerID;
+		switch (col.type) {
+		case Collider::ColliderType::Box: {
+			Math::Vec3 halfExtents = std::get<Collider::BoxColliderData>(col.data).halfExtents;
+			JPH::BoxShapeSettings s(JPH::Vec3(halfExtents.x, halfExtents.y, halfExtents.z));
 
-        m_characters[entityLUID] = std::move(rt);
-    }
+			base = CreateShape(s);
+		} break;
+		case Collider::ColliderType::Sphere: {
+			JPH::SphereShapeSettings s(std::get<Collider::SphereColliderData>(col.data).radius);
 
-    void PhysicsManager::UpdateCharacters(float dt) {
-        const JPH::Vec3 gravity = m_physicsSystem->GetGravity();
+			base = CreateShape(s);
+		} break;
+		case Collider::ColliderType::Capsule: {
+			auto& data = std::get<Collider::CapsuleColliderData>(col.data);
+			JPH::CapsuleShapeSettings s(data.height * 0.5f, data.radius);
 
-        for (auto& [luid, rt] : m_characters) {
-            JPH::CharacterVirtual& ch = *rt.controller;
+			base = CreateShape(s);
+		} break;
+		case Collider::ColliderType::Cylinder: {
+			auto& data = std::get<Collider::CylinderColliderData>(col.data);
+			JPH::CylinderShapeSettings s(data.height * 0.5f, data.radius);
 
-            if (rt.hasPendingDelta) {
-                rt.velocity = rt.pendingDelta / dt;
-                rt.pendingDelta = JPH::Vec3::sZero();
-                rt.hasPendingDelta = false;
-            } else {
-                rt.velocity = JPH::Vec3::sZero();
-            }
+			base = CreateShape(s);
+		} break;
+		case Collider::ColliderType::Mesh: {
+			auto& data = std::get<Collider::MeshColliderData>(col.data);
+			if (!m_componentManager->HasComponent<ECS::Component::Renderer>(entity)) {
+				SPD_WARNING("CreateOrUpdateShape: Entity " << entity << " has Mesh collider but no Renderer component.");
+				RemoveShape(entityLUID);
+				return;
+			}
+			auto& rend = m_componentManager->GetComponent<ECS::Component::Renderer>(entity);
+			if (!rend.model) {
+				SPD_WARNING("CreateOrUpdateShape: Entity " << entity << " has Mesh collider but Renderer has no model loaded.");
+				RemoveShape(entityLUID);
+				return;
+			}
 
-            ch.SetLinearVelocity(rt.velocity);
+			const uint8_t* blobData = nullptr;
+			uint32_t blobSize = 0;
+			uint8_t blobType = 0;
 
-            const uint32_t layerMask = m_collisionMatrix[rt.layerID];
-            ObjectLayerFilterImpl layerFilter(layerMask);
-            
-            ch.Update(
-                dt,
-                gravity,
-                JPH::BroadPhaseLayerFilter(),
-                layerFilter,
-                JPH::BodyFilter(),
-                JPH::ShapeFilter(),
+			if (!rend.model->GetSubmeshColliderBlob(rend.subMeshIndex, blobData, blobSize, blobType)) {
+				SPD_WARNING("Mesh collider: no cooked blob for submesh " << rend.subMeshIndex);
+				RemoveShape(entityLUID);
+				return;
+			}
+
+			if (blobType != 1) {
+				SPD_WARNING("Mesh collider: unsupported blob type " << (int)blobType);
+				RemoveShape(entityLUID);
+				return;
+			}
+
+			StreamInImpl in(blobData, blobSize);
+			JPH::ShapeRefC meshShape = JPH::Shape::sRestoreFromBinaryState(in).Get();
+			if (!meshShape || in.IsFailed()) {
+				SPD_WARNING("Mesh collider: failed to restore from blob");
+				RemoveShape(entityLUID);
+				return;
+			}
+			base = meshShape;
+		} break;
+		default:
+			return;
+		}
+
+		if (!base) return;
+
+		JPH::ShapeRefC finalShape = base;
+		if (!col.center.Zero()) {
+			JPH::RotatedTranslatedShapeSettings rt(
+				JPH::Vec3(col.center.x, col.center.y, col.center.z),
+				JPH::Quat::sIdentity(),
+				base
+			);
+			finalShape = CreateShape(rt);
+			if (!finalShape) return;
+		}
+
+		m_shapes[entityLUID] = StoredShape{ finalShape, newSig };
+	}
+
+	void PhysicsManager::RemoveShape(const uint64_t entityLUID) {
+		m_shapes.erase(entityLUID);
+	}
+
+	void PhysicsManager::CreateCharacterController(uint32_t entity, uint64_t entityLUID,
+		const ECS::Component::Transform& t, const ECS::Component::CharacterController& cc,
+		const ECS::Component::Collider& col, uint8_t layerID)
+	{
+		JPH::RefConst<JPH::Shape> shape;
+
+		auto itShape = m_shapes.find(entityLUID);
+		if (itShape != m_shapes.end() && itShape->second.shape) {
+			shape = itShape->second.shape.GetPtr();
+		}
+
+		if (!shape) {
+			SPD_WARNING("CreateCharacterController failed: missing shape for LUID" << entityLUID);
+			return;
+		}
+
+		const Math::Vec3 pos = t.worldMatrix.GetTranslation();
+		const JPH::RVec3 jPos((double)pos.x, (double)pos.y, (double)pos.z);
+
+		const float yawRad = JPH::DegreesToRadians(t.localRotationEuler.y);
+		const JPH::Quat jRot = JPH::Quat::sRotation(JPH::Vec3::sAxisY(), yawRad);
+
+		JPH::CharacterVirtualSettings settings;
+		settings.mShape = shape;
+
+		settings.mMaxSlopeAngle = JPH::DegreesToRadians(cc.maxSlopeAngleDeg);
+		settings.mMaxStrength = cc.maxStrength;
+		settings.mCharacterPadding = cc.characterPadding;
+		settings.mPenetrationRecoverySpeed = cc.penRecoverySpeed;
+		settings.mPredictiveContactDistance = cc.predictiveContactDistance;
+		settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
+		settings.mSupportingVolume = JPH::Plane(JPH::Vec3::sAxisY(), -cc.supportingVolumeDepth);
+
+		JPH::Ref<JPH::CharacterVirtual> character = new JPH::CharacterVirtual(
+			&settings,
+			jPos,
+			jRot,
+			m_physicsSystem.get()
+		);
+
+		CharacterRuntime rt;
+		rt.controller = character;
+		rt.velocity = JPH::Vec3::sZero();
+		rt.entity = entity;
+		rt.luid = entityLUID;
+		rt.layerID = layerID;
+
+		m_characters[entityLUID] = std::move(rt);
+	}
+
+	void PhysicsManager::UpdateCharacters(float dt) {
+		const JPH::Vec3 gravity = m_physicsSystem->GetGravity();
+
+		for (auto& [luid, rt] : m_characters) {
+			JPH::CharacterVirtual& ch = *rt.controller;
+
+			if (rt.hasPendingDelta) {
+				rt.velocity = rt.pendingDelta / dt;
+				rt.pendingDelta = JPH::Vec3::sZero();
+				rt.hasPendingDelta = false;
+			} else {
+				rt.velocity = JPH::Vec3::sZero();
+			}
+
+			ch.SetLinearVelocity(rt.velocity);
+
+			const uint32_t layerMask = m_collisionMatrix[rt.layerID];
+			ObjectLayerFilterImpl layerFilter(layerMask);
+
+			ch.Update(
+				dt,
+				gravity,
+				JPH::BroadPhaseLayerFilter(),
+				layerFilter,
+				JPH::BodyFilter(),
+				JPH::ShapeFilter(),
 				*m_tempAllocator
-            );
+			);
 
-            rt.velocity = ch.GetLinearVelocity();
+			rt.velocity = ch.GetLinearVelocity();
 
-            ECS::Entity e = static_cast<ECS::Entity>(rt.entity);
-            if (m_componentManager->HasComponent<ECS::Component::Transform>(e)) {
-                auto& tr = m_componentManager->GetComponent<ECS::Component::Transform>(e);
+			ECS::Entity e = static_cast<ECS::Entity>(rt.entity);
+			if (m_componentManager->HasComponent<ECS::Component::Transform>(e)) {
+				auto& tr = m_componentManager->GetComponent<ECS::Component::Transform>(e);
 
-                const JPH::RVec3 p = ch.GetPosition();
-                tr.localPosition = ToEngineVec3(p);
+				const JPH::RVec3 p = ch.GetPosition();
+				tr.localPosition = ToEngineVec3(p);
 
-    //            float yaw = Wrap360(ExtractYawDegrees(ch.GetRotation()));
-				////SPD_WARNING("Yaw: " << yaw);
-    //            tr.localRotationEuler = { 0.0f, yaw, 0.0f };
-				//SPD_WARNING(tr.localRotationEuler);
+				//            float yaw = Wrap360(ExtractYawDegrees(ch.GetRotation()));
+							////SPD_WARNING("Yaw: " << yaw);
+				//            tr.localRotationEuler = { 0.0f, yaw, 0.0f };
+							//SPD_WARNING(tr.localRotationEuler);
 
-                Math::Quat q = ToEngineQuat(ch.GetRotation());
-                tr.localRotationQuat = q;
+				Math::Quat q = ToEngineQuat(ch.GetRotation());
+				tr.localRotationQuat = q;
 
-                //Math::Vec3 e = QuatToEulerDegrees(q);                // any consistent order
-                //tr.localRotationEuler = StabilizeEulerForUI(e, tr.localRotationEuler);
+				//Math::Vec3 e = QuatToEulerDegrees(q);                // any consistent order
+				//tr.localRotationEuler = StabilizeEulerForUI(e, tr.localRotationEuler);
 
-                tr.isDirty = true;
-            }
-        }
-    }
+				tr.isDirty = true;
+			}
+		}
+	}
 
-    bool PhysicsManager::CharacterIsGrounded(uint64_t entityLUID) const {
-        auto it = m_characters.find(entityLUID);
-        if (it == m_characters.end()) return false;
+	bool PhysicsManager::CharacterIsGrounded(uint64_t entityLUID) const {
+		auto it = m_characters.find(entityLUID);
+		if (it == m_characters.end()) return false;
 
-        const CharacterRuntime& rt = it->second;
+		const CharacterRuntime& rt = it->second;
 
-        return rt.controller->GetGroundState() == JPH::CharacterVirtual::EGroundState::OnGround;
-    }
+		return rt.controller->GetGroundState() == JPH::CharacterVirtual::EGroundState::OnGround;
+	}
 
-    void PhysicsManager::CharacterMove(uint64_t entityLUID, const Math::Vec3& delta) {
-        auto it = m_characters.find(entityLUID);
-        if (it == m_characters.end()) return;
+	void PhysicsManager::CharacterMove(uint64_t entityLUID, const Math::Vec3& delta) {
+		auto it = m_characters.find(entityLUID);
+		if (it == m_characters.end()) return;
 
-        CharacterRuntime& rt = it->second;
+		CharacterRuntime& rt = it->second;
 
-        if (rt.hasPendingDelta)
-            rt.pendingDelta += JPH::Vec3(delta.x, delta.y, delta.z);
-        else {
-            rt.pendingDelta = JPH::Vec3(delta.x, delta.y, delta.z);
-            rt.hasPendingDelta = true;
-        }
-    }
+		if (rt.hasPendingDelta)
+			rt.pendingDelta += JPH::Vec3(delta.x, delta.y, delta.z);
+		else {
+			rt.pendingDelta = JPH::Vec3(delta.x, delta.y, delta.z);
+			rt.hasPendingDelta = true;
+		}
+	}
 
-    void PhysicsManager::CharacterRotateYaw(uint64_t entityLUID, float yawDegrees) {
-        auto it = m_characters.find(entityLUID);
-        if (it == m_characters.end()) return;
+	void PhysicsManager::CharacterRotateYaw(uint64_t entityLUID, float yawDegrees) {
+		auto it = m_characters.find(entityLUID);
+		if (it == m_characters.end()) return;
 
-        it->second.controller->SetRotation(
-            JPH::Quat::sRotation(JPH::Vec3::sAxisY(), JPH::DegreesToRadians(yawDegrees))
-        );
-    }
+		it->second.controller->SetRotation(
+			JPH::Quat::sRotation(JPH::Vec3::sAxisY(), JPH::DegreesToRadians(yawDegrees))
+		);
+	}
 
-    Math::Vec3 PhysicsManager::CharacterGetVelocity(uint64_t entityLUID) const {
-        auto it = m_characters.find(entityLUID);
-        if (it == m_characters.end()) return { 0.f, 0.f, 0.f };
+	Math::Vec3 PhysicsManager::CharacterGetVelocity(uint64_t entityLUID) const {
+		auto it = m_characters.find(entityLUID);
+		if (it == m_characters.end()) return { 0.f, 0.f, 0.f };
 
-        const JPH::Vec3& v = it->second.velocity;
+		const JPH::Vec3& v = it->second.velocity;
 		return Math::Vec3(v.GetX(), v.GetY(), v.GetZ());
-    }
+	}
 
-    Math::Vec3 PhysicsManager::CharacterGetGroundNormal(uint64_t entityLUID) const {
-        auto it = m_characters.find(entityLUID);
-        if (it == m_characters.end() || !it->second.controller)
-            return { 0.f, 1.f, 0.f };
+	Math::Vec3 PhysicsManager::CharacterGetGroundNormal(uint64_t entityLUID) const {
+		auto it = m_characters.find(entityLUID);
+		if (it == m_characters.end() || !it->second.controller)
+			return { 0.f, 1.f, 0.f };
 
-        const JPH::CharacterVirtual& ch = *it->second.controller;
+		const JPH::CharacterVirtual& ch = *it->second.controller;
 
-        if (ch.GetGroundState() != JPH::CharacterVirtual::EGroundState::OnGround)
-            return { 0.f, 1.f, 0.f };
+		if (ch.GetGroundState() != JPH::CharacterVirtual::EGroundState::OnGround)
+			return { 0.f, 1.f, 0.f };
 
-        const JPH::Vec3 n = ch.GetGroundNormal();
+		const JPH::Vec3 n = ch.GetGroundNormal();
 
-        return { n.GetX(), n.GetY(), n.GetZ() };
-    }
+		return { n.GetX(), n.GetY(), n.GetZ() };
+	}
 
-    void PhysicsManager::CreateBody(uint32_t entity, uint64_t luid, const ECS::Component::Transform& t,
-        const ECS::Component::Rigidbody& rb, const ECS::Component::Collider& col, uint8_t layerID) {
+	void PhysicsManager::CreateBody(uint32_t entity, uint64_t luid, const ECS::Component::Transform& t,
+		const ECS::Component::Rigidbody& rb, const ECS::Component::Collider& col, uint8_t layerID) {
+		auto itShape = m_shapes.find(luid);
+		if (itShape == m_shapes.end() || !itShape->second.shape)
+			return;
 
-        auto itShape = m_shapes.find(luid);
-        if (itShape == m_shapes.end() || !itShape->second)
-            return;
+		const JPH::ShapeRefC& shape = itShape->second.shape;
 
-        const JPH::ShapeRefC& shape = itShape->second;
+		const Math::Vec3 pos = t.worldMatrix.GetTranslation();
+		const JPH::RVec3 jPos((double)pos.x, (double)pos.y, (double)pos.z);
+		//const JPH::Quat jRot = JPH::Quat::sEulerAngles({
+		//	JPH::DegreesToRadians(t.localRotationEuler.x),
+		//	JPH::DegreesToRadians(t.localRotationEuler.y),
+		//	JPH::DegreesToRadians(t.localRotationEuler.z) }
+		//	);
 
-        const Math::Vec3 pos = t.worldMatrix.GetTranslation();
-        const JPH::RVec3 jPos((double)pos.x, (double)pos.y, (double)pos.z);
-        const JPH::Quat jRot = JPH::Quat::sEulerAngles({
-            JPH::DegreesToRadians(t.localRotationEuler.x),
-            JPH::DegreesToRadians(t.localRotationEuler.y),
-            JPH::DegreesToRadians(t.localRotationEuler.z) }
-        );
+		const JPH::Quat jRot = ToJPHQuat(t.localRotationQuat);
 
-        const JPH::EMotionType motion = ToMotionType(rb);
-        const JPH::ObjectLayer objLayer = ToObjectLayer(layerID, motion);
+		const JPH::EMotionType motion = ToMotionType(rb);
+		const JPH::ObjectLayer objLayer = ToObjectLayer(layerID, motion);
 
-        JPH::BodyCreationSettings settings(
-            shape,
-            jPos,
-            jRot,
-            motion,
-            objLayer
-        );
+		JPH::BodyCreationSettings settings(
+			shape,
+			jPos,
+			jRot,
+			motion,
+			objLayer
+		);
 
-        settings.mGravityFactor = rb.useGravity ? 1.0f : 0.0f;
-        settings.mLinearDamping = rb.linearDamping;
-        settings.mAngularDamping = rb.angularDamping;
-        settings.mIsSensor = col.isTrigger;
+		settings.mGravityFactor = rb.useGravity ? 1.0f : 0.0f;
+		settings.mLinearDamping = rb.linearDamping;
+		settings.mAngularDamping = rb.angularDamping;
+		settings.mIsSensor = col.isTrigger;
 
-        JPH::EAllowedDOFs allowedDOFs = JPH::EAllowedDOFs::All;
+		JPH::EAllowedDOFs allowedDOFs = JPH::EAllowedDOFs::All;
 
-        if (rb.freezePosX) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationX;
-        if (rb.freezePosY) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationY;
-        if (rb.freezePosZ) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationZ;
+		if (rb.freezePosX) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationX;
+		if (rb.freezePosY) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationY;
+		if (rb.freezePosZ) allowedDOFs &= ~JPH::EAllowedDOFs::TranslationZ;
 
-        if (rb.freezeRotX) allowedDOFs &= ~JPH::EAllowedDOFs::RotationX;
-        if (rb.freezeRotY) allowedDOFs &= ~JPH::EAllowedDOFs::RotationY;
-        if (rb.freezeRotZ) allowedDOFs &= ~JPH::EAllowedDOFs::RotationZ;
+		if (rb.freezeRotX) allowedDOFs &= ~JPH::EAllowedDOFs::RotationX;
+		if (rb.freezeRotY) allowedDOFs &= ~JPH::EAllowedDOFs::RotationY;
+		if (rb.freezeRotZ) allowedDOFs &= ~JPH::EAllowedDOFs::RotationZ;
 
-        settings.mAllowedDOFs = allowedDOFs;
-        
-        if (motion == JPH::EMotionType::Dynamic) {
-            settings.mOverrideMassProperties = JPH::EOverrideMassProperties::CalculateInertia;
-            settings.mMassPropertiesOverride.mMass = rb.mass;
-        }
+		settings.mAllowedDOFs = allowedDOFs;
 
-        JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
-        JPH::Body* body = bi.CreateBody(settings);
-        if (!body) return;
+		if (motion == JPH::EMotionType::Dynamic) {
+			settings.mOverrideMassProperties = JPH::EOverrideMassProperties::CalculateInertia;
+			settings.mMassPropertiesOverride.mMass = rb.mass;
+		}
 
-        const JPH::BodyID id = body->GetID();
-        bi.AddBody(id, JPH::EActivation::Activate);
-        bi.SetUserData(id, static_cast<JPH::uint64>(entity));
+		JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+		JPH::Body* body = bi.CreateBody(settings);
+		if (!body) return;
 
-        m_bodies[luid] = id;
-    }
+		const JPH::BodyID id = body->GetID();
+		bi.AddBody(id, JPH::EActivation::Activate);
+		bi.SetUserData(id, static_cast<JPH::uint64>(entity));
 
-    void PhysicsManager::CreateBody(uint32_t entity, uint64_t luid, const ECS::Component::Transform& t,
-        const ECS::Component::Collider& col, uint8_t layerID) {
+		m_bodies[luid] = id;
+	}
 
-        auto itShape = m_shapes.find(luid);
-        if (itShape == m_shapes.end() || !itShape->second)
-            return;
+	void PhysicsManager::CreateBody(uint32_t entity, uint64_t luid, const ECS::Component::Transform& t,
+		const ECS::Component::Collider& col, uint8_t layerID) {
+		auto itShape = m_shapes.find(luid);
+		if (itShape == m_shapes.end() || !itShape->second.shape)
+			return;
 
-        const JPH::ShapeRefC& shape = itShape->second;
+		const JPH::ShapeRefC& shape = itShape->second.shape;
 
-        const Math::Vec3 pos = t.worldMatrix.GetTranslation();
-        const JPH::RVec3 jPos((double)pos.x, (double)pos.y, (double)pos.z);
-        const JPH::Quat jRot = JPH::Quat::sEulerAngles({
-            JPH::DegreesToRadians(t.localRotationEuler.x),
-            JPH::DegreesToRadians(t.localRotationEuler.y),
-            JPH::DegreesToRadians(t.localRotationEuler.z) }
-        );
+		const Math::Vec3 pos = t.worldMatrix.GetTranslation();
+		const JPH::RVec3 jPos((double)pos.x, (double)pos.y, (double)pos.z);
+		const JPH::Quat jRot = JPH::Quat::sEulerAngles({
+			JPH::DegreesToRadians(t.localRotationEuler.x),
+			JPH::DegreesToRadians(t.localRotationEuler.y),
+			JPH::DegreesToRadians(t.localRotationEuler.z) }
+			);
 
-        const JPH::EMotionType motion = JPH::EMotionType::Static;
-        const JPH::ObjectLayer objLayer = ToObjectLayer(layerID, motion);
+		const JPH::EMotionType motion = JPH::EMotionType::Static;
+		const JPH::ObjectLayer objLayer = ToObjectLayer(layerID, motion);
 
-        JPH::BodyCreationSettings settings(
-            shape,
-            jPos,
-            jRot,
-            motion,
-            objLayer
-        );
+		JPH::BodyCreationSettings settings(
+			shape,
+			jPos,
+			jRot,
+			motion,
+			objLayer
+		);
 
-        settings.mIsSensor = col.isTrigger;
+		settings.mIsSensor = col.isTrigger;
 
-        JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
-        JPH::Body* body = bi.CreateBody(settings);
-        if (!body) return;
+		JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+		JPH::Body* body = bi.CreateBody(settings);
+		if (!body) return;
 
-        const JPH::BodyID id = body->GetID();
-        bi.AddBody(id, JPH::EActivation::DontActivate);
-        bi.SetUserData(id, static_cast<JPH::uint64>(entity));
+		const JPH::BodyID id = body->GetID();
+		bi.AddBody(id, JPH::EActivation::DontActivate);
+		bi.SetUserData(id, static_cast<JPH::uint64>(entity));
 
-        m_bodies[luid] = id;
-    }
+		m_bodies[luid] = id;
+	}
 
-    void PhysicsManager::DestroyBody(uint64_t luid) {
-        JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+	void PhysicsManager::DestroyBody(uint64_t luid) {
+		JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
 
-        auto& id = m_bodies.at(luid);
-        bi.RemoveBody(id);
-        bi.DestroyBody(id);
-    }
+		auto& id = m_bodies.at(luid);
+		bi.RemoveBody(id);
+		bi.DestroyBody(id);
+	}
 
-    void PhysicsManager::SyncTransformToBodies(uint64_t luid, ECS::Component::Transform& t) const {
-        JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+	void PhysicsManager::SyncTransformToBodies(uint64_t luid, ECS::Component::Transform& t) const {
+		JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
 
-        auto& bodyID = m_bodies.at(luid);
-        t.localPosition = ToEngineVec3(bi.GetPosition(bodyID));
-        t.localRotationEuler = JQuatToDegreeEuler(bi.GetRotation(bodyID));
+		auto& bodyID = m_bodies.at(luid);
+		t.localPosition = ToEngineVec3(bi.GetPosition(bodyID));
+		t.localRotationEuler = JQuatToDegreeEuler(bi.GetRotation(bodyID));
+		t.localRotationQuat = ToEngineQuat(bi.GetRotation(bodyID));
 
-        t.isDirty = true;
-    }
+		t.isDirty = true;
+	}
 
-    void PhysicsManager::SyncTransformToCharacters(uint64_t entityLUID, ECS::Component::Transform& t) const {
-        auto& rt = m_characters.at(entityLUID);
+	void PhysicsManager::SyncTransformToCharacters(uint64_t entityLUID, ECS::Component::Transform& t) const {
+		auto& rt = m_characters.at(entityLUID);
 		auto& ch = *rt.controller;
-        t.localPosition = ToEngineVec3(ch.GetPosition());
-        
-        auto euler = JQuatToDegreeEuler(ch.GetRotation());
-        euler.x = 0.0f;
-        euler.z = 0.0f;
-        t.localRotationEuler = euler;
+		t.localPosition = ToEngineVec3(ch.GetPosition());
 
-        t.isDirty = true;
-    }
+		auto euler = JQuatToDegreeEuler(ch.GetRotation());
+		euler.x = 0.0f;
+		euler.z = 0.0f;
+		t.localRotationEuler = euler;
 
-    void PhysicsManager::DrawShapeGizmo(const uint64_t entityLUID, const ECS::Component::Transform& t, const ECS::Component::Collider& col) {
-        auto it = m_shapes.find(entityLUID);
-        if (it == m_shapes.end()) return;
+		t.isDirty = true;
+	}
 
-        auto& shapeSettings = it->second;
+	void PhysicsManager::DrawShapeGizmo(const uint64_t entityLUID, const ECS::Component::Transform& t, const ECS::Component::Collider& col) {
+		auto it = m_shapes.find(entityLUID);
+		if (it == m_shapes.end()) return;
 
-        const Math::Vec3 pos = t.worldMatrix.GetTranslation();
-        const JPH::Quat rot = JPH::Quat::sEulerAngles({
-                JPH::DegreesToRadians(t.localRotationEuler.x),
-                JPH::DegreesToRadians(t.localRotationEuler.y),
-                JPH::DegreesToRadians(t.localRotationEuler.z)
-            }
-        );
+		auto& shapeSettings = it->second;
 
-        JPH::RMat44 world = JPH::RMat44::sRotationTranslation(
-            rot,
-            JPH::RVec3((double)pos.x, (double)pos.y, (double)pos.z)
-        );
+		const Math::Vec3 pos = t.worldMatrix.GetTranslation();
+		//const JPH::Quat rot = ToJPHQuat(t.loc)
+		const JPH::Quat rot = JPH::Quat::sEulerAngles({
+				JPH::DegreesToRadians(t.localRotationEuler.x),
+				JPH::DegreesToRadians(t.localRotationEuler.y),
+				JPH::DegreesToRadians(t.localRotationEuler.z)
+			}
+		);
 
-        world = world * JPH::RMat44::sTranslation(JPH::Vec3(col.center.x, col.center.y, col.center.z));
+		JPH::RMat44 world = JPH::RMat44::sRotationTranslation(
+			rot,
+			JPH::RVec3((double)pos.x, (double)pos.y, (double)pos.z)
+		);
 
-        it->second->Draw(m_debugRenderer.get(),
-            world,
-            JPH::Vec3::sReplicate(1.f),
-            JPH::Color::sGreen,
-            false,
-            true
-        );
-    }
+		world = world * JPH::RMat44::sTranslation(JPH::Vec3(col.center.x, col.center.y, col.center.z));
 
-    bool PhysicsManager::Raycast(Math::Vec3 origin, Math::Vec3 direction, RaycastHit& outHitInfo, float maxDistance, uint32_t layerMask) {
-        JPH::Vec3 joltDir(direction.x, direction.y, direction.z);
-        joltDir = joltDir.Normalized();
+		it->second.shape->Draw(m_debugRenderer.get(),
+			world,
+			JPH::Vec3::sReplicate(1.f),
+			JPH::Color::sGreen,
+			false,
+			true
+		);
+	}
 
-        JPH::RRayCast joltRay{ ToJoltVec3(origin), ToJoltVec3(direction * maxDistance) };
+	bool PhysicsManager::Raycast(Math::Vec3 origin, Math::Vec3 direction, RaycastHit& outHitInfo, float maxDistance, uint32_t layerMask) {
+		JPH::Vec3 joltDir(direction.x, direction.y, direction.z);
+		joltDir = joltDir.Normalized();
 
-        ObjectLayerFilterImpl layerFilter(layerMask);
+		JPH::RRayCast joltRay{ ToJoltVec3(origin), ToJoltVec3(direction * maxDistance) };
 
-        JPH::RayCastResult result;
-        bool hasHit = m_physicsSystem->GetNarrowPhaseQuery().CastRay(
-            joltRay,
-            result,
-            JPH::BroadPhaseLayerFilter(),
-            layerFilter,
-            JPH::BodyFilter()
-        );
+		ObjectLayerFilterImpl layerFilter(layerMask);
 
-        if (hasHit && !result.mBodyID.IsInvalid()) {
-            outHitInfo.distance = result.mFraction * maxDistance;
+		JPH::RayCastResult result;
+		bool hasHit = m_physicsSystem->GetNarrowPhaseQuery().CastRay(
+			joltRay,
+			result,
+			JPH::BroadPhaseLayerFilter(),
+			layerFilter,
+			JPH::BodyFilter()
+		);
 
-            JPH::RVec3 hitPoint = joltRay.mOrigin + joltRay.mDirection * result.mFraction;
-            outHitInfo.point = Math::Vec3(
-                hitPoint.GetX(),
-                hitPoint.GetY(),
-                hitPoint.GetZ()
-            );
+		if (hasHit && !result.mBodyID.IsInvalid()) {
+			outHitInfo.distance = result.mFraction * maxDistance;
 
-            JPH::BodyLockRead lock(m_physicsSystem->GetBodyLockInterface(), result.mBodyID);
-            if (lock.Succeeded()) {
-                const JPH::Body& body = lock.GetBody();
+			JPH::RVec3 hitPoint = joltRay.mOrigin + joltRay.mDirection * result.mFraction;
+			outHitInfo.point = Math::Vec3(
+				hitPoint.GetX(),
+				hitPoint.GetY(),
+				hitPoint.GetZ()
+			);
 
-                JPH::Vec3 joltNormal = body.GetWorldSpaceSurfaceNormal(result.mSubShapeID2, hitPoint);
-                outHitInfo.normal = Math::Vec3(joltNormal.GetX(), joltNormal.GetY(), joltNormal.GetZ());
+			JPH::BodyLockRead lock(m_physicsSystem->GetBodyLockInterface(), result.mBodyID);
+			if (lock.Succeeded()) {
+				const JPH::Body& body = lock.GetBody();
 
-                // Get entity from physics body
-                ECS::Entity hitEntity = static_cast<ECS::Entity>(body.GetUserData());
-                outHitInfo.colliderEntityID = hitEntity;
+				JPH::Vec3 joltNormal = body.GetWorldSpaceSurfaceNormal(result.mSubShapeID2, hitPoint);
+				outHitInfo.normal = Math::Vec3(joltNormal.GetX(), joltNormal.GetY(), joltNormal.GetZ());
 
-                // Populate component LUIDs using ComponentManager
-                if (m_componentManager) {
-                    if (m_componentManager->HasComponent<ECS::Component::Transform>(hitEntity)) {
-                        auto& transform = m_componentManager->GetComponent<ECS::Component::Transform>(hitEntity);
-                        outHitInfo.transformLuid = transform.luid;
-                    }
+				// Get entity from physics body
+				ECS::Entity hitEntity = static_cast<ECS::Entity>(body.GetUserData());
+				outHitInfo.colliderEntityID = hitEntity;
 
-                    if (m_componentManager->HasComponent<ECS::Component::Rigidbody>(hitEntity)) {
-                        auto& rigidbody = m_componentManager->GetComponent<ECS::Component::Rigidbody>(hitEntity);
-                        outHitInfo.rigidbodyLuid = rigidbody.luid;
-                    }
+				// Populate component LUIDs using ComponentManager
+				if (m_componentManager) {
+					if (m_componentManager->HasComponent<ECS::Component::Transform>(hitEntity)) {
+						auto& transform = m_componentManager->GetComponent<ECS::Component::Transform>(hitEntity);
+						outHitInfo.transformLuid = transform.luid;
+					}
 
-                    if (m_componentManager->HasComponent<ECS::Component::Collider>(hitEntity)) {
-                        auto& collider = m_componentManager->GetComponent<ECS::Component::Collider>(hitEntity);
-                        outHitInfo.colliderLuid = collider.luid;
-                    }
-                }
-            }
+					if (m_componentManager->HasComponent<ECS::Component::Rigidbody>(hitEntity)) {
+						auto& rigidbody = m_componentManager->GetComponent<ECS::Component::Rigidbody>(hitEntity);
+						outHitInfo.rigidbodyLuid = rigidbody.luid;
+					}
 
-            //SPD_DEBUG("Raycast Hit Body with ID: " << hit.bodyID << " with Entity: " << hit.entity);
-        }
+					if (m_componentManager->HasComponent<ECS::Component::Collider>(hitEntity)) {
+						auto& collider = m_componentManager->GetComponent<ECS::Component::Collider>(hitEntity);
+						outHitInfo.colliderLuid = collider.luid;
+					}
+				}
+			}
 
-        return hasHit;
-    }
+			//SPD_DEBUG("Raycast Hit Body with ID: " << hit.bodyID << " with Entity: " << hit.entity);
+		}
 
-    bool PhysicsManager::Raycast(Ray ray, RaycastHit& outHitInfo, float maxDistance, uint32_t layerMask) {
-        return Raycast(ray.origin, ray.direction, outHitInfo, maxDistance, layerMask);
-    }
+		return hasHit;
+	}
 
-    bool PhysicsManager::SphereCast(Math::Vec3 origin, float radius, Math::Vec3 direction, RaycastHit& outHitInfo, float maxDistance, uint32_t layerMask) {
-        JPH::Vec3 joltDir(direction.x, direction.y, direction.z);
-        joltDir = joltDir.Normalized();
-        
+	bool PhysicsManager::Raycast(Ray ray, RaycastHit& outHitInfo, float maxDistance, uint32_t layerMask) {
+		return Raycast(ray.origin, ray.direction, outHitInfo, maxDistance, layerMask);
+	}
+
+	bool PhysicsManager::SphereCast(Math::Vec3 origin, float radius, Math::Vec3 direction, RaycastHit& outHitInfo, float maxDistance, uint32_t layerMask) {
+		JPH::Vec3 joltDir(direction.x, direction.y, direction.z);
+		joltDir = joltDir.Normalized();
+
 		JPH::SphereShapeSettings sphereSettings(radius);
 		JPH::ShapeSettings::ShapeResult sphereResult = sphereSettings.Create();
 
@@ -652,146 +808,202 @@ namespace NE::Physics {
 			return false;
 		}
 
-        JPH::RefConst<JPH::Shape> sphereShape = sphereResult.Get();
+		JPH::RefConst<JPH::Shape> sphereShape = sphereResult.Get();
 
-        JPH::RMat44 startWorld = JPH::RMat44::sTranslation(JPH::RVec3(origin.x, origin.y, origin.z));
+		JPH::RMat44 startWorld = JPH::RMat44::sTranslation(JPH::RVec3(origin.x, origin.y, origin.z));
 
-        JPH::Vec3 castDir = joltDir * maxDistance;
+		JPH::Vec3 castDir = joltDir * maxDistance;
 
-        JPH::RShapeCast sphereCast =
-            JPH::RShapeCast::sFromWorldTransform(
-                sphereShape.GetPtr(),
-                JPH::Vec3::sReplicate(1.0f),
-                startWorld,
-                castDir
-            );
+		JPH::RShapeCast sphereCast =
+			JPH::RShapeCast::sFromWorldTransform(
+				sphereShape.GetPtr(),
+				JPH::Vec3::sReplicate(1.0f),
+				startWorld,
+				castDir
+			);
 
-        ObjectLayerFilterImpl layerFilter(layerMask);
+		ObjectLayerFilterImpl layerFilter(layerMask);
 
-        using CollectorT = JPH::ClosestHitCollisionCollector<JPH::CastShapeCollector>;
-        CollectorT collector;
+		using CollectorT = JPH::ClosestHitCollisionCollector<JPH::CastShapeCollector>;
+		CollectorT collector;
 
-        JPH::ShapeCastSettings settings;
+		JPH::ShapeCastSettings settings;
 
-        JPH::RVec3 baseOffset = JPH::RVec3::sZero();
+		JPH::RVec3 baseOffset = JPH::RVec3::sZero();
 
-        m_physicsSystem->GetNarrowPhaseQuery().CastShape(
-            sphereCast,
-            settings,
-            baseOffset,
-            collector,
-            JPH::BroadPhaseLayerFilter(),
-            layerFilter,
-            JPH::BodyFilter(),
-            JPH::ShapeFilter()
-        );
+		m_physicsSystem->GetNarrowPhaseQuery().CastShape(
+			sphereCast,
+			settings,
+			baseOffset,
+			collector,
+			JPH::BroadPhaseLayerFilter(),
+			layerFilter,
+			JPH::BodyFilter(),
+			JPH::ShapeFilter()
+		);
 
-        if (!collector.HadHit() || collector.mHit.mBodyID2.IsInvalid())
-            return false;
+		if (!collector.HadHit() || collector.mHit.mBodyID2.IsInvalid())
+			return false;
 
-        const JPH::ShapeCastResult& hit = collector.mHit;
+		const JPH::ShapeCastResult& hit = collector.mHit;
 
-        outHitInfo.distance = hit.mFraction * maxDistance;
+		outHitInfo.distance = hit.mFraction * maxDistance;
 
-        const JPH::Vec3 p = hit.mContactPointOn2;
-        outHitInfo.point = Math::Vec3(p.GetX(), p.GetY(), p.GetZ());
+		const JPH::Vec3 p = hit.mContactPointOn2;
+		outHitInfo.point = Math::Vec3(p.GetX(), p.GetY(), p.GetZ());
 
-        JPH::Vec3 n = -hit.mPenetrationAxis.Normalized();
-        outHitInfo.normal = Math::Vec3(n.GetX(), n.GetY(), n.GetZ());
+		JPH::Vec3 n = -hit.mPenetrationAxis.Normalized();
+		outHitInfo.normal = Math::Vec3(n.GetX(), n.GetY(), n.GetZ());
 
-        JPH::BodyLockRead lock(m_physicsSystem->GetBodyLockInterface(), hit.mBodyID2);
-        if (lock.Succeeded()) {
-            const JPH::Body& body = lock.GetBody();
+		JPH::BodyLockRead lock(m_physicsSystem->GetBodyLockInterface(), hit.mBodyID2);
+		if (lock.Succeeded()) {
+			const JPH::Body& body = lock.GetBody();
 
-            ECS::Entity hitEntity = static_cast<ECS::Entity>(body.GetUserData());
-            outHitInfo.colliderEntityID = hitEntity;
+			ECS::Entity hitEntity = static_cast<ECS::Entity>(body.GetUserData());
+			outHitInfo.colliderEntityID = hitEntity;
 
-            if (m_componentManager) {
-                if (m_componentManager->HasComponent<ECS::Component::Transform>(hitEntity))
-                    outHitInfo.transformLuid = m_componentManager->GetComponent<ECS::Component::Transform>(hitEntity).luid;
+			if (m_componentManager) {
+				if (m_componentManager->HasComponent<ECS::Component::Transform>(hitEntity))
+					outHitInfo.transformLuid = m_componentManager->GetComponent<ECS::Component::Transform>(hitEntity).luid;
 
-                if (m_componentManager->HasComponent<ECS::Component::Rigidbody>(hitEntity))
-                    outHitInfo.rigidbodyLuid = m_componentManager->GetComponent<ECS::Component::Rigidbody>(hitEntity).luid;
+				if (m_componentManager->HasComponent<ECS::Component::Rigidbody>(hitEntity))
+					outHitInfo.rigidbodyLuid = m_componentManager->GetComponent<ECS::Component::Rigidbody>(hitEntity).luid;
 
-                if (m_componentManager->HasComponent<ECS::Component::Collider>(hitEntity))
-                    outHitInfo.colliderLuid = m_componentManager->GetComponent<ECS::Component::Collider>(hitEntity).luid;
-            }
-        }
+				if (m_componentManager->HasComponent<ECS::Component::Collider>(hitEntity))
+					outHitInfo.colliderLuid = m_componentManager->GetComponent<ECS::Component::Collider>(hitEntity).luid;
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    bool PhysicsManager::SphereCast(Ray ray, float radius, RaycastHit& outHitInfo, float maxDistance, uint32_t layerMask) {
+	bool PhysicsManager::SphereCast(Ray ray, float radius, RaycastHit& outHitInfo, float maxDistance, uint32_t layerMask) {
 		return SphereCast(ray.origin, radius, ray.direction, outHitInfo, maxDistance, layerMask);
-    }
+	}
 
-    void PhysicsManager::AddForce(uint64_t entityLUID, Math::Vec3 force, ForceMode forceMode) {
-        auto it = m_bodies.find(entityLUID);
-        if (it != m_bodies.end()) {
-            switch (forceMode) {
-                case ForceMode::Impulse: {
-                    m_physicsSystem->GetBodyInterface().AddImpulse(it->second, ToJoltVec3(force));
-                } break;
-                //case ForceMode::Acceleration: {
-                //} break;
-                //case ForceMode::VelocityChange: {
-                //} break;
-                default: {
-                    m_physicsSystem->GetBodyInterface().AddForce(it->second, ToJoltVec3(force));
-                }
-            }
-        }
-    }
+	void PhysicsManager::AddForce(uint64_t entityLUID, Math::Vec3 force, ForceMode forceMode) {
+		auto it = m_bodies.find(entityLUID);
+		if (it != m_bodies.end()) {
+			switch (forceMode) {
+			case ForceMode::Impulse: {
+				m_physicsSystem->GetBodyInterface().AddImpulse(it->second, ToJoltVec3(force));
+			} break;
+								   //case ForceMode::Acceleration: {
+								   //} break;
+								   //case ForceMode::VelocityChange: {
+								   //} break;
+			default: {
+				m_physicsSystem->GetBodyInterface().AddForce(it->second, ToJoltVec3(force));
+			}
+			}
+		}
+	}
 
-    Math::Vec3 PhysicsManager::GetLinearVelocity(uint64_t entityLUID) const {
-        auto it = m_bodies.find(entityLUID);
-        if (it != m_bodies.end()) {
-            JPH::Vec3 joltVel = m_physicsSystem->GetBodyInterface().GetLinearVelocity(it->second);
-            return Math::Vec3(joltVel.GetX(), joltVel.GetY(), joltVel.GetZ());
-        }
-        return Math::Vec3(0.0f, 0.0f, 0.0f);
-    }
+	Math::Vec3 PhysicsManager::GetLinearVelocity(uint64_t entityLUID) const {
+		auto it = m_bodies.find(entityLUID);
+		if (it != m_bodies.end()) {
+			JPH::Vec3 joltVel = m_physicsSystem->GetBodyInterface().GetLinearVelocity(it->second);
+			return Math::Vec3(joltVel.GetX(), joltVel.GetY(), joltVel.GetZ());
+		}
+		return Math::Vec3(0.0f, 0.0f, 0.0f);
+	}
 
-    void PhysicsManager::SetLinearVelocity(uint64_t entityLUID, const Math::Vec3& velocity) {
-        auto it = m_bodies.find(entityLUID);
-        if (it != m_bodies.end()) {
-            m_physicsSystem->GetBodyInterface().SetLinearVelocity(it->second, ToJoltVec3(velocity));
-        }
-    }
+	void PhysicsManager::SetLinearVelocity(uint64_t entityLUID, const Math::Vec3& velocity) {
+		auto it = m_bodies.find(entityLUID);
+		if (it != m_bodies.end()) {
+			m_physicsSystem->GetBodyInterface().SetLinearVelocity(it->second, ToJoltVec3(velocity));
+		}
+	}
 
-    Math::Vec3 PhysicsManager::GetAngularVelocity(uint64_t entityLUID) const {
-        auto it = m_bodies.find(entityLUID);
-        if (it != m_bodies.end()) {
-            JPH::Vec3 joltAngVel = m_physicsSystem->GetBodyInterface().GetAngularVelocity(it->second);
-            return Math::Vec3(joltAngVel.GetX(), joltAngVel.GetY(), joltAngVel.GetZ());
-        }
-        return Math::Vec3(0.0f, 0.0f, 0.0f);
-    }
+	Math::Vec3 PhysicsManager::GetAngularVelocity(uint64_t entityLUID) const {
+		auto it = m_bodies.find(entityLUID);
+		if (it != m_bodies.end()) {
+			JPH::Vec3 joltAngVel = m_physicsSystem->GetBodyInterface().GetAngularVelocity(it->second);
+			return Math::Vec3(joltAngVel.GetX(), joltAngVel.GetY(), joltAngVel.GetZ());
+		}
+		return Math::Vec3(0.0f, 0.0f, 0.0f);
+	}
 
-    void PhysicsManager::SetAngularVelocity(uint64_t entityLUID, const Math::Vec3& angularVelocity) {
-        auto it = m_bodies.find(entityLUID);
-        if (it != m_bodies.end()) {
-            m_physicsSystem->GetBodyInterface().SetAngularVelocity(it->second, ToJoltVec3(angularVelocity));
-        }
-    }
+	void PhysicsManager::SetAngularVelocity(uint64_t entityLUID, const Math::Vec3& angularVelocity) {
+		auto it = m_bodies.find(entityLUID);
+		if (it != m_bodies.end()) {
+			m_physicsSystem->GetBodyInterface().SetAngularVelocity(it->second, ToJoltVec3(angularVelocity));
+		}
+	}
 
-    void PhysicsManager::OnPlay() {
+	bool PhysicsManager::CookMeshCollider(const std::vector<Math::Vec3>& vertices,
+		const std::vector<uint32_t>& indices, std::vector<uint8_t>& outBlob) {
+		if (!m_physicsSystem)
+			return false;
 
-    }
+		if (vertices.empty() || indices.size() < 3 || indices.size() % 3 != 0) {
+			SPD_ERROR("PhysicsManager::CookMeshCollider -  invalid mesh data");
+			return false;
+		}
 
-    void PhysicsManager::OnStop() {
-        JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+		JPH::VertexList joltVerts;
+		joltVerts.reserve(vertices.size());
+		for (const auto& v : vertices) {
+			joltVerts.emplace_back(v.x, v.y, v.z);
+		}
 
-        for (auto& [luid, id] : m_bodies) {
-            bi.RemoveBody(id);
-            bi.DestroyBody(id);
-        }
-        m_bodies.clear();
+		JPH::IndexedTriangleList tris;
+		tris.reserve(indices.size() / 3);
 
-        m_characters.clear();
-    }
+		// IndexedTriangle (i0, i1, i2, materialIndex (0 for now))
+		for (size_t i = 0; i < indices.size(); i += 3) {
+			uint32_t i0 = indices[i + 0];
+			uint32_t i1 = indices[i + 1];
+			uint32_t i2 = indices[i + 2];
 
-    void PhysicsManager::SetComponentManager(ECS::ComponentManager* cm) {
-        m_componentManager = cm;
-    }
+			tris.emplace_back(
+				i0,
+				i1,
+				i2,
+				0u
+			);
+		}
+
+		JPH::MeshShapeSettings meshSettings(std::move(joltVerts), std::move(tris));
+
+		meshSettings.mBuildQuality = JPH::MeshShapeSettings::EBuildQuality::FavorRuntimePerformance;
+		meshSettings.mPerTriangleUserData = false;
+
+		JPH::ShapeSettings::ShapeResult shapeResult = meshSettings.Create();
+		if (shapeResult.HasError()) {
+			SPD_ERROR("PhysicsManager::CookMeshCollider - error: " << shapeResult.GetError().c_str());
+			return false;
+		}
+
+		JPH::RefConst<JPH::Shape> meshShape = shapeResult.Get();
+		NE::Physics::StreamOutImpl outBlobStream(outBlob);
+		meshShape->SaveBinaryState(outBlobStream);
+		meshShape->SaveBinaryState(outBlobStream);
+		if (outBlobStream.IsFailed()) {
+			SPD_ERROR("CookMeshCollider - failed to serialize shape");
+			outBlob.clear();
+			return false;
+		}
+
+		return true;
+	}
+
+	void PhysicsManager::OnPlay() {
+	}
+
+	void PhysicsManager::OnStop() {
+		JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+
+		for (auto& [luid, id] : m_bodies) {
+			bi.RemoveBody(id);
+			bi.DestroyBody(id);
+		}
+		m_bodies.clear();
+
+		m_characters.clear();
+	}
+
+	void PhysicsManager::SetComponentManager(ECS::ComponentManager* cm) {
+		m_componentManager = cm;
+	}
 }

--- a/NANOEngine/src/Physics/PhysicsManager.hpp
+++ b/NANOEngine/src/Physics/PhysicsManager.hpp
@@ -19,6 +19,7 @@ namespace NE::ECS::Component {
     struct Transform;
     struct Rigidbody;
 	struct CharacterController;
+	struct Renderer;
 }
 
 namespace NE::Math {
@@ -62,12 +63,14 @@ namespace NE::Physics {
         void Update(double dt);
         void Shutdown();
 
+
         void OnPlay();
         void OnStop();
 
         void SetComponentManager(ECS::ComponentManager* cm);
 
-        void CreateOrUpdateShape(const uint64_t entityLUID, const ECS::Component::Collider& col);
+        uint64_t ComputeShapeSignature(uint32_t entity, const ECS::Component::Collider& col);
+        void CreateOrUpdateShape(uint32_t entity, uint64_t entityLUID, const ECS::Component::Collider& col);
         void RemoveShape(const uint64_t entityLUID);
 
         // Character Controller
@@ -101,7 +104,15 @@ namespace NE::Physics {
         Math::Vec3 GetAngularVelocity(uint64_t entityLUID) const;
         void SetAngularVelocity(uint64_t entityLUID, const Math::Vec3& angularVelocity);
 
+        bool CookMeshCollider(const std::vector<Math::Vec3>& vertices,
+            const std::vector<uint32_t>& indices, std::vector<uint8_t>& outBlob);
+
     private:
+        struct StoredShape {
+            JPH::ShapeRefC shape;
+            uint64_t       signature = 0;
+        };
+
         ECS::ComponentManager* m_componentManager = nullptr;
 
         std::unique_ptr<JPH::Factory> m_factory;
@@ -117,8 +128,9 @@ namespace NE::Physics {
 
         std::unique_ptr<JoltDebugRenderer> m_debugRenderer;
 
-        std::unordered_map<uint64_t, JPH::ShapeRefC> m_shapes;
+        std::unordered_map<uint64_t, StoredShape> m_shapes;
         std::unordered_map<uint64_t, JPH::BodyID> m_bodies;
+        //std::unordered_map<uint32_t, JPH::RefConst<JPH::Shape>> m_meshShapes;
 
         std::unordered_map<uint64_t, CharacterRuntime> m_characters;
 

--- a/NANOEngine/src/Physics/StreamInImpl.cpp
+++ b/NANOEngine/src/Physics/StreamInImpl.cpp
@@ -1,0 +1,23 @@
+#include "StreamInImpl.hpp"
+
+namespace NE::Physics {
+	StreamInImpl::StreamInImpl(const uint8_t* data, size_t size)
+		: mData(data), mSize(size) {
+	}
+
+	void StreamInImpl::ReadBytes(void* outData, size_t inNumBytes) {
+		if (mPos + inNumBytes > mSize) {
+			mFailed = true;
+			return;
+		}
+		std::memcpy(outData, mData + mPos, inNumBytes);
+		mPos += inNumBytes;
+	}
+
+	bool StreamInImpl::IsEOF() const {
+		return mPos >= mSize;
+	}
+	bool StreamInImpl::IsFailed() const {
+		return mFailed;
+	}
+}

--- a/NANOEngine/src/Physics/StreamInImpl.hpp
+++ b/NANOEngine/src/Physics/StreamInImpl.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Jolt/Jolt.h>
+#include <Jolt/Core/StreamIn.h>
+
+namespace NE::Physics {
+	class StreamInImpl final : public JPH::StreamIn {
+	public:
+		StreamInImpl(const uint8_t* data, size_t size);
+
+		void ReadBytes(void* outData, size_t inNumBytes) override;
+
+		bool IsEOF() const override;
+		bool IsFailed() const override;
+
+	private:
+		const uint8_t* mData = nullptr;
+		size_t mSize = 0;
+		size_t mPos = 0;
+		bool mFailed = false;
+	};
+}

--- a/NANOEngine/src/Physics/StreamOutImpl.cpp
+++ b/NANOEngine/src/Physics/StreamOutImpl.cpp
@@ -1,0 +1,16 @@
+#include "StreamOutImpl.hpp"
+
+namespace NE::Physics {
+    StreamOutImpl::StreamOutImpl(std::vector<uint8_t>& out) 
+        : mOut(out) {}
+
+    void StreamOutImpl::WriteBytes(const void* inData, size_t inNumBytes) {
+        size_t old = mOut.size();
+        mOut.resize(old + inNumBytes);
+        std::memcpy(mOut.data() + old, inData, inNumBytes);
+    }
+
+    bool StreamOutImpl::IsFailed() const { 
+        return false; 
+    }
+}

--- a/NANOEngine/src/Physics/StreamOutImpl.hpp
+++ b/NANOEngine/src/Physics/StreamOutImpl.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Jolt/Jolt.h>
+#include <Jolt/Core/StreamOut.h>
+
+namespace NE::Physics {
+    class StreamOutImpl final : public JPH::StreamOut {
+    public:
+        StreamOutImpl(std::vector<uint8_t>& out);
+        void WriteBytes(const void* inData, size_t inNumBytes) override;
+        bool IsFailed() const override;
+
+    private:
+        std::vector<uint8_t>& mOut;
+    };
+}
+

--- a/NANOEngine/src/ResourceManagement/BinaryHeaders/NanoModelHeader.hpp
+++ b/NANOEngine/src/ResourceManagement/BinaryHeaders/NanoModelHeader.hpp
@@ -4,7 +4,7 @@
 namespace NE::Resource {
 
     inline constexpr uint32_t NMOD_MAGIC = 0x4E4D4F44;
-    inline constexpr int CURRENT_NANOMODEL_FORMAT_VERSION = 2;
+    inline constexpr int CURRENT_NANOMODEL_FORMAT_VERSION = 3;
 
 #pragma pack(push, 1)
     struct NanoMeshHeader {
@@ -25,8 +25,14 @@ namespace NE::Resource {
         float aabbMin[3] = { 0,0,0 };
         float aabbMax[3] = { 0,0,0 };
 
-        //float sphereCenter[3] = { 0,0,0 };
         float sphereRadius = 0.0f;
+
+        uint32_t colliderDataOffset = 0; // 0 => none
+        uint32_t colliderDataSize = 0;
+
+        uint8_t  colliderType = 0; // 0 none, 1 triMesh, 2 convexHull, 3 compound etc
+        uint8_t  vertexFlags = 0; // bit0 hasTangents, etc
+        uint16_t reserved = 0;
     };
 #pragma pack(pop)
 

--- a/NANOEngine/src/SceneManagement/Scene.cpp
+++ b/NANOEngine/src/SceneManagement/Scene.cpp
@@ -36,9 +36,6 @@ namespace NE::SceneManagement {
 	}
 
 	void Scene::InitRuntime() {
-		// Initialize PhysicsManager with ComponentManager for LUID resolution
-		Physics::PhysicsManager::GetInstance().SetComponentManager(&m_ecsCoordinator.GetComponentManager());
-
 		m_ecsCoordinator.m_hierarchySystem->Init();
 		m_ecsCoordinator.m_transformSystem->Init();
 		m_ecsCoordinator.m_rigidbodySystem->Init();

--- a/NANOEngine/src/SceneManagement/SceneManager.cpp
+++ b/NANOEngine/src/SceneManagement/SceneManager.cpp
@@ -6,6 +6,7 @@
 #include "ECS/Core/Entity.hpp"
 #include "PrefabManagement/PrefabManager.hpp"
 #include "Serialisation/Serializer.hpp"
+#include "Physics/PhysicsManager.hpp"
 
 namespace NE::SceneManagement {
 
@@ -14,6 +15,7 @@ namespace NE::SceneManagement {
 		m_editor = std::make_unique<Scene>();
 		Prefab::PrefabManager::Init(this);
 		Scripting::ScriptingEngine::GetInstance().BeginSceneLoad();
+		Physics::PhysicsManager::GetInstance().SetComponentManager(&m_editor->GetECSCoordinator().GetComponentManager());
 		if (!NE::Deserialization::DeserializeScene(m_editor->GetECSCoordinator(), path)) {
 			m_editor.reset();
 			Scripting::ScriptingEngine::GetInstance().EndSceneLoad();
@@ -42,6 +44,7 @@ namespace NE::SceneManagement {
 		m_editor = std::make_unique<Scene>();
 		Prefab::PrefabManager::Init(this);
 		Scripting::ScriptingEngine::GetInstance().BeginSceneLoad();
+		Physics::PhysicsManager::GetInstance().SetComponentManager(&m_editor->GetECSCoordinator().GetComponentManager());
 	}
 
 	void SceneManager::StartSceneFallback() {
@@ -64,6 +67,7 @@ namespace NE::SceneManagement {
 		// Load runtime scene from file
 		m_runtime = std::make_unique<Scene>();
 		Scripting::ScriptingEngine::GetInstance().BeginSceneLoad();
+		Physics::PhysicsManager::GetInstance().SetComponentManager(&m_editor->GetECSCoordinator().GetComponentManager());
 		NE::Deserialization::DeserializeScene(m_runtime->GetECSCoordinator(), m_loadedPath);
 
 		// Transfer editor field values to runtime scene (before Init)
@@ -102,6 +106,7 @@ namespace NE::SceneManagement {
 			auto& entityMgr = coordinator.GetEntityManager();
 			auto& luidRegistry = coordinator.GetLUIDRegistry();
 			Scripting::ScriptingEngine::GetInstance().RecreateScriptInstances(componentMgr, entityMgr, luidRegistry);
+			Physics::PhysicsManager::GetInstance().SetComponentManager(&m_editor->GetECSCoordinator().GetComponentManager());
 
 			// Important to recreate the editor's renderviews
 			m_editor->CameraEnter();


### PR DESCRIPTION
Implemented mesh collider support by adding cooked collider blobs to model assets and loading them in the engine. Updated PhysicsManager to handle mesh colliders using cooked data, and refactored shape creation to use signatures for caching. Added new StreamInImpl and StreamOutImpl for collider serialization, and updated related project files.