### PR TITLE
Sync quaternion rotation with Euler updates

### DIFF
--- a/NANOEngine/src/Physics/PhysicsManager.cpp
+++ b/NANOEngine/src/Physics/PhysicsManager.cpp
@@ -722,6 +722,7 @@ namespace NE::Physics {
 		euler.x = 0.0f;
 		euler.z = 0.0f;
 		t.localRotationEuler = euler;
+		t.localRotationQuat = ToEngineQuat(ch.GetRotation());
 
 		t.isDirty = true;
 	}

--- a/NANOEngine/src/Scripting/ScriptAPI.cpp
+++ b/NANOEngine/src/Scripting/ScriptAPI.cpp
@@ -299,6 +299,7 @@ namespace NE {
 			if (m_context->componentManager->HasComponent<ECS::Component::Transform>(targetEntity)) {
 				auto& transform = m_context->componentManager->GetComponent<ECS::Component::Transform>(targetEntity);
 				transform.localRotationEuler = ToEngineVec3(rot);
+				transform.localRotationQuat = NE::Math::Quat::FromEulerDegrees(transform.localRotationEuler);
 				transform.isDirty = true;
 			}
 		}


### PR DESCRIPTION
Updated both PhysicsManager and ScriptAPI to ensure localRotationQuat is set when localRotationEuler is modified. This maintains consistency between Euler angles and quaternion representations in transform components.