### PR TITLE
Refactor frustum culling and improve skybox rendering

### DIFF
--- a/NANOEngine/src/ECS/Systems/RenderSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/RenderSystem.cpp
@@ -1,21 +1,21 @@
 #include "RenderSystem.hpp"
-#include "../Components/Renderer.hpp"
-#include "../Components/Transform.hpp"
-#include "../Components/Collider.hpp"
-#include "../Components/Light.hpp"
-#include "../Components/EntityMeta.hpp"
-#include "../../Graphics/Core/GraphicsManager.hpp"
-#include "../../Graphics/Core/Vertex.hpp"
-#include "../../Graphics/OpenGL/GLVertexBuffer.hpp"
-#include "../../Graphics/OpenGL/GLIndexBuffer.hpp"
-#include "../../Graphics/OpenGL/GLGeometryBuffer.hpp"
-#include "../../Graphics/OpenGL/GLShader.hpp"
-#include "../../Graphics/OpenGL/GLPipeline.hpp"
-#include "../../Graphics/Core/Material.hpp"
-#include "../../Graphics/Core/DrawCommand.hpp"
-#include "../../Core/Profiler.hpp"
+#include "ECS/Components/Renderer.hpp"
+#include "ECS/Components/Transform.hpp"
+//#include "../Components/Collider.hpp"
+//#include "../Components/Light.hpp"
+#include "ECS/Components/EntityMeta.hpp"
+#include "Graphics/Core/GraphicsManager.hpp"
+//#include "../../Graphics/Core/Vertex.hpp"
+//#include "../../Graphics/OpenGL/GLVertexBuffer.hpp"
+//#include "../../Graphics/OpenGL/GLIndexBuffer.hpp"
+//#include "../../Graphics/OpenGL/GLGeometryBuffer.hpp"
+//#include "../../Graphics/OpenGL/GLShader.hpp"
+//#include "../../Graphics/OpenGL/GLPipeline.hpp"
+#include "Graphics/Core/Material.hpp"
+#include "Graphics/Core/DrawCommand.hpp"
+#include "Core/Profiler.hpp"
 #include "ResourceManagement/ResourceManager.hpp"
-#include <glad/glad.h>
+//#include <glad/glad.h>
 #include "Core/LUIDGenerator.hpp"
 #include "Core/LUIDRegistry.hpp"
 
@@ -25,19 +25,6 @@ using NE::Graphics::GraphicsManager;
 
 namespace NE::ECS::Systems {
     namespace {
-        inline bool SphereInFrustum(const NE::Graphics::Frustum& f,
-            const NE::Math::Vec3& c,
-            float r)
-        {
-            for (int i = 0; i < 6; ++i) {
-                const auto& p = f.planes[i];
-                float dist = p.n.x * c.x + p.n.y * c.y + p.n.z * c.z + p.d;
-                //float dist = p.n.Dot(c) + p.d;
-                if (dist < -r) return false;
-            }
-            return true;
-        }
-
         inline float MaxScaleAxis(const NE::Math::Mat4& M) {
             NE::Math::Vec3 x = { M.GetElement(0, 0), M.GetElement(1, 0), M.GetElement(2, 0) };
             NE::Math::Vec3 y = { M.GetElement(0, 1), M.GetElement(1, 1), M.GetElement(2, 1) };
@@ -92,17 +79,12 @@ namespace NE::ECS::Systems {
 #ifndef PRODUCTION_BUILD
 		NE_PROFILE_FUNCTION();
 #endif
-
-        const Frustum frustum = BuildFrustum();
-        const auto& entities = GetEntities();
+        const auto& entities = m_entities.GetDenseContainer();
 
         for (Entity entity : entities) {
-            // Skip inactive entities
-            if (m_componentManager->HasComponent<Component::EntityMeta>(entity)) {
-                const auto& meta = m_componentManager->GetComponent<Component::EntityMeta>(entity);
-                if (!meta.isActive) {
-                    continue;
-                }
+            const auto& meta = m_componentManager->GetComponent<Component::EntityMeta>(entity);
+            if (!meta.isActive) {
+                continue;
             }
 
             auto& renderer = m_componentManager->GetComponent<Component::Renderer>(entity);
@@ -110,85 +92,30 @@ namespace NE::ECS::Systems {
 
             auto& transform = m_componentManager->GetComponent<Component::Transform>(entity);
 
+            const auto& ms = renderer.model->meshes[renderer.subMeshIndex].localSphere;
+            float baseR = ms.radius;
 
-            if (renderer.subMeshIndex < 0) {
-                continue;
-       //         const auto& ms = renderer.model->localSphere;
-       //         float baseR = ms.radius;
+            Graphics::DrawCommand cmd;
+            cmd.mesh = renderer.model->meshes[renderer.subMeshIndex].buffer;
+            cmd.material = renderer.material;
+            cmd.transform = transform.worldMatrix;
 
-       //         bool visible = true;
-       //         if (baseR > 0.0f) {
-       //             Vec3 centerWS = TransformPoint(transform.worldMatrix, ms.center);
-       //             float rWS = baseR * MaxScaleAxis(transform.worldMatrix);
-       //             visible = SphereInFrustum(frustum, centerWS, rWS);
-       //         }
+            float r = (float)(entity & 0xFF) / 255.0f;
+            float g = (float)((entity >> 8) & 0xFF) / 255.0f;
+            float b = (float)((entity >> 16) & 0xFF) / 255.0f;
+            cmd.idRGB = Vec3{ r, g, b };
 
-       //         if (!visible) continue;
+            cmd.boundsCenterWS = TransformPoint(transform.worldMatrix, ms.center);
+            cmd.boundsRadiusWs = baseR * MaxScaleAxis(transform.worldMatrix);
 
-			    //for (auto& sub : renderer.model->meshes) {
-				   // Graphics::DrawCommand cmd;
-				   // cmd.mesh = sub.buffer;
-				   // cmd.material = renderer.material;
-				   // cmd.transform = transform.worldMatrix;
+            cmd.castsShadow = (renderer.shadowCastMode != Component::Renderer::ShadowCastMode::Off);
+            cmd.receivesShadow = renderer.receiveShadows;
 
-       //             float r = (float)(entity & 0xFF) / 255.0f;
-       //             float g = (float)((entity >> 8) & 0xFF) / 255.0f;
-       //             float b = (float)((entity >> 16) & 0xFF) / 255.0f;
-				   // cmd.idRGB = Vec3{ r, g, b };
-
-       //             cmd.castsShadow = (renderer.shadowCastMode != Component::Renderer::ShadowCastMode::Off);
-       //             cmd.receivesShadow = renderer.receiveShadows;
-
-				   // Graphics::GraphicsManager::Submit(cmd);
-			    //}
-            } else {
-                const auto& ms = renderer.model->meshes[renderer.subMeshIndex].localSphere;
-                float baseR = ms.radius;
-
-                bool visible = true;
-                if (baseR > 0.0f) {
-                    Vec3 centerWS = TransformPoint(transform.worldMatrix, ms.center);
-                    float rWS = baseR * MaxScaleAxis(transform.worldMatrix);
-                    visible = SphereInFrustum(frustum, centerWS, rWS);
-                }
-
-                if (!visible) continue;
-
-                Graphics::DrawCommand cmd;
-                cmd.mesh = renderer.model->meshes[renderer.subMeshIndex].buffer;
-                cmd.material = renderer.material;
-                cmd.transform = transform.worldMatrix;
-
-                float r = (float)(entity & 0xFF) / 255.0f;
-                float g = (float)((entity >> 8) & 0xFF) / 255.0f;
-                float b = (float)((entity >> 16) & 0xFF) / 255.0f;
-                cmd.idRGB = Vec3{ r, g, b };
-
-                cmd.castsShadow = (renderer.shadowCastMode != Component::Renderer::ShadowCastMode::Off);
-                cmd.receivesShadow = renderer.receiveShadows;
-
-                Graphics::GraphicsManager::Submit(cmd);
-            }
+            Graphics::GraphicsManager::Submit(cmd);
         }
     }
 
     void RenderSystem::Exit()
     {
     }
-
-    Frustum RenderSystem::BuildFrustum() {
-        auto* cam = GraphicsManager::GetEditorCamera();
-
-        if (!cam)
-        {
-            return Frustum::ExtractPlanesFromVP(Mat4{}); // default
-        }
-
-        const Mat4& V = cam->GetViewMatrix();
-        const Mat4& P = cam->GetProjectionMatrix();
-
-        Mat4 nonConstPCopy = P;
-        return Frustum::ExtractPlanesFromVP(nonConstPCopy * V);
-    }
-
 }

--- a/NANOEngine/src/Engine.cpp
+++ b/NANOEngine/src/Engine.cpp
@@ -111,7 +111,7 @@ namespace NE {
 		
 		gSceneManager.Update(dt);
 
-		Graphics::GraphicsManager::SubmitSkybox(); // Submit skybox once per frame
+		//Graphics::GraphicsManager::SubmitSkybox(); // Submit skybox once per frame
 
 		Physics::JoltDebugRenderer::EndFrame();
 		gSceneManager.Render();

--- a/NANOEngine/src/Graphics/Core/DrawCommand.hpp
+++ b/NANOEngine/src/Graphics/Core/DrawCommand.hpp
@@ -7,12 +7,15 @@
 
 namespace NE::Graphics {
     struct DrawCommand {
+        Math::Mat4 transform;
+        Math::Vec3 idRGB = Math::Vec3{ -1.0f, -1.0f, -1.0f }; // for object picking
+        Math::Vec3 boundsCenterWS = Math::Vec3{ 0.0f, 0.0f, 0.0f };
         std::shared_ptr<IGeometryBuffer> mesh;
         std::shared_ptr<Material> material;
-        Math::Mat4 transform;
-		Math::Vec3 idRGB = Math::Vec3{ -1.0f, -1.0f, -1.0f }; // for object picking
 
-        bool castsShadow;
-        bool receivesShadow;
+        float boundsRadiusWs = 0.0f;
+
+        bool castsShadow = false;
+        bool receivesShadow = false;
     };
 }

--- a/NANOEngine/src/Graphics/Core/GraphicsManager.cpp
+++ b/NANOEngine/src/Graphics/Core/GraphicsManager.cpp
@@ -51,6 +51,7 @@
 #include <GL/gl.h> // Add this include for OpenGL functions like glBegin, glEnd, etc.
 
 #include "Input/InputManager.hpp"
+#include "Frustum.hpp"
 
 
 namespace NE::Graphics {
@@ -183,6 +184,19 @@ namespace NE::Graphics {
 
             Mat4 lightProj = Mat4::BuildOrtho(minX, maxX, minY, maxY, nearP, farP);
             return lightProj * lightView;
+        }
+
+        inline bool SphereInFrustum(const NE::Graphics::Frustum& f,
+            const NE::Math::Vec3& c,
+            float r)
+        {
+            for (int i = 0; i < 6; ++i) {
+                const auto& p = f.planes[i];
+                float dist = p.n.x * c.x + p.n.y * c.y + p.n.z * c.z + p.d;
+                //float dist = p.n.Dot(c) + p.d;
+                if (dist < -r) return false;
+            }
+            return true;
         }
     }
 
@@ -638,18 +652,14 @@ namespace NE::Graphics {
         if (s_skybox) s_skybox->Submit();
     }
 
-    void GraphicsManager::DrawFrame()
-    {
+    void GraphicsManager::DrawFrame() {
         NE_PROFILE_FUNCTION();
-
-        int renderedViews = 0;
 
         UpdateShadowMaps();
 
         for (auto& [handle, view] : s_RenderViewManager->GetAllRenderViews()) {
             if (!view.isActive) continue;
             if (view.isMain && view.order == 0) s_GameViewHandle = handle;
-
 
             s_RenderViewManager->Bind(handle);
             s_CommandBuffer->Begin();
@@ -757,16 +767,23 @@ namespace NE::Graphics {
                 currentMesh->Unbind();
 
                 instanceData.clear();
-                ++drawCount;
+
+                if (view.isMain && view.order == 0)
+                    ++drawCount;
 
                 };
 
+            const Frustum frustum = Frustum::ExtractPlanesFromVP(camProj * camView);
             const auto& commands = s_DrawQueue->GetCommands();
+
             for (const auto& command : commands) {
+                if (!SphereInFrustum(frustum, command.boundsCenterWS, command.boundsRadiusWs)) {
+                    continue;
+                }
+
                 auto mesh = command.mesh;
                 auto material = command.material;
                 bool receives = command.receivesShadow;
-                
 
                 // Check compatibility with current batch
                 bool compatible =
@@ -793,19 +810,19 @@ namespace NE::Graphics {
                 instanceData.push_back(instance);
             }
 
-            // Flush any remaining batch
             if (!instanceData.empty()) {
                 flushBatch();
+            }
+
+            if (s_skybox) {
+                s_StateCache->Bind(s_skybox->GetSkyboxPipeline());
+                s_skybox->Draw(view);
             }
 
             if (handle == 1) // Assuming editor camera handle will always be 1
                 DrawAllDebugGeometry();
 
-            ++renderedViews;
             s_RenderViewManager->Unbind();
-        }
-        if (renderedViews > 0) {
-            drawCount /= renderedViews;
         }
 
 		// Note: Reset should be called right before any post-processing
@@ -1257,25 +1274,21 @@ namespace NE::Graphics {
 #pragma endregion
     }
 
-    void GraphicsManager::Submit(const DrawCommand& command) 
-    {
+    void GraphicsManager::Submit(const DrawCommand& command) {
 		s_DrawQueue->Submit(command);
     }
 
-    void GraphicsManager::EndFrame() 
-    {
+    void GraphicsManager::EndFrame() {
 		s_RenderViewManager->Unbind();
         //s_CommandBuffer->EndRenderPass();
         //s_CommandBuffer->End();
     }
 
-    void GraphicsManager::Clear() 
-    {
+    void GraphicsManager::Clear() {
         s_DrawQueue->Clear();
 	}
 
-    void GraphicsManager::Shutdown() 
-    {
+    void GraphicsManager::Shutdown() {
 		s_RenderViewManager->Shutdown();
         s_skybox.reset();
         s_CommandBuffer.reset();
@@ -1308,18 +1321,15 @@ namespace NE::Graphics {
         NE::Graphics::OpenGL::GLGeometryBuffer::ShutdownInstanceBuffer();
     }
 
-    void GraphicsManager::SetEditorCamera(EditorCamera* cam) 
-    {
+    void GraphicsManager::SetEditorCamera(EditorCamera* cam) {
         s_EditorCamera = cam;
     }
 
-    EditorCamera* GraphicsManager::GetEditorCamera() 
-    {
+    EditorCamera* GraphicsManager::GetEditorCamera() {
         return s_EditorCamera;
     }
 
-    void GraphicsManager::UpdateEditorCameraData()
-    {
+    void GraphicsManager::UpdateEditorCameraData() {
         s_RenderViewManager->SetCameraData(
             s_SceneViewHandle, 
 			s_EditorCamera->GetProjectionMatrix(),

--- a/NANOEngine/src/Graphics/Core/Material.cpp
+++ b/NANOEngine/src/Graphics/Core/Material.cpp
@@ -112,6 +112,7 @@ namespace NE::Graphics {
 
     void Material::Bind() const {
         auto* shader = m_Pipeline->GetSpecification().shader.get();
+
         for (const auto& [uName, val] : m_FloatUniforms)
             shader->SetUniformFloat(uName, val);
         for (const auto& [uName, val] : m_Vec3Uniforms)

--- a/NANOEngine/src/Graphics/Core/Skybox.cpp
+++ b/NANOEngine/src/Graphics/Core/Skybox.cpp
@@ -11,6 +11,7 @@
 #include "Vertex.hpp"
 #include "DrawCommand.hpp"
 #include "ResourceManagement/ResourceManager.hpp"
+#include "Graphics/Core/RenderViewManager.hpp"
 
 namespace NE::Graphics {
 
@@ -39,26 +40,51 @@ namespace NE::Graphics {
 
         auto vb = std::make_shared<GLVertexBuffer>(vertices, static_cast<uint32_t>(sizeof(vertices)), sizeof(Vertex));
         auto ib = std::make_shared<GLIndexBuffer>(indices, sizeof(indices) / sizeof(uint32_t));
-        m_Mesh = std::make_shared<GLGeometryBuffer>(vb, ib);
+        m_mesh = std::make_shared<GLGeometryBuffer>(vb, ib);
 
         auto shader = Resource::ResourceManager::GetInstance().
             LoadResource<GLShader>("neskybox");
         PipelineSpecification spec;
         spec.shader = shader;
         spec.CullMode = GL_BACK;
-        spec.EnableDepthTest = false;
+        spec.EnableDepthTest = true;
+        spec.DepthWrite = false;
         spec.PolygonMode = GL_FILL;
         auto pipeline = std::make_shared<GLPipeline>(spec, "Skybox");
-        m_Material = std::make_shared<Material>(pipeline);
-		m_Material->SetQueueBase(RenderQueue::BACKGROUND);
+        m_material = std::make_shared<Material>(pipeline);
+		m_material->SetQueueBase(RenderQueue::BACKGROUND);
+    }
+
+    void Skybox::Draw(const RenderView& view) const {
+        glDepthFunc(GL_LEQUAL);
+		glDepthMask(GL_FALSE);
+
+        auto pipeline = m_material->GetPipeline();
+        auto shader = pipeline->GetSpecification().shader;
+
+        m_material->Bind();
+        m_mesh->Bind();
+
+        shader->SetUniformMat4("u_View", view.view);
+        shader->SetUniformMat4("u_Projection", view.projection);
+
+        m_mesh->Draw();
+        m_mesh->Unbind();
+
+		glDepthMask(GL_TRUE);
+        glDepthFunc(GL_LESS);
     }
 
     void Skybox::Submit() const {
         DrawCommand cmd;
-        cmd.mesh = m_Mesh;
-        cmd.material = m_Material;
+        cmd.mesh = m_mesh;
+        cmd.material = m_material;
         cmd.transform = Math::Mat4::BuildScaling(50.f, 50.f, 50.f);
         GraphicsManager::Submit(cmd);
+    }
+
+    std::shared_ptr<IPipeline> Skybox::GetSkyboxPipeline() const {
+		return m_material->GetPipeline();
     }
 
 }

--- a/NANOEngine/src/Graphics/Core/Skybox.hpp
+++ b/NANOEngine/src/Graphics/Core/Skybox.hpp
@@ -5,15 +5,18 @@
 #include "../Interfaces/IGeometryBuffer.hpp"
 
 namespace NE::Graphics {
+	struct RenderView;
 
     class Skybox {
     public:
         Skybox();
+        void Draw(const RenderView& view) const;
         void Submit() const;
 
+        std::shared_ptr<IPipeline> GetSkyboxPipeline() const;
     private:
-        std::shared_ptr<IGeometryBuffer> m_Mesh;
-        std::shared_ptr<Material> m_Material;
+        std::shared_ptr<IGeometryBuffer> m_mesh;
+        std::shared_ptr<Material> m_material;
     };
 
 }

--- a/NANOEngine/src/Graphics/OpenGL/GLCommandBuffer.cpp
+++ b/NANOEngine/src/Graphics/OpenGL/GLCommandBuffer.cpp
@@ -15,8 +15,9 @@ namespace NE::Graphics::OpenGL {
     }
 
     void GLCommandBuffer::Begin() {
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         glClearColor(1.f, 1.f, 1.f, 1.f);
+        glClearDepth(1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     }
 
     void GLCommandBuffer::End() {

--- a/NANOEngine/src/Graphics/OpenGL/GLStateCache.cpp
+++ b/NANOEngine/src/Graphics/OpenGL/GLStateCache.cpp
@@ -130,8 +130,7 @@ namespace NE::Graphics::OpenGL {
 		}
 	}
 
-	void GLStateCache::Bind(const std::shared_ptr<IPipeline>& pipeline)
-	{
+	void GLStateCache::Bind(const std::shared_ptr<IPipeline>& pipeline) {
 		if (pipeline) {
 			Bind(pipeline->GetSpecification());
 		}

--- a/binfiles/Library/Shaders/Skybox.nanoshader
+++ b/binfiles/Library/Shaders/Skybox.nanoshader
@@ -2,9 +2,6 @@
 #version 460 core
 
 layout(location = 0) in vec3 a_Position;
-layout(location = 1) in vec3 a_Normal;
-layout(location = 2) in vec2 a_TexCoord;
-layout(location = 5) in mat4 i_Model;
 
 uniform mat4 u_View;
 uniform mat4 u_Projection;
@@ -12,9 +9,11 @@ uniform mat4 u_Projection;
 out vec3 v_Dir;
 
 void main() {
-    mat4 view = mat4(mat3(u_View));
+    mat4 viewNoTrans = mat4(mat3(u_View));
     v_Dir = a_Position;
-    gl_Position = u_Projection * view * i_Model * vec4(a_Position, 1.0);
+
+    vec4 p = u_Projection * viewNoTrans * vec4(a_Position, 1.0);
+    gl_Position = p.xyww;
 }
 
 #type fragment
@@ -26,8 +25,38 @@ out vec4 FragColor;
 
 void main() {
     vec3 dir = normalize(v_Dir);
-    float t = dir.y * 0.5 + 0.5;
-    vec3 bottom = vec3(0.8, 0.9, 1.0);
-    vec3 top = vec3(0.1, 0.2, 0.5);
-    FragColor = vec4(mix(bottom, top, t), 1.0);
+
+    // 0 at horizon, 1 at zenith
+    float up = clamp(dir.y * 0.5 + 0.5, 0.0, 1.0);
+
+    // Sharper shaping for nicer gradient
+    float zenithW  = pow(up, 1.8);
+    float horizonW = pow(1.0 - abs(dir.y), 3.5); // thin band around horizon
+
+    // Base sky colors (linear, HDR-friendly)
+    vec3 zenithCol  = vec3(0.08, 0.18, 0.55) * 1.2;
+    vec3 horizonCol = vec3(0.55, 0.72, 1.05) * 1.1;
+
+    // Main gradient
+    vec3 sky = mix(horizonCol, zenithCol, zenithW);
+
+    // Horizon haze glow (slightly warm)
+    vec3 hazeCol = vec3(1.10, 0.95, 0.80) * 0.35;
+    sky += hazeCol * horizonW;
+
+    // Sun (pick a direction in world space; tune as you like)
+    vec3 sunDir = normalize(vec3(0.25, 0.55, 0.25));
+    float sunCos = max(dot(dir, sunDir), 0.0);
+
+    // Sun disc + bloom lobe (HDR)
+    float sunDisc  = smoothstep(0.9994, 1.0, sunCos);       // tiny disc
+    float sunBloom = pow(sunCos, 180.0) * 0.8 + pow(sunCos, 32.0) * 0.25;
+
+    vec3 sunCol = vec3(1.15, 1.05, 0.90) * 8.0;             // bright in linear HDR
+    sky += sunCol * (sunDisc * 1.0 + sunBloom);
+
+    // Gentle overall exposure (still linear; tonemap later)
+    sky *= 1.0;
+
+    FragColor = vec4(sky, 1.0);
 }


### PR DESCRIPTION
Moved frustum culling logic from RenderSystem to GraphicsManager and now perform culling in DrawFrame using per-object bounds. Refactored DrawCommand to include world-space bounds for efficient culling. Updated skybox rendering to use correct depth state and pipeline, and improved the skybox shader for a more realistic gradient and sun effect. Cleaned up includes and removed unused code in RenderSystem.