### PR TITLE
Fix prefab-drag logic and update debug-draw includes

### DIFF
--- a/Editor/src/Panels/HierarchyPanel.cpp
+++ b/Editor/src/Panels/HierarchyPanel.cpp
@@ -273,7 +273,7 @@ namespace Editor {
 			if (hierHovered && !m_draggedEntities.empty()) {
 				if (EditorScene::selectedPrefab.empty()) {
 					for (auto child : m_draggedEntities) {
-						if (NE::ECS::Query::HasPrefabLink(child)) {
+						if (!NE::ECS::Query::HasPrefabInstance(child) && NE::ECS::Query::HasPrefabLink(child)) {
 							m_dragRep = NE::ECS::NO_ENTITY;
 							m_draggedEntities.clear();
 							m_previewAsChild = false;

--- a/NANOEngine/NANOEngine.vcxproj
+++ b/NANOEngine/NANOEngine.vcxproj
@@ -32,7 +32,6 @@
     <ClInclude Include="src\Graphics\Core\PostProcessPipeline.hpp" />
     <ClInclude Include="src\EditorInterface\AudioExports.hpp" />
     <ClInclude Include="src\Graphics\DebugRenderer\DebugDrawSystem.hpp" />
-    <ClInclude Include="src\Graphics\Debug\DebugDrawSystem.hpp" />
     <ClInclude Include="src\Physics\ContactDefs.hpp" />
     <ClInclude Include="src\Physics\ContactListenerImpl.hpp" />
     <ClInclude Include="src\Animation\AnimationClip.hpp" />
@@ -207,7 +206,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Graphics\DebugRenderer\DebugDrawSystem.cpp" />
-    <ClCompile Include="src\Graphics\Debug\DebugDrawSystem.cpp" />
     <ClCompile Include="src\Graphics\Core\ShadowRenderer.cpp" />
     <ClCompile Include="src\Graphics\Core\PostProcessPipeline.cpp" />
     <ClCompile Include="src\EditorInterface\AudioExports.cpp" />

--- a/NANOEngine/src/Graphics/Core/GraphicsManager.cpp
+++ b/NANOEngine/src/Graphics/Core/GraphicsManager.cpp
@@ -35,7 +35,7 @@
 #include "../OpenGL/GLClusteredLighting.hpp"
 
 #include "GizmosRenderer.hpp"
-#include "../Debug/DebugDrawSystem.hpp"
+#include "Graphics/DebugRenderer/DebugDrawSystem.hpp"
 #include "../../Core/Logger.hpp"
 #include "../../Core/Profiler.hpp"
 #include "../../ECS/Components/Light.hpp"


### PR DESCRIPTION
Refine prefab drag handling and project include paths: add a check to ignore prefab instances when clearing dragged entities (only clear if HasPrefabLink && not a PrefabInstance) to avoid dropping valid prefab instances during drag. Remove duplicate/outdated DebugDrawSystem entries from the .vcxproj and update GraphicsManager include to the correct DebugDrawSystem header path to match the new file location and prevent build/include errors.