### PR TITLE
Improve postprocess ping-pong & render graph

### DIFF
--- a/NANOEngine/src/Graphics/Core/GraphicsManager.cpp
+++ b/NANOEngine/src/Graphics/Core/GraphicsManager.cpp
@@ -438,7 +438,7 @@ namespace NE::Graphics {
     uint32_t GraphicsManager::GetSceneColorAttachment() 
     {
         //if (InputManager::IsKeyDown('4')) return s_FinalColorTex;
-        //if (InputManager::IsKeyDown('8')) return s_RenderViewManager->GetFramebuffer(s_SceneViewHandle)->GetDepthAttachment();
+        //if (InputManager::IsKeyDown('8')) return s_RenderViewManager->GetFramebuffer(s_SceneViewHandle)->GetColorAttachment();
         //if (InputManager::IsKeyDown('9')) return s_SSAOTex;
         //if (InputManager::IsKeyDown('0')) return s_RenderViewManager->GetFramebuffer(s_GameViewHandle)->GetColorAttachment();
         //if (InputManager::IsKeyDown('P')) return s_RenderViewManager->GetFramebuffer(s_FinalGameOutputHandle)->GetColorAttachment();

--- a/NANOEngine/src/Graphics/Core/PostProcessPipeline.cpp
+++ b/NANOEngine/src/Graphics/Core/PostProcessPipeline.cpp
@@ -14,8 +14,7 @@
 #include <GL/gl.h>
 
 namespace NE::Graphics {
-	void PostProcessPipeline::Init(RenderViewManager* rvm, uint32_t initialW, uint32_t initialH)
-	{
+	void PostProcessPipeline::Init(RenderViewManager* rvm, uint32_t initialW, uint32_t initialH) {
 		m_rvm = rvm;
 		m_Width = initialW;
 		m_Height = initialH;
@@ -30,16 +29,14 @@ namespace NE::Graphics {
 		InitSSAOResources(m_Width, m_Height);
 	}
 
-	void PostProcessPipeline::Shutdown()
-	{
+	void PostProcessPipeline::Shutdown() {
 		DestroyResources(true);
 		m_graph.reset();
 		m_pool.reset();
 		m_rvm = nullptr;
 	}
 
-	void PostProcessPipeline::Resize(uint32_t w, uint32_t h)
-	{
+	void PostProcessPipeline::Resize(uint32_t w, uint32_t h) {
 		if (w == 0 || h == 0) return;
 		if (w == m_Width && h == m_Height) return;
 
@@ -54,8 +51,8 @@ namespace NE::Graphics {
 	void PostProcessPipeline::Execute(RenderViewHandle sourceView,
 		RenderViewHandle destView,
 		const Math::Mat4& invProj,
-		bool isSceneView)
-	{
+		bool isSceneView
+	) {
 		if (!m_rvm || !m_graph) return;
 
 		m_context.invProj = invProj;
@@ -65,13 +62,11 @@ namespace NE::Graphics {
 		m_graph->Execute();
 	}
 
-	void PostProcessPipeline::SetSettings(PostProcessingSettings* settings)
-	{
+	void PostProcessPipeline::SetSettings(PostProcessingSettings* settings) {
 		m_settings = settings;
 	}
 
-	void PostProcessPipeline::InitFullscreenQuad()
-	{
+	void PostProcessPipeline::InitFullscreenQuad() {
 		if (m_QuadVAO != 0) return;
 
 		float quadVerts[] = {
@@ -96,8 +91,7 @@ namespace NE::Graphics {
 		glBindVertexArray(0);
 	}
 
-	void PostProcessPipeline::InitBloomResources(uint32_t w, uint32_t h)
-	{
+	void PostProcessPipeline::InitBloomResources(uint32_t w, uint32_t h) {
 		if (w == 0 || h == 0) return;
 
 		if (m_brightPassFBO == 0) {
@@ -212,8 +206,7 @@ namespace NE::Graphics {
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	}
 
-	void PostProcessPipeline::LoadShaders()
-	{
+	void PostProcessPipeline::LoadShaders() {
 		if (!m_brightPassShader) {
 			m_brightPassShader = Resource::ResourceManager::GetInstance()
 				.LoadResource<OpenGL::GLShader>("nebrightpass");
@@ -423,7 +416,8 @@ namespace NE::Graphics {
 					int w = m_bloomWidth[hi];
 					int h = m_bloomHeight[hi];
 
-					glBindFramebuffer(GL_FRAMEBUFFER, m_bloomFBO[hi]);
+					// Avoid read/write hazards by ping-ponging to a temp target.
+					glBindFramebuffer(GL_FRAMEBUFFER, m_bloomTempFBO[hi]);
 					glViewport(0, 0, w, h);
 					glClearColor(0, 0, 0, 1);
 					glClear(GL_COLOR_BUFFER_BIT);
@@ -440,6 +434,9 @@ namespace NE::Graphics {
 
 					glBindVertexArray(m_QuadVAO);
 					glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+					std::swap(m_bloomTex[hi], m_bloomTempTex[hi]);
+					std::swap(m_bloomFBO[hi], m_bloomTempFBO[hi]);
 				}
 				glBindFramebuffer(GL_FRAMEBUFFER, 0);
 			});

--- a/NANOEngine/src/Graphics/Core/PostProcessPipeline.hpp
+++ b/NANOEngine/src/Graphics/Core/PostProcessPipeline.hpp
@@ -15,8 +15,6 @@ namespace NE {
 		namespace OpenGL {
 			class GLShader;
 		}
-		//class RenderGraph;
-		//class TexturePool;
 		class IFrameBuffer;
 		class RenderViewManager;
 		struct PostProcessingSettings;

--- a/NANOEngine/src/Graphics/Core/RenderGraph.cpp
+++ b/NANOEngine/src/Graphics/Core/RenderGraph.cpp
@@ -341,25 +341,30 @@ namespace NE::Graphics {
         std::vector<std::vector<size_t>>& adjacency,
         std::vector<size_t>& inDegree) const
     {
-        // Build a map: resource -> pass that writes it
-        std::unordered_map<uint32_t, size_t> resourceWriters;
+        // Track the last writer as we walk passes in insertion order.
+        // This preserves ordering for multiple writes to the same resource.
+        std::unordered_map<uint32_t, size_t> lastWriter;
 
         for (size_t i = 0; i < m_Passes.size(); ++i) {
-            for (const auto& write : m_Passes[i].writes) {
-                resourceWriters[write.id] = i;
-            }
-        }
+            const auto& pass = m_Passes[i];
 
-        // For each pass that reads a resource, add edge from writer to reader
-        for (size_t i = 0; i < m_Passes.size(); ++i) {
-            for (const auto& read : m_Passes[i].reads) {
-                auto it = resourceWriters.find(read.id);
-                if (it != resourceWriters.end() && it->second != i) {
-                    // Pass it->second writes this resource, pass i reads it
-                    // So it->second must execute before i
+            // Reads depend on the most recent writer.
+            for (const auto& read : pass.reads) {
+                auto it = lastWriter.find(read.id);
+                if (it != lastWriter.end() && it->second != i) {
                     adjacency[it->second].push_back(i);
                     ++inDegree[i];
                 }
+            }
+
+            // Writes must be ordered after the previous writer (write-after-write).
+            for (const auto& write : pass.writes) {
+                auto it = lastWriter.find(write.id);
+                if (it != lastWriter.end() && it->second != i) {
+                    adjacency[it->second].push_back(i);
+                    ++inDegree[i];
+                }
+                lastWriter[write.id] = i;
             }
         }
     }


### PR DESCRIPTION
Refactor postprocessing and render graph logic: use temporary ping-pong targets for bloom passes and swap textures/FBOs to avoid read/write hazards; tidy PostProcessPipeline brace/style and small API call formatting; remove unused forward declarations from PostProcessPipeline.hpp; fix a commented debug line in GraphicsManager to reference color attachment; update RenderGraph dependency builder to track the last writer per resource (preserving insertion order) and add proper edges for read-after-write and write-after-write cases.