### PR TITLE
Add bidirectional transform-physics sync

### DIFF
--- a/NANOEngine/src/ECS/Systems/CharacterControllerSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/CharacterControllerSystem.cpp
@@ -52,7 +52,14 @@ namespace NE::ECS::Systems {
 		for (auto& e : allEntities) {
 			auto& meta = m_componentManager->GetComponent<Component::EntityMeta>(e);
 			auto& t = m_componentManager->GetComponent<Component::Transform>(e);
-			Physics::PhysicsManager::GetInstance().SyncTransformToCharacters(meta.luid, t);
+
+			// If transform was manually changed, sync TO character controller
+			// Otherwise, sync FROM character controller TO transform
+			if (t.isDirty) {
+				Physics::PhysicsManager::GetInstance().SyncCharactersToTransform(meta.luid, t);
+			} else {
+				Physics::PhysicsManager::GetInstance().SyncTransformToCharacters(meta.luid, t);
+			}
 		}
 	}
 

--- a/NANOEngine/src/ECS/Systems/RigidbodySystem.cpp
+++ b/NANOEngine/src/ECS/Systems/RigidbodySystem.cpp
@@ -50,7 +50,14 @@ namespace NE::ECS::Systems {
 		for (auto& e : allEntities) {
 			auto& meta = m_componentManager->GetComponent<Component::EntityMeta>(e);
 			auto& t = m_componentManager->GetComponent<Component::Transform>(e);
-			Physics::PhysicsManager::GetInstance().SyncTransformToBodies(meta.luid, t);
+
+			// If transform was manually changed, sync TO physics body
+			// Otherwise, sync FROM physics body TO transform
+			if (t.isDirty) {
+				Physics::PhysicsManager::GetInstance().SyncBodiesToTransform(meta.luid, t);
+			} else {
+				Physics::PhysicsManager::GetInstance().SyncTransformToBodies(meta.luid, t);
+			}
 		}
 	}
 

--- a/NANOEngine/src/Physics/PhysicsManager.cpp
+++ b/NANOEngine/src/Physics/PhysicsManager.cpp
@@ -716,6 +716,19 @@ namespace NE::Physics {
 		t.isDirty = true;
 	}
 
+	void PhysicsManager::SyncBodiesToTransform(uint64_t luid, const ECS::Component::Transform& t) {
+		JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+
+		auto it = m_bodies.find(luid);
+		if (it == m_bodies.end()) return;
+
+		const JPH::BodyID& bodyID = it->second;
+		const JPH::RVec3 newPos = ToJoltVec3(t.worldMatrix.GetTranslation());
+		const JPH::Quat newRot = ToJPHQuat(t.localRotationQuat);
+
+		bi.SetPositionAndRotation(bodyID, newPos, newRot, JPH::EActivation::Activate);
+	}
+
 	void PhysicsManager::SyncTransformToCharacters(uint64_t entityLUID, ECS::Component::Transform& t) const {
 		auto& rt = m_characters.at(entityLUID);
 		auto& ch = *rt.controller;
@@ -728,6 +741,18 @@ namespace NE::Physics {
 		t.localRotationQuat = ToEngineQuat(ch.GetRotation());
 
 		t.isDirty = true;
+	}
+
+	void PhysicsManager::SyncCharactersToTransform(uint64_t entityLUID, const ECS::Component::Transform& t) {
+		auto it = m_characters.find(entityLUID);
+		if (it == m_characters.end()) return;
+
+		auto& ch = *it->second.controller;
+		const JPH::RVec3 newPos = ToJoltVec3(t.worldMatrix.GetTranslation());
+		const JPH::Quat newRot = ToJPHQuat(t.localRotationQuat);
+
+		ch.SetPosition(newPos);
+		ch.SetRotation(newRot);
 	}
 
 	void PhysicsManager::DrawShapeGizmo(const uint64_t entityLUID, const ECS::Component::Transform& t, const ECS::Component::Collider& col) {

--- a/NANOEngine/src/Physics/PhysicsManager.hpp
+++ b/NANOEngine/src/Physics/PhysicsManager.hpp
@@ -101,7 +101,9 @@ namespace NE::Physics {
         void RemoveContactsInvolving(uint64_t luid);
 
         void SyncTransformToBodies(uint64_t entityLUID, ECS::Component::Transform& t) const;
+		void SyncBodiesToTransform(uint64_t entityLUID, const ECS::Component::Transform& t);
 		void SyncTransformToCharacters(uint64_t entityLUID, ECS::Component::Transform& t) const;
+		void SyncCharactersToTransform(uint64_t entityLUID, const ECS::Component::Transform& t);
 
         void DrawShapeGizmo(const uint64_t entityLUID, const ECS::Component::Transform& t, const ECS::Component::Collider& col);
 


### PR DESCRIPTION
Make transform synchronization bidirectional: systems now check Transform::isDirty and either push manual transform changes to physics (bodies/characters) or pull updated transforms from physics. Implemented PhysicsManager::SyncBodiesToTransform and SyncCharactersToTransform (with early exits when missing) and added their declarations. RigidbodySystem and CharacterControllerSystem now call the appropriate sync method based on t.isDirty.