### PR TITLE
Add RB_SetIsTrigger and physics trigger support

### DIFF
--- a/NANOEngine/include/ScriptSDK/ScriptAPI.h
+++ b/NANOEngine/include/ScriptSDK/ScriptAPI.h
@@ -363,6 +363,8 @@ namespace Scripting {
         void RB_AddImpulse(const Vec3& impulse, Entity entity = DEFAULT_ENTITY_PARAM);
         void RB_AddImpulse(float x, float y, float z, Entity entity = DEFAULT_ENTITY_PARAM);
 
+        void RB_SetIsTrigger(bool isTrigger, Entity entity = DEFAULT_ENTITY_PARAM);
+
         //=====================================================================
         // CHARACTER CONTROLLER PHYSICS (CC_*)
         // All functions support optional Entity parameter

--- a/NANOEngine/src/Physics/PhysicsManager.cpp
+++ b/NANOEngine/src/Physics/PhysicsManager.cpp
@@ -990,6 +990,25 @@ namespace NE::Physics {
 		}
 	}
 
+	void PhysicsManager::SetIsTrigger(uint64_t entityLUID, bool isTrigger) {
+		auto it = m_bodies.find(entityLUID);
+		if (it != m_bodies.end()) {
+			JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+			JPH::BodyID bodyID = it->second;
+			bi.SetIsSensor(bodyID, isTrigger);
+		}
+	}
+
+	void PhysicsManager::SetIsKinematic(uint64_t entityLUID, bool isKinematic) {
+		//auto it = m_bodies.find(entityLUID);
+		//if (it != m_bodies.end()) {
+		//	JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+		//	JPH::BodyID bodyID = it->second;
+		//	JPH::EMotionType newMotion = isKinematic ? JPH::EMotionType::Kinematic : JPH::EMotionType::Dynamic;
+		//	bi.SetMotionType(bodyID, newMotion);
+		//}
+	}
+
 	bool PhysicsManager::CookMeshCollider(const std::vector<Math::Vec3>& vertices,
 		const std::vector<uint32_t>& indices, std::vector<uint8_t>& outBlob) {
 		if (!m_physicsSystem)

--- a/NANOEngine/src/Physics/PhysicsManager.hpp
+++ b/NANOEngine/src/Physics/PhysicsManager.hpp
@@ -116,6 +116,8 @@ namespace NE::Physics {
         void SetLinearVelocity(uint64_t entityLUID, const Math::Vec3& velocity);
         Math::Vec3 GetAngularVelocity(uint64_t entityLUID) const;
         void SetAngularVelocity(uint64_t entityLUID, const Math::Vec3& angularVelocity);
+		void SetIsTrigger(uint64_t entityLUID, bool isTrigger);
+		void SetIsKinematic(uint64_t entityLUID, bool isKinematic);
 
         bool CookMeshCollider(const std::vector<Math::Vec3>& vertices,
             const std::vector<uint32_t>& indices, std::vector<uint8_t>& outBlob);

--- a/NANOEngine/src/Scripting/ScriptAPI.cpp
+++ b/NANOEngine/src/Scripting/ScriptAPI.cpp
@@ -14,6 +14,7 @@
  // Internal engine headers (NOT exposed to scripts)
 #include "../ECS/Components/Transform.hpp"
 #include "../ECS/Components/Rigidbody.hpp"
+#include "../ECS/Components/Collider.hpp"
 #include "../ECS/Components/AudioSource.hpp"
 #include "../ECS/Components/EntityMeta.hpp"
 #include "../ECS/Components/Renderer.hpp"
@@ -662,6 +663,17 @@ namespace NE {
 
 		void IScript::RB_AddImpulse(float x, float y, float z, Entity entity) {
 			RB_AddImpulse(Vec3(x, y, z), entity);
+		}
+
+		void IScript::RB_SetIsTrigger(bool isTrigger, Entity entity) {
+			CHECK_CONTEXT_OR_RETURN();
+			Entity targetEntity = (entity == DEFAULT_ENTITY_PARAM) ? m_entity : entity;
+
+			auto& meta = m_context->componentManager->GetComponent<ECS::Component::EntityMeta>(targetEntity);
+			auto& collider = m_context->componentManager->GetComponent<ECS::Component::Collider>(targetEntity);
+
+			collider.isTrigger = isTrigger;
+			Physics::PhysicsManager::GetInstance().SetIsTrigger(meta.luid, isTrigger);
 		}
 
 		void IScript::CC_Move(const Vec3& displacement, Entity entity) {


### PR DESCRIPTION
Expose RB_SetIsTrigger to the scripting API and wire it to the physics layer. Added ScriptAPI header declaration and IScript::RB_SetIsTrigger implementation (updates Collider component and calls PhysicsManager::SetIsTrigger). Implemented PhysicsManager::SetIsTrigger (uses JPH::BodyInterface::SetIsSensor) and added a stub for SetIsKinematic. Also included Collider.hpp in the scripting source and updated PhysicsManager.hpp declarations.