### PR TITLE
Add Anim_Play/Stop and auto-stop animator

### DIFF
--- a/NANOEngine/include/ScriptSDK/ScriptAPI.h
+++ b/NANOEngine/include/ScriptSDK/ScriptAPI.h
@@ -376,6 +376,9 @@ namespace Scripting {
 		Vec3 CC_GetGroundNormal(Entity entity = DEFAULT_ENTITY_PARAM) const;
 		void CC_SetPosition(const Vec3& position, Entity entity = DEFAULT_ENTITY_PARAM);
 
+        void Anim_Play(Entity entity = DEFAULT_ENTITY_PARAM);
+		void Anim_Stop(Entity entity = DEFAULT_ENTITY_PARAM);
+
         //=====================================================================
         // PHYSICS RAYCASTING
         //=====================================================================

--- a/NANOEngine/src/ECS/Systems/AnimatorSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/AnimatorSystem.cpp
@@ -19,7 +19,7 @@
 
 namespace NE::ECS::Systems {
     namespace {
-        float AdvanceTime(float t, float dt, const Animation::AnimationClip& clip) {
+        float AdvanceTime(float t, float dt, NE::ECS::Component::Animator& animator, const Animation::AnimationClip& clip) {
             float L = clip.GetLengthSeconds();
             if (L <= 0.0f) return std::max(0.0f, t + dt);
 
@@ -29,6 +29,8 @@ namespace NE::ECS::Systems {
                 t = std::fmod(t, L);
                 if (t < 0.0f) t += L;
                 return t;
+            } else {
+				if (t >= L) animator.isPlaying = false;
             }
             return std::clamp(t, 0.0f, L);
         }
@@ -192,7 +194,7 @@ namespace NE::ECS::Systems {
             float dt = static_cast<float>(deltaTime);
 
             anim.prevTime = anim.time;
-            anim.time = AdvanceTime(anim.time, dt * anim.speed, *anim.clip);
+            anim.time = AdvanceTime(anim.time, dt * anim.speed, anim, *anim.clip);
 
             ApplyClipAtTime(entity, *anim.clip, anim.time);
         }

--- a/NANOEngine/src/Scripting/ScriptAPI.cpp
+++ b/NANOEngine/src/Scripting/ScriptAPI.cpp
@@ -18,6 +18,7 @@
 #include "../ECS/Components/AudioSource.hpp"
 #include "../ECS/Components/EntityMeta.hpp"
 #include "../ECS/Components/Renderer.hpp"
+#include "../ECS/Components/Animator.hpp"
 #include "../ECS/Components/Camera.hpp"
 #include "../ECS/Components/NativeScript.hpp"
 #include "../ECS/Components/Hierarchy.hpp"
@@ -718,6 +719,24 @@ namespace NE {
 
 			auto& meta = m_context->componentManager->GetComponent<ECS::Component::EntityMeta>(targetEntity);
 			Physics::PhysicsManager::GetInstance().CharacterSetPosition(meta.luid, ToEngineVec3(position));
+		}
+
+		void IScript::Anim_Play(Entity entity) {
+			CHECK_CONTEXT_OR_RETURN();
+			Entity targetEntity = (entity == DEFAULT_ENTITY_PARAM) ? m_entity : entity;
+			if (m_context->componentManager->HasComponent<ECS::Component::Animator>(targetEntity)) {
+				auto& animator = m_context->componentManager->GetComponent<ECS::Component::Animator>(targetEntity);
+				animator.isPlaying = true;
+			}
+		}
+
+		void IScript::Anim_Stop(Entity entity) {
+			CHECK_CONTEXT_OR_RETURN();
+			Entity targetEntity = (entity == DEFAULT_ENTITY_PARAM) ? m_entity : entity;
+			if (m_context->componentManager->HasComponent<ECS::Component::Animator>(targetEntity)) {
+				auto& animator = m_context->componentManager->GetComponent<ECS::Component::Animator>(targetEntity);
+				animator.isPlaying = false;
+			}
 		}
 
 		//=========================================================================


### PR DESCRIPTION
Expose Anim_Play and Anim_Stop script API methods (ScriptAPI.h / ScriptAPI.cpp) to control Animator components from scripts. Include Animator component header in ScriptAPI.cpp and implement the two methods to toggle Animator::isPlaying on the target entity. Update AnimatorSystem::AdvanceTime to accept the Animator reference and automatically stop non-looping animations when the playback time reaches the clip length, and update the call site to pass the animator. These changes allow scripts to start/stop animations and ensure non-looping clips stop playing at their end.