### PR TITLE
Use R8 SSAO texture and depth-scaled sampling

### DIFF
--- a/NANOEngine/src/Graphics/Core/PostProcessPipeline.cpp
+++ b/NANOEngine/src/Graphics/Core/PostProcessPipeline.cpp
@@ -186,9 +186,9 @@ namespace NE::Graphics {
 			glGenTextures(1, &m_SSAOTex);
 		}
 		glBindTexture(GL_TEXTURE_2D, m_SSAOTex);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8,
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_R8,
 			static_cast<GLsizei>(w), static_cast<GLsizei>(h), 0,
-			GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+			GL_RED, GL_UNSIGNED_BYTE, nullptr);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/binfiles/Library/Shaders/SSAO.nanoshader
+++ b/binfiles/Library/Shaders/SSAO.nanoshader
@@ -74,7 +74,8 @@ void main()
     float occlusion = 0.0;
 
     for (int i = 0; i < SAMPLE_COUNT; ++i) {
-        vec2 sampleUV = vUV + offsets[i] * texel * u_Radius * 4.0;
+        float depthScale = max(abs(centerPos.z), 1e-2);
+        vec2 sampleUV = vUV + offsets[i] * texel * (u_Radius / depthScale) * 4.0;
         if (sampleUV.x < 0.0 || sampleUV.x > 1.0 ||
             sampleUV.y < 0.0 || sampleUV.y > 1.0)
             continue;
@@ -91,7 +92,7 @@ void main()
         float NdotD = max(dot(normal, dir), 0.0);
 
         float rangeCheck = smoothstep(0.0, 1.0, u_Radius / (dist + 1e-4));
-        float deltaDepth = samplePos.z - centerPos.z;
+        float deltaDepth = centerPos.z - samplePos.z;
 
         if (deltaDepth > u_Bias && dist < u_Radius) {
             occlusion += NdotD * rangeCheck;


### PR DESCRIPTION
Change SSAO render target to a single-channel R8 texture (GL_RED) to save memory/bandwidth and match the shader output. Update SSAO shader to scale sample radius by a depth-derived factor (using centerPos.z with a 1e-2 clamp) so sampling range adapts to scene depth, and fix the depth delta sign (centerPos.z - samplePos.z) for correct occlusion testing.