### PR TITLE
Add runtime ImGui font resizing

### DIFF
--- a/Editor/src/Application.cpp
+++ b/Editor/src/Application.cpp
@@ -155,6 +155,7 @@ namespace Editor {
 
 			NE::Run(timer.GetDeltaTime());
 
+			FlushPendingFontRebuild();
 			ImGui_ImplOpenGL3_NewFrame();
 			ImGui_ImplGlfw_NewFrame();
 			ImGui::NewFrame();

--- a/Editor/src/EditorLayer.cpp
+++ b/Editor/src/EditorLayer.cpp
@@ -1,4 +1,5 @@
 ﻿#include "EditorLayer.hpp"
+#include "ImGuiLayer.hpp"
 #include "imgui/imgui.h"
 #include <imgui/imgui_internal.h>
 #include <wtypes.h>
@@ -59,7 +60,12 @@ namespace Editor {
 		ImGui::DockSpace(dockspace_id, ImGui::GetContentRegionAvail(), dockspace_flags);
 
 		if ((ImGui::GetIO().KeyCtrl && !ImGui::GetIO().KeyShift && !ImGui::GetIO().KeyAlt)) {
-			if (ImGui::IsKeyPressed(ImGuiKey_S, false)) {
+			if (ImGui::IsKeyPressed(ImGuiKey_Equal, false)) {
+				RebuildFonts(GetFontSize() + 1.0f);
+			} else if (ImGui::IsKeyPressed(ImGuiKey_Minus, false)) {
+				float newSize = GetFontSize() - 1.0f;
+				if (newSize >= 8.0f) RebuildFonts(newSize);
+			} else if (ImGui::IsKeyPressed(ImGuiKey_S, false)) {
 				auto sceneAsset = dynamic_cast<Assets::SceneAsset*>(Assets::AssetManager::GetInstance().GetRecord(EditorScene::s_currentSceneUUID)->asset.get());
 				sceneAsset->SaveScene(EditorScene::s_currentScenePath);
 				EditorScene::isDirty = false;

--- a/Editor/src/ImGuiLayer.cpp
+++ b/Editor/src/ImGuiLayer.cpp
@@ -5,6 +5,8 @@
 #include <imgui/widgets/imsearch/imsearch.h>
 
 namespace Editor {
+    static float s_fontSize = 15.0f;
+    static float s_pendingFontSize = 0.0f; // 0 means no rebuild pending
     void InitImGui(GLFWwindow* window) {
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
@@ -119,7 +121,7 @@ namespace Editor {
 
         ImFont* uiFont = io.Fonts->AddFontFromFileTTF(
             "Library/Fonts/NotoSans-Regular.ttf",
-            15.0f,
+            s_fontSize,
             &config
         );
 
@@ -127,6 +129,43 @@ namespace Editor {
 
         ImGui_ImplGlfw_InitForOpenGL(window, false);
         ImGui_ImplOpenGL3_Init("#version 430");
+    }
+
+    void RebuildFonts(float fontSize) {
+        s_pendingFontSize = fontSize;
+    }
+
+    void FlushPendingFontRebuild() {
+        if (s_pendingFontSize == 0.0f) return;
+
+        s_fontSize = s_pendingFontSize;
+        s_pendingFontSize = 0.0f;
+
+        ImGuiIO& io = ImGui::GetIO();
+
+        ImGui_ImplOpenGL3_DestroyFontsTexture();
+
+        io.Fonts->Clear();
+
+        ImFontConfig config;
+        config.OversampleH = 2;
+        config.OversampleV = 2;
+        config.PixelSnapH = false;
+
+        ImFont* uiFont = io.Fonts->AddFontFromFileTTF(
+            "Library/Fonts/NotoSans-Regular.ttf",
+            s_fontSize,
+            &config
+        );
+
+        io.FontDefault = uiFont;
+        io.Fonts->Build();
+
+        ImGui_ImplOpenGL3_CreateFontsTexture();
+    }
+
+    float GetFontSize() {
+        return s_fontSize;
     }
 
     void ShutdownImGui() {

--- a/Editor/src/ImGuiLayer.hpp
+++ b/Editor/src/ImGuiLayer.hpp
@@ -6,6 +6,9 @@ struct GLFWwindow;
 namespace Editor {
     void InitImGui(GLFWwindow* window);
     void ShutdownImGui();
+    void RebuildFonts(float fontSize);
+    void FlushPendingFontRebuild();
+    float GetFontSize();
 }
 
 #endif // !EDITOR_IMGUILAYER_HPP


### PR DESCRIPTION
Introduce a deferred font-rebuild system for ImGui: s_fontSize and s_pendingFontSize state, RebuildFonts(), FlushPendingFontRebuild(), and GetFontSize() in ImGuiLayer. The main loop now calls FlushPendingFontRebuild() so font changes are applied safely between frames. Rebuild logic clears and rebuilds ImGui fonts and recreates the OpenGL font texture. EditorLayer keyboard handling now uses Ctrl+= to increase and Ctrl+- to decrease font size (with a minimum of 8), keeping Ctrl+S as save; ImGuiLayer.hpp was updated and included where needed.