### PR TITLE
Add ACESFitted tone-mapping option and shader

### DIFF
--- a/Editor/src/Panels/LightingPanel.cpp
+++ b/Editor/src/Panels/LightingPanel.cpp
@@ -154,7 +154,7 @@ namespace Editor {
 				Editor::DrawFloatField("Bloom Strength", postProcessingSettings.bloomSettings.bloomIntensity, 0.1f, true);
 			}
 
-			const char* toneMapTypeItems[] = { "Reinhard", "ReinhardExtended", "ACESApproximation", "FilmicACES" };
+			const char* toneMapTypeItems[] = { "Reinhard", "ReinhardExtended", "ACESApproximation", "FilmicACES", "ACESFitted"};
 			int toneMapType = static_cast<int>(postProcessingSettings.bloomSettings.toneMapType);
 
 			if (ImGui::CollapsingHeader("Tone-Mapping##Header", ImGuiTreeNodeFlags_DefaultOpen)) {

--- a/NANOEngine/src/Graphics/Core/PostProcessingSettings.hpp
+++ b/NANOEngine/src/Graphics/Core/PostProcessingSettings.hpp
@@ -12,7 +12,8 @@ namespace NE::Graphics {
 			Reinhard,
 			ReinhardExtended,
 			ACESApproximation,
-			FilmicACES
+			FilmicACES,
+			ACESFitted
 		};
 
 		Math::Vec3 tint;

--- a/binfiles/Library/Shaders/BloomComposite.nanoshader
+++ b/binfiles/Library/Shaders/BloomComposite.nanoshader
@@ -72,6 +72,35 @@ vec3 ReinhardExtended(vec3 x)
     return num / denom;
 }
 
+vec3 ACESFitted(vec3 color) {
+    mat3 ACESInputMat = mat3(
+        0.59719, 0.35458, 0.04823,
+        0.07600, 0.90834, 0.01566,
+        0.02840, 0.13383, 0.83777
+    );
+
+    mat3 ACESOutputMat = mat3(
+         1.60475, -0.53108, -0.07367,
+        -0.10208,  1.10813, -0.00605,
+        -0.00327, -0.07276,  1.07602
+    );
+
+    color = color * ACESInputMat;
+    
+    // RRT
+    vec3 a = color * (color + 0.0245786) - 0.000090537;
+    vec3 b = color * (0.983729 * color + 0.4329510) + 0.238081;
+    color = a / b;
+    
+    // ODT
+    color = color * ACESOutputMat;
+    
+    // Clamp for safety
+    color = clamp(color, 0.0, 1.0);
+    
+    return color;
+}
+
 vec3 Tonemap(vec3 x, int type)
 {
     if (type == 1) {
@@ -90,6 +119,9 @@ vec3 Tonemap(vec3 x, int type)
         // Filmic (Uncharted-style)
         return FilmicTonemap(x);
     }
+	else if (type == 5) {
+		return ACESFitted(x);
+	}
     else {
         // 0 or unknown: no tonemap, just clamp
         return clamp(x, 0.0, 1.0);


### PR DESCRIPTION
Introduce the ACESFitted tone-mapping operator across codebase: add ACESFitted to the PostProcessingSettings enum, expose it in the editor tone-map UI list, and implement the ACESFitted function in BloomComposite.nanoshader (including input/output matrices, RRT/ODT steps and clamping). Also update Tonemap to handle the new type index so the operator can be selected at runtime.