### PR TITLE
Sync ImGui mouse flag with cursor visibility

### DIFF
--- a/Editor/src/Application.cpp
+++ b/Editor/src/Application.cpp
@@ -219,10 +219,14 @@ namespace Editor {
 	}
 
 	void Application::ShowCursor() {
+		ImGuiIO& io = ImGui::GetIO();
+		io.ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
 		glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 	}
 
 	void Application::HideCursor() {
+		ImGuiIO& io = ImGui::GetIO();
+		io.ConfigFlags |= ImGuiConfigFlags_NoMouse;
 		glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 	}
 }


### PR DESCRIPTION
Update Application::ShowCursor and ::HideCursor to also toggle ImGui's NoMouse flag via ImGui::GetIO(). Clearing ImGuiConfigFlags_NoMouse when showing the cursor and setting it when hiding ensures ImGui's internal mouse handling stays consistent with GLFW cursor modes (GLFW_CURSOR_NORMAL / GLFW_CURSOR_DISABLED). Changes in Editor/src/Application.cpp.