### PR TITLE
Add UICanvas alpha and renderer support

### DIFF
--- a/ChronoGame/Scripts/EngineAPI.hpp
+++ b/ChronoGame/Scripts/EngineAPI.hpp
@@ -426,6 +426,10 @@ namespace Command {
         return NE::ECS::Command::GetUIDropdown(e);
     }
 
+    // UICanvas helpers
+    inline float GetUICanvasAlpha(uint32_t e) { return NE::ECS::Command::GetUICanvasAlpha(e); }
+    inline void SetUICanvasAlpha(uint32_t e, float alpha) { NE::ECS::Command::SetUICanvasAlpha(e, alpha); }
+
     // UI image utilities
     inline bool SetUIImageTexture(uint32_t e, const char* uuid) {
         return NE::ECS::Command::SetUIImageTexture(e, uuid);

--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -3293,6 +3293,13 @@ namespace Editor {
 			if (ImGui::DragInt("##SortOrder", &comp.sortingOrder)) {
 			}
 
+			// Opacity
+			ImGui::AlignTextToFramePadding();
+			ImGui::Text("Opacity");
+			ImGui::SameLine(labelWidth);
+			ImGui::SetNextItemWidth(-1);
+			ImGui::SliderFloat("##CanvasAlpha", &comp.alpha, 0.0f, 1.0f);
+
 			ImGui::Unindent();
 		}
 

--- a/NANOEngine/include/ScriptSDK/UI.h
+++ b/NANOEngine/include/ScriptSDK/UI.h
@@ -83,6 +83,9 @@ namespace Component {
         // Higher values render on top (layering of canvases)
         int sortingOrder = 0;
 
+        // Canvas-level opacity multiplied into all child element colors (0 = invisible, 1 = fully opaque)
+        float alpha = 1.0f;
+
         // Runtime only (not serialized)
         float scaleFactor = 1.0f;
         RenderMode lastInitializedMode = RenderMode::SCREEN_SPACE_OVERLAY;
@@ -536,6 +539,17 @@ namespace Command {
 
     /// Add UIDropdown component to an entity
     NANOENGINE_API void AddUIDropdownComponent(uint32_t e, const Component::UIDropdown& c);
+
+    //=========================================================================
+    // UICANVAS HELPERS
+    //=========================================================================
+
+    /// Get the opacity of a UICanvas (0 = invisible, 1 = fully opaque)
+    NANOENGINE_API float GetUICanvasAlpha(uint32_t e);
+
+    /// Set the opacity of a UICanvas. Multiplied into all child element colors at render time.
+    /// @param alpha Clamped to [0, 1]
+    NANOENGINE_API void SetUICanvasAlpha(uint32_t e, float alpha);
 
     //=========================================================================
     // TEXTURE SWAPPING UTILITIES

--- a/NANOEngine/src/ECS/Components/UICanvas.hpp
+++ b/NANOEngine/src/ECS/Components/UICanvas.hpp
@@ -39,6 +39,9 @@ namespace NE::ECS::Component {
         // Higher values render on top (layering of canvases)
         int sortingOrder = 0;
 
+        // Canvas-level opacity multiplied into all child element colors (0 = invisible, 1 = fully opaque)
+        float alpha = 1.0f;
+
         // Reflection
         NE_REFLECT_BEGIN(UICanvas)
             NE_REFLECT_FIELD_HIDDEN(luid),
@@ -50,7 +53,8 @@ namespace NE::ECS::Component {
             NE_REFLECT_FIELD(referenceHeight),
             NE_REFLECT_FIELD(pixelPerfect),
             NE_REFLECT_FIELD(isActive),
-            NE_REFLECT_FIELD(sortingOrder)
+            NE_REFLECT_FIELD(sortingOrder),
+            NE_REFLECT_FIELD(alpha)
         NE_REFLECT_END()
 
         // run time only

--- a/NANOEngine/src/ECS/Systems/UIRenderSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/UIRenderSystem.cpp
@@ -760,7 +760,10 @@ namespace NE::ECS::Systems {
 
                 UIBatch& batch = worldBatchMap[key];
                 uint32_t base = static_cast<uint32_t>(batch.vertices.size());
-                for (const auto& v : verts) batch.vertices.push_back(v);
+                for (auto v : verts) {
+                    v.Color.w *= canvas.alpha;
+                    batch.vertices.push_back(v);
+                }
 
                 // verts.size() is always 4 (simple quad)
                 uint32_t quadCount = static_cast<uint32_t>(verts.size()) / 4;
@@ -852,7 +855,8 @@ namespace NE::ECS::Systems {
                 UIBatch& batch = batchMap[key];
                 uint32_t baseVertex = static_cast<uint32_t>(batch.vertices.size());
 
-                for (const auto& v : verticesV2) {
+                for (auto v : verticesV2) {
+                    v.Color.w *= canvas.alpha;
                     batch.vertices.push_back(v);
                 }
 
@@ -1055,6 +1059,10 @@ namespace NE::ECS::Systems {
                 std::vector<NE::Graphics::UIVertex2> verticesV2 = GenerateTextVertices(entity);
                 if (verticesV2.empty()) continue;
 
+                if (canvas.alpha < 1.0f) {
+                    for (auto& v : verticesV2) v.Color.w *= canvas.alpha;
+                }
+
                 m_frameDrawCalls++;
                 auto geometryBuffer = CreateDynamicTextGeometry(verticesV2);
                 if (!geometryBuffer) continue;
@@ -1108,7 +1116,8 @@ namespace NE::ECS::Systems {
             UIBatch& batch = batchMap[key];
             uint32_t baseVertex = static_cast<uint32_t>(batch.vertices.size());
 
-            for (const auto& v : verticesV2) {
+            for (auto v : verticesV2) {
+                v.Color.w *= canvas.alpha;
                 batch.vertices.push_back(v);
             }
 
@@ -1356,7 +1365,13 @@ namespace NE::ECS::Systems {
         if (!isWorldSpace) {
             scissor = ComputeScissorRect(entity, canvasEntity, canvas);
         }
-        SubmitTextElement(entity, canvas, text, rect, text.cachedVertices, fontAtlas, scissor);
+        if (canvas.alpha < 1.0f) {
+            std::vector<NE::Graphics::UIVertex2> alphaVerts = text.cachedVertices;
+            for (auto& v : alphaVerts) v.Color.w *= canvas.alpha;
+            SubmitTextElement(entity, canvas, text, rect, alphaVerts, fontAtlas, scissor);
+        } else {
+            SubmitTextElement(entity, canvas, text, rect, text.cachedVertices, fontAtlas, scissor);
+        }
     }
 
     //=========================================================================

--- a/NANOEngine/src/EditorInterface/ECSExports.cpp
+++ b/NANOEngine/src/EditorInterface/ECSExports.cpp
@@ -1300,6 +1300,22 @@ namespace NE::ECS {
 		}
 
 		//=========================================================================
+		// UI CANVAS HELPERS
+		//=========================================================================
+
+		float GetUICanvasAlpha(uint32_t e) {
+			auto& ecs = GetScene().GetECSCoordinator();
+			if (!ecs.HasComponent<Component::UICanvas>(e)) return 1.0f;
+			return ecs.GetComponent<Component::UICanvas>(e).alpha;
+		}
+
+		void SetUICanvasAlpha(uint32_t e, float alpha) {
+			auto& ecs = GetScene().GetECSCoordinator();
+			if (!ecs.HasComponent<Component::UICanvas>(e)) return;
+			ecs.GetComponent<Component::UICanvas>(e).alpha = alpha < 0.0f ? 0.0f : (alpha > 1.0f ? 1.0f : alpha);
+		}
+
+		//=========================================================================
 		// UI IMAGE UTILITIES
 		//=========================================================================
 

--- a/NANOEngine/src/EditorInterface/ECSExports.hpp
+++ b/NANOEngine/src/EditorInterface/ECSExports.hpp
@@ -425,6 +425,10 @@ namespace NE::ECS {
 		NANOENGINE_API std::shared_ptr<NE::Animation::AnimationClip> GetAnimationClip(const std::string& uuid);
 		NANOENGINE_API void AssignAnimClip(uint32_t e, const std::string& uuid);
 
+		// --- UICanvas Helpers ---
+		NANOENGINE_API float GetUICanvasAlpha(uint32_t e);
+		NANOENGINE_API void SetUICanvasAlpha(uint32_t e, float alpha);
+
 		// --- UI Image Utilities ---
 		/// Swap the texture on a UIImage component (handles GPU resource loading)
 		NANOENGINE_API bool SetUIImageTexture(uint32_t imageEntity, const char* textureUUID);

--- a/NANOEngine/src/Serialisation/Serializer.cpp
+++ b/NANOEngine/src/Serialisation/Serializer.cpp
@@ -81,7 +81,7 @@ namespace NE {
 		}
 
 		inline constexpr uint32_t NSCE_MAGIC = 0x4E534345;
-		inline constexpr int CURRENT_NANOSCENE_FORMAT_VERSION = 3;
+		inline constexpr int CURRENT_NANOSCENE_FORMAT_VERSION = 4;
 
 		inline constexpr uint32_t NFAB_MAGIC = 0x4E464142;
 		inline constexpr int CURRENT_NANOPREFAB_FORMAT_VERSION = 2;


### PR DESCRIPTION
Introduce a canvas-level alpha property to UICanvas (serialized & reflected) and expose getters/setters via the engine API and editor ECS exports. Apply the canvas alpha to UI vertex and text colors in UIRenderSystem so child elements inherit canvas opacity (Set clamps alpha to [0,1]). Add an Opacity slider to the Inspector panel. Bump NanoScene format version to 4 to account for the new field.

Addresses and Closes #302
