### PR TITLE
Support FOV axis & projection in Camera UI

### DIFF
--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -60,10 +60,26 @@
 #include "../Layers/LayerModal.hpp"
 #include <Events/EventBus.hpp>
 #include "../EditorEvents.hpp"
+#include "Engine.hpp"
+#include <algorithm>
+#include <cmath>
 
 bool openLayerSettings = false;
 
 namespace {
+	float DegToRad(float deg) { return deg * 3.14159265358979323846f / 180.0f; }
+	float RadToDeg(float rad) { return rad * 180.0f / 3.14159265358979323846f; }
+
+	// Convert an FOV value between vertical/horizontal for a given aspect ratio while preserving the view.
+	float ConvertFovDegrees(float fovDeg, float aspect, bool fromVerticalToHorizontal) {
+		aspect = std::max(1e-6f, aspect);
+		fovDeg = std::clamp(fovDeg, 1.0f, 179.0f);
+
+		const float half = std::tan(DegToRad(fovDeg) * 0.5f);
+		const float halfOut = fromVerticalToHorizontal ? (half * aspect) : (half / aspect);
+		return RadToDeg(2.0f * std::atan(halfOut));
+	}
+
 	// the widget maker
 	// takes a field and draws the right UI widget for it
 	// bool -> checkbox
@@ -2700,7 +2716,7 @@ namespace Editor {
 	}
 
 	void InspectorPanel::DrawCameraComponent(uint32_t entity) {
-		auto& comp = NE::ECS::Query::GetEntityCamera(entity);
+		auto& comp = NE::ECS::Command::GetEntityCamera(entity);
 
 		bool copyComp = false;
 		bool deleteComp = false;
@@ -2722,7 +2738,52 @@ namespace Editor {
 		if (!open)
 			return;
 
-		ImGui::SeparatorText("Camera");
+		static const char* ProjectionTypeNames[] = { "Perspective", "Orthographic" };
+		int currProjectionType = static_cast<int>(comp.projectionType);
+
+		if (DrawEnumPillCombo("Projection", currProjectionType, ProjectionTypeNames, IM_ARRAYSIZE(ProjectionTypeNames), 100.0f)) {
+			comp.projectionType = static_cast<NE::ECS::Component::Camera::ProjectionType>(currProjectionType);
+			comp.isDirty = true;
+		}
+
+		static const char* fovAxis[] = { "Vertical", "Horizontal" };
+		const auto prevAxis = comp.fovAxis;
+		int currAxis = static_cast<int>(comp.fovAxis);
+
+		if (DrawEnumPillCombo("FOV Axis", currAxis, fovAxis, IM_ARRAYSIZE(fovAxis), 100.0f)) {
+			const auto newAxis = static_cast<NE::ECS::Component::Camera::FieldOfViewAxis>(currAxis);
+
+			if (newAxis != prevAxis) {
+				float aspect = comp.aspectRatio;
+				if (comp.isMain) {
+					const uint32_t w = NE::GetGameViewWidth();
+					const uint32_t h = NE::GetGameViewHeight();
+					aspect = (h > 0) ? (static_cast<float>(w) / static_cast<float>(h)) : (16.0f / 9.0f);
+				}
+
+				if (comp.projectionType == NE::ECS::Component::Camera::ProjectionType::Perspective) {
+					if (prevAxis == NE::ECS::Component::Camera::FieldOfViewAxis::Vertical &&
+						newAxis == NE::ECS::Component::Camera::FieldOfViewAxis::Horizontal) {
+						comp.fovY = ConvertFovDegrees(comp.fovY, aspect, true);
+					} else if (prevAxis == NE::ECS::Component::Camera::FieldOfViewAxis::Horizontal &&
+						newAxis == NE::ECS::Component::Camera::FieldOfViewAxis::Vertical) {
+						comp.fovY = ConvertFovDegrees(comp.fovY, aspect, false);
+					}
+				} else {
+					aspect = std::max(1e-6f, aspect);
+					if (prevAxis == NE::ECS::Component::Camera::FieldOfViewAxis::Vertical &&
+						newAxis == NE::ECS::Component::Camera::FieldOfViewAxis::Horizontal) {
+						comp.fovY *= aspect;
+					} else if (prevAxis == NE::ECS::Component::Camera::FieldOfViewAxis::Horizontal &&
+						newAxis == NE::ECS::Component::Camera::FieldOfViewAxis::Vertical) {
+						comp.fovY /= aspect;
+					}
+				}
+			}
+
+			comp.fovAxis = newAxis;
+			comp.isDirty = true;
+		}
 
 		NE::Core::ForEachFieldView<NE::ECS::Component::Camera>(comp,
 			[&](auto const& desc, auto const& currentValue) {

--- a/NANOEngine/src/ECS/Components/Camera.hpp
+++ b/NANOEngine/src/ECS/Components/Camera.hpp
@@ -10,17 +10,17 @@ namespace NE::ECS::Component {
 
 	using RenderViewHandle = std::uint32_t;
 
-	enum class ProjectionType : uint8_t {
-		Perspective,
-		Orthographic
-	};
-
-	enum class FieldOfViewAxis : uint8_t {
-		Vertical,
-		Horizontal
-	};
-
 	struct Camera {
+		enum class ProjectionType : uint8_t {
+			Perspective,
+			Orthographic
+		};
+
+		enum class FieldOfViewAxis : uint8_t {
+			Vertical,
+			Horizontal
+		};
+
 		Mat4 viewMtx;
 		Mat4 projectionMtx;
 		uint64_t luid = 0;

--- a/NANOEngine/src/ECS/Systems/CameraSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/CameraSystem.cpp
@@ -6,6 +6,7 @@
 #include "../../../src/Math/Mat4.hpp"
 #include "../../Graphics/Core/GraphicsManager.hpp"
 #include <Core/Profiler.hpp>
+#include <algorithm>
 #include <cmath>
 
 namespace NE::ECS::Systems {
@@ -171,26 +172,58 @@ namespace NE::ECS::Systems {
 		}
 	}
 
-	void CameraSystem::BuildProjection(Camera& cam)
-	{
-		// Build perspective projection matrix
-		// Convert FOV from degrees to radians
-		float fovYRadians = cam.fovY * Math::DEG_TO_RAD;
-		float f = 1.0f / std::tan(fovYRadians * 0.5f);
-		const float aspect = cam.isMain ? Graphics::GraphicsManager::GetGameViewAspect() : cam.aspectRatio;
+	void CameraSystem::BuildProjection(Camera& cam) {
+		const float aspectRaw = cam.isMain ? Graphics::GraphicsManager::GetGameViewAspect() : cam.aspectRatio;
+		const float aspect = std::max(1e-6f, aspectRaw);
 		float& nearPlane = cam.nearPlane;
 		float& farPlane = cam.farPlane;
 
-		cam.projectionMtx.SetToZero();
-		cam.projectionMtx.GetElement(0, 0) = f / aspect;
-		cam.projectionMtx.GetElement(1, 1) = f;
-		cam.projectionMtx.GetElement(2, 2) = (farPlane + nearPlane) / (nearPlane - farPlane);
-		cam.projectionMtx.GetElement(2, 3) = (2 * farPlane * nearPlane) / (nearPlane - farPlane);
-		cam.projectionMtx.GetElement(3, 2) = -1.0f;
-		cam.projectionMtx.GetElement(3, 3) = 0.0f;
+		if (cam.projectionType == Camera::ProjectionType::Orthographic) {
+			const float size = std::max(0.001f, cam.fovY);
+
+			float halfH = size;
+			float halfW = size;
+
+			if (cam.fovAxis == Camera::FieldOfViewAxis::Vertical) {
+				halfH = size;
+				halfW = size * aspect;
+			} else {
+				halfW = size;
+				halfH = (aspect > 1e-6f) ? (size / aspect) : size;
+			}
+
+			const float l = -halfW;
+			const float r = +halfW;
+			const float b = -halfH;
+			const float t = +halfH;
+
+			cam.projectionMtx = Mat4::BuildOrtho(l, r, b, t, nearPlane, farPlane);
+		} else {
+			const float fovDeg = std::clamp(cam.fovY, 1.0f, 179.0f);
+			const float fovRad = fovDeg * Math::DEG_TO_RAD;
+			const float invTan = 1.0f / std::tan(fovRad * 0.5f);
+
+			float xScale = 0.0f;
+			float yScale = 0.0f;
+
+			if (cam.fovAxis == Camera::FieldOfViewAxis::Vertical) {
+				yScale = invTan;
+				xScale = invTan / aspect;
+			} else {
+				xScale = invTan;
+				yScale = invTan * aspect;
+			}
+
+			cam.projectionMtx.SetToZero();
+			cam.projectionMtx.GetElement(0, 0) = xScale;
+			cam.projectionMtx.GetElement(1, 1) = yScale;
+			cam.projectionMtx.GetElement(2, 2) = (farPlane + nearPlane) / (nearPlane - farPlane);
+			cam.projectionMtx.GetElement(2, 3) = (2 * farPlane * nearPlane) / (nearPlane - farPlane);
+			cam.projectionMtx.GetElement(3, 2) = -1.0f;
+			cam.projectionMtx.GetElement(3, 3) = 0.0f;
+		}
 
 		cam.isDirty = false;
-		//cam.projectionMtx = Mat4::BuildOrtho(left, right, bottom, top, nearPlane, farPlane);
 	}
 
 	void CameraSystem::BuildView(Camera& cam, Transform& transform) {


### PR DESCRIPTION
Add UI and math to manage camera projection and FOV axis in the inspector, including a projection selector (Perspective/Orthographic) and a FOV Axis pill (Vertical/Horizontal). Preserve and convert FOV correctly when switching axes (using aspect ratio or game view size for main camera) and clamp/guard values to avoid degenerate aspect or FOV inputs. Refactor Camera definition to nest ProjectionType and FieldOfViewAxis inside the Camera struct and switch inspector access to Command::GetEntityCamera. Update CameraSystem::BuildProjection to handle both orthographic and perspective projections with correct scaling based on the chosen FOV axis and improved numeric safety.