### PR TITLE
Inject EntityManager into LightSystem

### DIFF
--- a/NANOEngine/src/ECS/Core/ECSCoordinator.cpp
+++ b/NANOEngine/src/ECS/Core/ECSCoordinator.cpp
@@ -105,7 +105,7 @@ namespace NE::ECS {
             SetSystemSignature<Systems::RenderSystem>(sig);
         }
 
-        m_lightSystem = m_systemManager->RegisterSystem<Systems::LightSystem>(m_componentManager.get());
+        m_lightSystem = m_systemManager->RegisterSystem<Systems::LightSystem>(m_componentManager.get(), m_entityManager.get());
         {
             Signature sig;
             sig.set(GetComponentType<Component::Transform>());

--- a/NANOEngine/src/ECS/Systems/LightSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/LightSystem.cpp
@@ -1,12 +1,13 @@
 #include "pch.h"
 #include "LightSystem.hpp"
-#include "../../Core/Profiler.hpp"
-#include "../../Graphics/Core/GraphicsManager.hpp"
-#include "../../Graphics/Core/LightGizmoCommand.hpp"
-#include "../../ECS/Components/Transform.hpp"
-#include "../../ECS/Components/EntityMeta.hpp"
+
+#include "ECS/Core/ComponentManager.hpp"
+#include "ECS/Core/EntityManager.hpp"
+#include "Core/Profiler.hpp"
+#include "Graphics/Core/GraphicsManager.hpp"
+#include "Graphics/Core/LightGizmoCommand.hpp"
+#include "ECS/Components/Transform.hpp"
 #include "../Components/Light.hpp"
-#include "Core/SpdLogger.hpp"
 
 namespace NE::ECS::Systems {
     namespace {
@@ -18,8 +19,8 @@ namespace NE::ECS::Systems {
         }
     }
 
-    LightSystem::LightSystem(NE::ECS::ComponentManager* cm)
-        : m_componentManager(cm) {}
+    LightSystem::LightSystem(ComponentManager* cm, EntityManager* em)
+        : m_componentManager(cm), m_entityManager(em) {}
 
     void LightSystem::OnEntityAdded(Entity /*entity*/) {
         //auto& t = m_componentManager->GetComponent<Component::Transform>(entity);
@@ -55,8 +56,7 @@ namespace NE::ECS::Systems {
 
         const auto& entities = m_entities.GetDenseContainer();
         for (Entity entity : entities) {
-            auto& meta = m_componentManager->GetComponent<Component::EntityMeta>(entity);
-            if (meta.isActive) {
+            if (m_entityManager->GetActive(entity)) {
                 auto& t = m_componentManager->GetComponent<Component::Transform>(entity);
                 auto& light = m_componentManager->GetComponent<Component::Light>(entity);
                 light.position = t.worldMatrix.GetTranslation();

--- a/NANOEngine/src/ECS/Systems/LightSystem.hpp
+++ b/NANOEngine/src/ECS/Systems/LightSystem.hpp
@@ -1,13 +1,17 @@
 #pragma once
 
 #include "../Core/System.hpp"
-#include "../Core/ComponentManager.hpp"
+
+namespace NE::ECS {
+    class ComponentManager;
+    class EntityManager;
+}
 
 namespace NE::ECS::Systems {
 
     class LightSystem final : public System {
     public:
-        explicit LightSystem(ComponentManager* cm);
+        explicit LightSystem(ComponentManager* cm, EntityManager* em);
 
         void OnEntityAdded(Entity entity) override;
         void OnEntityRemoved(Entity entity) override;
@@ -25,7 +29,7 @@ namespace NE::ECS::Systems {
 
     private:
         ComponentManager* m_componentManager;
-
+		EntityManager* m_entityManager;
         //std::vector<Component::DirectionalLight*> m_directionalLights;
         //std::vector<Component::PointLight*> m_pointLights;
         //std::vector<Component::SpotLight*> m_spotLights;


### PR DESCRIPTION
Update LightSystem to accept and store an EntityManager pointer and use it to check entity active state instead of reading Component::EntityMeta. Adjusted ECSCoordinator to pass m_entityManager when registering the system. Cleaned up includes and forward-declared ComponentManager/EntityManager in the LightSystem header, and updated the constructor/signature and member variables accordingly.