### PR TITLE
Add UIRectTransform helpers and UI API

### DIFF
--- a/ChronoGame/Scripts/EngineAPI.hpp
+++ b/ChronoGame/Scripts/EngineAPI.hpp
@@ -28,6 +28,9 @@
 #include <ScriptSDK/ECS.h>
 #include <ScriptSDK/Renderer.h>
 
+// UI component definitions and API
+#include <ScriptSDK/UI.h>
+
 // SDK HEADERS LOADED:
 // - Math.h → Math::Vec3, Math::Mat4 (with Scripting::Vec3 conversions)
 // - Components.h → Transform, Light, Collider component types
@@ -59,6 +62,24 @@ namespace NE {
                     return HasAnimator(entity);
                 } else if constexpr (std::is_same_v<T, Component::Camera>) {
                     return HasCamera(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIRectTransform>) {
+                    return HasUIRectTransform(entity);
+                } else if constexpr (std::is_same_v<T, Component::UICanvas>) {
+                    return HasUICanvas(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIImage>) {
+                    return HasUIImage(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIText>) {
+                    return HasUIText(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIButton>) {
+                    return HasUIButton(entity);
+                } else if constexpr (std::is_same_v<T, Component::UISlider>) {
+                    return HasUISlider(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIToggle>) {
+                    return HasUIToggle(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIInputField>) {
+                    return HasUIInputField(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIDropdown>) {
+                    return HasUIDropdown(entity);
                 }
                 return false;
             }
@@ -91,6 +112,24 @@ namespace NE {
                     return GetEntityAnimator(entity);
                 } else if constexpr (std::is_same_v<T, Component::Camera>) {
                     return GetEntityCamera(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIRectTransform>) {
+                    return GetUIRectTransform(entity);
+                } else if constexpr (std::is_same_v<T, Component::UICanvas>) {
+                    return GetUICanvas(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIImage>) {
+                    return GetUIImage(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIText>) {
+                    return GetUIText(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIButton>) {
+                    return GetUIButton(entity);
+                } else if constexpr (std::is_same_v<T, Component::UISlider>) {
+                    return GetUISlider(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIToggle>) {
+                    return GetUIToggle(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIInputField>) {
+                    return GetUIInputField(entity);
+                } else if constexpr (std::is_same_v<T, Component::UIDropdown>) {
+                    return GetUIDropdown(entity);
                 }
             }
         }
@@ -231,6 +270,15 @@ namespace Query {
     inline bool HasScript(uint32_t e) { return NE::ECS::Query::HasScript(e); }
     inline bool HasAnimator(uint32_t e) { return NE::ECS::Query::HasAnimator(e); }
     inline bool HasCamera(uint32_t e) { return NE::ECS::Query::HasCamera(e); }
+    inline bool HasUIRectTransform(uint32_t e) { return NE::ECS::Query::HasUIRectTransform(e); }
+    inline bool HasUICanvas(uint32_t e) { return NE::ECS::Query::HasUICanvas(e); }
+    inline bool HasUIImage(uint32_t e) { return NE::ECS::Query::HasUIImage(e); }
+    inline bool HasUIText(uint32_t e) { return NE::ECS::Query::HasUIText(e); }
+    inline bool HasUIButton(uint32_t e) { return NE::ECS::Query::HasUIButton(e); }
+    inline bool HasUISlider(uint32_t e) { return NE::ECS::Query::HasUISlider(e); }
+    inline bool HasUIToggle(uint32_t e) { return NE::ECS::Query::HasUIToggle(e); }
+    inline bool HasUIInputField(uint32_t e) { return NE::ECS::Query::HasUIInputField(e); }
+    inline bool HasUIDropdown(uint32_t e) { return NE::ECS::Query::HasUIDropdown(e); }
 
     // Read-only component getters
     inline const NE::ECS::Component::EntityMeta& GetEntityMeta(uint32_t e) {
@@ -259,6 +307,18 @@ namespace Query {
     }
     inline const NE::ECS::Component::Camera& GetEntityCamera(uint32_t e) {
         return NE::ECS::Query::GetEntityCamera(e);
+    }
+    inline const NE::ECS::Component::UIRectTransform& GetUIRectTransform(uint32_t e) {
+        return NE::ECS::Query::GetUIRectTransform(e);
+    }
+    inline const NE::ECS::Component::UICanvas& GetUICanvas(uint32_t e) {
+        return NE::ECS::Query::GetUICanvas(e);
+    }
+    inline const NE::ECS::Component::UIImage& GetUIImage(uint32_t e) {
+        return NE::ECS::Query::GetUIImage(e);
+    }
+    inline const NE::ECS::Component::UIText& GetUIText(uint32_t e) {
+        return NE::ECS::Query::GetUIText(e);
     }
 }
 
@@ -316,6 +376,38 @@ namespace Command {
     }
     inline NE::ECS::Component::Camera& GetEntityCamera(uint32_t e) {
         return NE::ECS::Command::GetEntityCamera(e);
+    }
+    inline NE::ECS::Component::UIRectTransform& GetUIRectTransform(uint32_t e) {
+        return NE::ECS::Command::GetUIRectTransform(e);
+    }
+    inline NE::ECS::Component::UICanvas& GetUICanvas(uint32_t e) {
+        return NE::ECS::Command::GetUICanvas(e);
+    }
+    inline NE::ECS::Component::UIImage& GetUIImage(uint32_t e) {
+        return NE::ECS::Command::GetUIImage(e);
+    }
+    inline NE::ECS::Component::UIText& GetUIText(uint32_t e) {
+        return NE::ECS::Command::GetUIText(e);
+    }
+
+    // UIRectTransform helpers (auto-mark layout dirty)
+    inline void SetUIRectTransformPos(uint32_t e, float x, float y) {
+        NE::ECS::Command::SetUIRectTransformPos(e, x, y);
+    }
+    inline void SetUIRectTransformSize(uint32_t e, float width, float height) {
+        NE::ECS::Command::SetUIRectTransformSize(e, width, height);
+    }
+    inline void SetUIRectTransformAnchor(uint32_t e, float minX, float minY, float maxX, float maxY) {
+        NE::ECS::Command::SetUIRectTransformAnchor(e, minX, minY, maxX, maxY);
+    }
+    inline void SetUIRectTransformPivot(uint32_t e, float pivotX, float pivotY) {
+        NE::ECS::Command::SetUIRectTransformPivot(e, pivotX, pivotY);
+    }
+    inline void SetUIRectTransformRotation(uint32_t e, float rotZ) {
+        NE::ECS::Command::SetUIRectTransformRotation(e, rotZ);
+    }
+    inline void SetUIRectTransformScale(uint32_t e, float scaleX, float scaleY) {
+        NE::ECS::Command::SetUIRectTransformScale(e, scaleX, scaleY);
     }
 
     // Script management

--- a/NANOEngine/include/ScriptSDK/UI.h
+++ b/NANOEngine/include/ScriptSDK/UI.h
@@ -98,14 +98,13 @@ namespace Component {
 
     /// UIRectTransform component - Layout and positioning for UI elements
     /// Uses anchor/pivot system for responsive layouts
+    ///
+    /// IMPORTANT: After modifying any layout field (x, y, width, height,
+    /// rotation, scale, anchor, pivot), you must set worldMatrixDirty = true
+    /// and worldRectCached = false so the layout system recalculates positions.
+    /// Prefer the helper functions (SetUIRectTransformPos, etc.) which do this
+    /// automatically.
     struct UIRectTransform {
-        // Parent entity ID
-        uint32_t parent = UINT32_MAX;
-
-        // LUID for serialization
-        uint64_t luid = 0;
-        uint64_t parentLuid = 0;
-
         // Position of pivot point (in pixels, relative to anchor)
         float x = 0.0f;
         float y = 0.0f;
@@ -140,6 +139,31 @@ namespace Component {
         // Pivot point (normalized 0-1, rotation/scale origin)
         float pivotX = 0.5f;
         float pivotY = 0.5f;
+
+        // Mask clipping (folded from UIRectMask2D)
+        bool enableMask = false;
+        float maskPaddingLeft  = 0.f;
+        float maskPaddingRight = 0.f;
+        float maskPaddingTop   = 0.f;
+        float maskPaddingBottom = 0.f;
+
+        // Internal: transform matrices (managed by engine — do not access directly)
+        float _localMatrix[16] = {};  ///< Local TRS matrix (64 bytes)
+        float _worldMatrix[16] = {};  ///< World transform (64 bytes)
+
+        // Set to true after modifying any layout field so the layout system
+        // recalculates. Helper functions handle this automatically.
+        bool worldMatrixDirty = true;
+
+        // Cached world-space rect (read-only, written by engine each frame)
+        float cachedWorldX      = 0.f;
+        float cachedWorldY      = 0.f;
+        float cachedWorldWidth  = 0.f;
+        float cachedWorldHeight = 0.f;
+        float cachedWorldRotZ   = 0.f;
+        float cachedWorldScaleX = 1.f;
+        float cachedWorldScaleY = 1.f;
+        bool  worldRectCached   = false;
 
         // Helper functions
         bool IsStretchedX() const { return anchorMinX != anchorMaxX; }
@@ -534,6 +558,28 @@ namespace Command {
 
     /// Add UIDropdown component to an entity
     NANOENGINE_API void AddUIDropdownComponent(uint32_t e, const Component::UIDropdown& c);
+
+    //=========================================================================
+    // UIRECTTRANSFORM HELPERS
+    //=========================================================================
+
+    /// Set position (x, y) and mark the layout dirty
+    NANOENGINE_API void SetUIRectTransformPos(uint32_t e, float x, float y);
+
+    /// Set size (width, height) and mark the layout dirty
+    NANOENGINE_API void SetUIRectTransformSize(uint32_t e, float width, float height);
+
+    /// Set anchor min/max corners and mark the layout dirty
+    NANOENGINE_API void SetUIRectTransformAnchor(uint32_t e, float minX, float minY, float maxX, float maxY);
+
+    /// Set pivot point and mark the layout dirty
+    NANOENGINE_API void SetUIRectTransformPivot(uint32_t e, float pivotX, float pivotY);
+
+    /// Set Z rotation (degrees) and mark the layout dirty
+    NANOENGINE_API void SetUIRectTransformRotation(uint32_t e, float rotZ);
+
+    /// Set XY scale and mark the layout dirty
+    NANOENGINE_API void SetUIRectTransformScale(uint32_t e, float scaleX, float scaleY);
 
     //=========================================================================
     // UICANVAS HELPERS

--- a/NANOEngine/src/EditorInterface/ECSExports.cpp
+++ b/NANOEngine/src/EditorInterface/ECSExports.cpp
@@ -1337,6 +1337,71 @@ namespace NE::ECS {
 		}
 
 		//=========================================================================
+		// UI RECT TRANSFORM HELPERS
+		//=========================================================================
+
+		void SetUIRectTransformPos(uint32_t e, float x, float y) {
+			auto& ecs = GetScene().GetECSCoordinator();
+			if (!ecs.HasComponent<Component::UIRectTransform>(e)) return;
+			auto& rect = ecs.GetComponent<Component::UIRectTransform>(e);
+			rect.x = x;
+			rect.y = y;
+			rect.worldMatrixDirty = true;
+			rect.worldRectCached = false;
+		}
+
+		void SetUIRectTransformSize(uint32_t e, float width, float height) {
+			auto& ecs = GetScene().GetECSCoordinator();
+			if (!ecs.HasComponent<Component::UIRectTransform>(e)) return;
+			auto& rect = ecs.GetComponent<Component::UIRectTransform>(e);
+			rect.width = width;
+			rect.height = height;
+			rect.worldMatrixDirty = true;
+			rect.worldRectCached = false;
+		}
+
+		void SetUIRectTransformAnchor(uint32_t e, float minX, float minY, float maxX, float maxY) {
+			auto& ecs = GetScene().GetECSCoordinator();
+			if (!ecs.HasComponent<Component::UIRectTransform>(e)) return;
+			auto& rect = ecs.GetComponent<Component::UIRectTransform>(e);
+			rect.anchorMinX = minX;
+			rect.anchorMinY = minY;
+			rect.anchorMaxX = maxX;
+			rect.anchorMaxY = maxY;
+			rect.worldMatrixDirty = true;
+			rect.worldRectCached = false;
+		}
+
+		void SetUIRectTransformPivot(uint32_t e, float pivotX, float pivotY) {
+			auto& ecs = GetScene().GetECSCoordinator();
+			if (!ecs.HasComponent<Component::UIRectTransform>(e)) return;
+			auto& rect = ecs.GetComponent<Component::UIRectTransform>(e);
+			rect.pivotX = pivotX;
+			rect.pivotY = pivotY;
+			rect.worldMatrixDirty = true;
+			rect.worldRectCached = false;
+		}
+
+		void SetUIRectTransformRotation(uint32_t e, float rotZ) {
+			auto& ecs = GetScene().GetECSCoordinator();
+			if (!ecs.HasComponent<Component::UIRectTransform>(e)) return;
+			auto& rect = ecs.GetComponent<Component::UIRectTransform>(e);
+			rect.rotationZ = rotZ;
+			rect.worldMatrixDirty = true;
+			rect.worldRectCached = false;
+		}
+
+		void SetUIRectTransformScale(uint32_t e, float scaleX, float scaleY) {
+			auto& ecs = GetScene().GetECSCoordinator();
+			if (!ecs.HasComponent<Component::UIRectTransform>(e)) return;
+			auto& rect = ecs.GetComponent<Component::UIRectTransform>(e);
+			rect.scaleX = scaleX;
+			rect.scaleY = scaleY;
+			rect.worldMatrixDirty = true;
+			rect.worldRectCached = false;
+		}
+
+		//=========================================================================
 		// UI CANVAS HELPERS
 		//=========================================================================
 

--- a/NANOEngine/src/EditorInterface/ECSExports.hpp
+++ b/NANOEngine/src/EditorInterface/ECSExports.hpp
@@ -439,6 +439,14 @@ namespace NE::ECS {
 		NANOENGINE_API std::shared_ptr<NE::Animation::AnimationClip> GetAnimationClip(const std::string& uuid);
 		NANOENGINE_API void AssignAnimClip(uint32_t e, const std::string& uuid);
 
+		// --- UIRectTransform Helpers ---
+		NANOENGINE_API void SetUIRectTransformPos(uint32_t e, float x, float y);
+		NANOENGINE_API void SetUIRectTransformSize(uint32_t e, float width, float height);
+		NANOENGINE_API void SetUIRectTransformAnchor(uint32_t e, float minX, float minY, float maxX, float maxY);
+		NANOENGINE_API void SetUIRectTransformPivot(uint32_t e, float pivotX, float pivotY);
+		NANOENGINE_API void SetUIRectTransformRotation(uint32_t e, float rotZ);
+		NANOENGINE_API void SetUIRectTransformScale(uint32_t e, float scaleX, float scaleY);
+
 		// --- UICanvas Helpers ---
 		NANOENGINE_API float GetUICanvasAlpha(uint32_t e);
 		NANOENGINE_API void SetUICanvasAlpha(uint32_t e, float alpha);


### PR DESCRIPTION
Expose UI components and helpers to the scripting/engine API. EngineAPI now includes UI.h and adds Has/Get/Command wrappers for UIRectTransform, UICanvas, UIImage, UIText, UIButton, UISlider, UIToggle, UIInputField and UIDropdown so scripts can query and modify UI components. UIRectTransform struct was extended with mask fields, internal local/world matrices, dirty/cache flags and cached world rect values. New Command helper functions (SetUIRectTransformPos/Size/Anchor/Pivot/Rotation/Scale) are declared and implemented in the editor exports to update fields and automatically mark the transform dirty (worldMatrixDirty = true, worldRectCached = false) so the layout system recalculates. Declarations were added to ECSExports.hpp and implementations to ECSExports.cpp.

closes #321 