### PR TITLE
Add DLL exports and silence unused warnings

### DIFF
--- a/Editor/src/Panels/AnimationPanel.cpp
+++ b/Editor/src/Panels/AnimationPanel.cpp
@@ -651,10 +651,6 @@ namespace Editor {
         rightClickedKey = false;
 
         if (tr.type == NE::Animation::AnimValueType::String) {
-            const float y = (rowRect.Min.y + rowRect.Max.y) * 0.5f;
-            constexpr float r = 5.0f;
-            constexpr float pad = 2.0f;
-
             for (int ki = 0; ki < (int)tr.s.keys.size(); ++ki) {
                 const float kt = tr.s.keys[ki].time;
                 const float x = rowRect.Min.x + (kt - t0) * pxPerSec;

--- a/Editor/src/Panels/AssetBrowserPanel.cpp
+++ b/Editor/src/Panels/AssetBrowserPanel.cpp
@@ -416,14 +416,14 @@ namespace Editor {
 				std::string dragPathStr = m_draggedAssetPath.string();
 
 				// Set the appropriate payload based on file type
-				const auto& entryPath = entry.path();
+				//const auto& entryPath = entry.path();
 				bool hasSpecialPayload = false;
 
 				if (!entry.is_directory()) {
 					// Get lowercase extension for case-insensitive comparison
-					std::string ext = entryPath.extension().string();
+				/*	std::string ext = entryPath.extension().string();
 					std::transform(ext.begin(), ext.end(), ext.begin(),
-						[](unsigned char c) { return std::tolower(c); });
+						[](unsigned char c) { return std::tolower(c); });*/
 
 					if (ext == ".obj" || ext == ".fbx") {
 						ImGui::SetDragDropPayload("ASSET_MESH_PATH", dragPathStr.c_str(), dragPathStr.size() + 1);
@@ -459,9 +459,9 @@ namespace Editor {
 					} else {
 						const auto& entryPath = entry.path();
 						if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
-							std::string ext = entryPath.extension().string();
+							/*std::string ext = entryPath.extension().string();
 							std::transform(ext.begin(), ext.end(), ext.begin(),
-								[](unsigned char c) { return std::tolower(c); });
+								[](unsigned char c) { return std::tolower(c); });*/
 
 							if (ext == ".obj" || ext == ".fbx" ||
 								ext == ".nanomat" ||
@@ -620,10 +620,10 @@ namespace Editor {
 						ImGui::PushID(subMeshName.c_str());
 
 						float submeshThumbnailSize = thumbnailSize * 0.8f;
-						unsigned int iconTexture = Assets::ThumbnailManager::GetInstance().GetThumbnail("submesh");
+						unsigned int submeshIconTexture = Assets::ThumbnailManager::GetInstance().GetThumbnail("submesh");
 
 						ImGui::ImageButton("##btn",
-							(ImTextureID)(intptr_t)iconTexture,
+							(ImTextureID)(intptr_t)submeshIconTexture,
 							ImVec2(submeshThumbnailSize, submeshThumbnailSize),
 							ImVec2(0, 1), ImVec2(1, 0)
 						);

--- a/NANOEngine/NANOEngine.vcxproj
+++ b/NANOEngine/NANOEngine.vcxproj
@@ -483,7 +483,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <TreatWarningAsError>false</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>$(ProjectDir)vendor\include;$(ProjectDir)src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)src</AdditionalIncludeDirectories>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -515,7 +515,8 @@ xcopy /y /d "$(ProjectDir)vendor\lib\fmod\*.dll" "$(SolutionDir)bin\Chrono\$(Con
       <LanguageStandard>stdcpp20</LanguageStandard>
       <TreatWarningAsError>false</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>$(ProjectDir)vendor\include;$(ProjectDir)src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)src</AdditionalIncludeDirectories>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -549,7 +550,8 @@ xcopy /Y "$(ProjectDir)vendor\lib\glfw\glfw3.dll" "$(SolutionDir)bin\Chrono\$(Co
       <LanguageStandard>stdcpp20</LanguageStandard>
       <TreatWarningAsError>false</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalIncludeDirectories>$(ProjectDir)vendor\include;$(ProjectDir)src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)src</AdditionalIncludeDirectories>
+      <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>

--- a/NANOEngine/src/Animation/AnimationClip.hpp
+++ b/NANOEngine/src/Animation/AnimationClip.hpp
@@ -89,20 +89,20 @@ namespace NE::Animation {
     };
 
 
-	class NANOENGINE_API AnimationClip final : public Resource::IResource {
+    class AnimationClip final : public Resource::IResource {
     public:
-		bool Preload(NE::Resource::BinaryView blob) override;
-		void Finalize() override;
+        NANOENGINE_API bool Preload(NE::Resource::BinaryView blob) override;
+        NANOENGINE_API void Finalize() override;
         static constexpr Resource::ResourceType GetStaticType() { return Resource::ResourceType::AnimationClip; }
-		Resource::ResourceType GetType() const override { return GetStaticType(); }
+        NANOENGINE_API Resource::ResourceType GetType() const override { return GetStaticType(); }
 
-        const std::string& GetName() const;
-        float GetLengthSeconds() const;
-		void SetLengthSeconds(float len);
-        bool IsLooping() const;
+        NANOENGINE_API const std::string& GetName() const;
+        NANOENGINE_API float GetLengthSeconds() const;
+        NANOENGINE_API void SetLengthSeconds(float len);
+        NANOENGINE_API bool IsLooping() const;
 
-        std::vector<AnimTrack>& GetTracksMutable();
-        const std::vector<AnimTrack>& GetTracks() const;
+        NANOENGINE_API std::vector<AnimTrack>& GetTracksMutable();
+        NANOENGINE_API const std::vector<AnimTrack>& GetTracks() const;
     private:
         struct ParsedAnimClip {
             const NE::Resource::NanoAnimClipHeader* hdr = nullptr;
@@ -116,5 +116,5 @@ namespace NE::Animation {
         bool looping;
 
         std::vector<AnimTrack> tracks;
-	};
+    };
 }

--- a/NANOEngine/src/Core/LUIDGenerator.hpp
+++ b/NANOEngine/src/Core/LUIDGenerator.hpp
@@ -9,9 +9,9 @@
 
 namespace NE::Core {
 
-	class NANOENGINE_API LUIDGenerator {
+	class LUIDGenerator {
 	public:
-		static uint64_t Generate(std::string_view);
+		NANOENGINE_API static uint64_t Generate(std::string_view);
 
 	private:
 		static uint32_t GetTimeInSeconds();

--- a/NANOEngine/src/Core/LayerRegistry.hpp
+++ b/NANOEngine/src/Core/LayerRegistry.hpp
@@ -18,21 +18,21 @@ namespace NE::Core {
 		std::array<LayerMask, MAX_LAYERS> collideWith{};
 	};
 
-	class NANOENGINE_API LayerRegistry {
+	class LayerRegistry {
 	public:
-		static LayerRegistry& GetInstance();
+		NANOENGINE_API static LayerRegistry& GetInstance();
 
-		LayerID CreateLayer(std::string_view name);
-		bool RenameLayer(LayerID id, std::string_view newName);
+		NANOENGINE_API LayerID CreateLayer(std::string_view name);
+		NANOENGINE_API bool RenameLayer(LayerID id, std::string_view newName);
 
-		bool SetCollision(LayerID a, LayerID b, bool enabled);
-		bool GetCollision(LayerID a, LayerID b) const;
-		LayerMask GetCollisionMask(LayerID a) const;
-		bool SetCollisionMask(LayerID a, LayerMask mask);
+		NANOENGINE_API bool SetCollision(LayerID a, LayerID b, bool enabled);
+		NANOENGINE_API bool GetCollision(LayerID a, LayerID b) const;
+		NANOENGINE_API LayerMask GetCollisionMask(LayerID a) const;
+		NANOENGINE_API bool SetCollisionMask(LayerID a, LayerMask mask);
 
-		bool IsUsed(LayerID id) const noexcept;
-		std::string_view GetName(LayerID id) const;
-		LayerID FindByName(std::string_view name) const;
+		NANOENGINE_API bool IsUsed(LayerID id) const noexcept;
+		NANOENGINE_API std::string_view GetName(LayerID id) const;
+		NANOENGINE_API LayerID FindByName(std::string_view name) const;
 
 		template<typename Fn>
 		void ForEachUsed(Fn&& fn) const {
@@ -43,7 +43,7 @@ namespace NE::Core {
 			}
 		}
 
-		const std::array<LayerMask, MAX_LAYERS>& GetCollisionMatrix() const noexcept;
+		NANOENGINE_API const std::array<LayerMask, MAX_LAYERS>& GetCollisionMatrix() const noexcept;
 
 	private:
 		LayerRegistry();

--- a/NANOEngine/src/ECS/Systems/ColliderSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/ColliderSystem.cpp
@@ -19,7 +19,7 @@ namespace NE::ECS::Systems {
 	void ColliderSystem::OnEntityAdded(Entity e) {
 		auto& meta = m_componentManager->GetComponent<Component::EntityMeta>(e);
 		auto& col = m_componentManager->GetComponent<Component::Collider>(e);
-		auto& t = m_componentManager->GetComponent<Component::Transform>(e);
+		//auto& t = m_componentManager->GetComponent<Component::Transform>(e);
 
 		if (col.luid == 0) {
 			col.luid = Core::LUIDGenerator::Generate("co");

--- a/NANOEngine/src/ECS/Systems/UIEventSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/UIEventSystem.cpp
@@ -66,7 +66,7 @@ namespace NE::ECS::Systems {
         return UIUtil::IsActiveForUI(m_cm, m_em, entity, canvasEntity);
     }
 
-    void UIEventSystem::OnEntityAdded(Entity e) {}
+    void UIEventSystem::OnEntityAdded(Entity) {}
 
     void UIEventSystem::OnEntityRemoved(Entity e) {
         if (e == m_hoveredEntity) {
@@ -817,7 +817,7 @@ namespace NE::ECS::Systems {
 
     Math::Mat4 UIEventSystem::BuildWorldSpaceModelMatrix(
         Entity entity,
-        Entity canvasEntity,
+        Entity /*canvasEntity*/,
         const Component::UIRectTransform& rect
     ) {
         // If UIRenderSystem already computed the world matrix this frame, reuse it
@@ -2014,7 +2014,7 @@ namespace NE::ECS::Systems {
         }
     }
 
-    void UIEventSystem::UpdateDropdowns(float mouseX, float mouseY, bool mousePressed, bool mouseReleased) {
+    void UIEventSystem::UpdateDropdowns(float /*mouseX*/, float /*mouseY*/, bool mousePressed, bool /*mouseReleased*/) {
         const auto& entities = GetEntities();
 
         // Handle clicks

--- a/NANOEngine/src/ECS/Systems/UIRenderSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/UIRenderSystem.cpp
@@ -512,7 +512,7 @@ namespace NE::ECS::Systems {
     void UIRenderSystem::SubmitUIElement(
         Entity entity,
         const UICanvas& canvas,
-        const UIImage& img,
+        const UIImage&,
         const UIRectTransform& rect,
         const std::vector<NE::Graphics::UIVertex2>& vertices,
         const std::optional<NE::Graphics::ScissorRect>& scissor
@@ -584,10 +584,10 @@ namespace NE::ECS::Systems {
     void UIRenderSystem::SubmitTextElement(
         Entity entity,
         const UICanvas& canvas,
-        const UIText& text,
+        const UIText&,
         const UIRectTransform& rect,
         const std::vector<NE::Graphics::UIVertex2>& vertices,
-        std::shared_ptr<NE::Graphics::FontAtlas> fontAtlas,
+        std::shared_ptr<NE::Graphics::FontAtlas>,
         const std::optional<NE::Graphics::ScissorRect>& scissor
     )
     {
@@ -863,7 +863,7 @@ namespace NE::ECS::Systems {
                 key.isWorldSpace = false;
                 key.enableDepthTest = false;
                 key.scissorRect = scissor;
-                key.sortingOrder = rect.z + canvas.sortingOrder * 1000.0f;
+                key.sortingOrder = static_cast<int>(rect.z + canvas.sortingOrder * 1000.0f);
 
                 UIBatch& batch = batchMap[key];
                 uint32_t baseVertex = static_cast<uint32_t>(batch.vertices.size());
@@ -887,7 +887,7 @@ namespace NE::ECS::Systems {
         }
 
         // Submit screen-space batches
-        m_frameSpriteBatches += batchMap.size();
+        m_frameSpriteBatches += static_cast<int>(batchMap.size());
         for (auto& [key, batch] : batchMap) {
             if (batch.vertices.empty()) continue;
             m_frameDrawCalls++;
@@ -1126,7 +1126,7 @@ namespace NE::ECS::Systems {
             key.isWorldSpace = false;
             key.enableDepthTest = false;
             key.scissorRect = scissor;
-            key.sortingOrder = rect.z + canvas.sortingOrder * 1000.0f;
+            key.sortingOrder = static_cast<int>(rect.z + canvas.sortingOrder * 1000.0f);
 
             UIBatch& batch = batchMap[key];
             uint32_t baseVertex = static_cast<uint32_t>(batch.vertices.size());
@@ -1142,7 +1142,7 @@ namespace NE::ECS::Systems {
         }
 
         // Submit screen-space text batches
-        m_frameTextBatches += batchMap.size();
+        m_frameTextBatches += static_cast<int>(batchMap.size());
         for (auto& [key, batch] : batchMap) {
             if (batch.vertices.empty()) continue;
             m_frameDrawCalls++;

--- a/NANOEngine/src/ECS/Systems/UIRenderSystem.hpp
+++ b/NANOEngine/src/ECS/Systems/UIRenderSystem.hpp
@@ -35,11 +35,11 @@ namespace NE::ECS::Systems {
 
     // Batch key for grouping UI elements into single draw calls
     struct UIBatchKey {
-        bool isText;
-        bool isWorldSpace;
-        bool enableDepthTest;
+        bool isText = false;
+        bool isWorldSpace = false;
+        bool enableDepthTest = false;
         std::optional<NE::Graphics::ScissorRect> scissorRect;
-        int sortingOrder;
+        int sortingOrder = 0;
 
         bool operator<(const UIBatchKey& other) const {
             if (sortingOrder != other.sortingOrder) return sortingOrder < other.sortingOrder;

--- a/NANOEngine/src/Engine.cpp
+++ b/NANOEngine/src/Engine.cpp
@@ -215,7 +215,7 @@ namespace NE {
 		gSceneManager.StartSceneFallback();
 	}
 
-	void CookPrefab(const ECS::Entity rootNode, const std::string& _artifactPath) {
+	void CookPrefab(const ECS::Entity, const std::string&) {
 		//NE::Serialization::SerializePrefab(GetScene().GetECSCoordinator(), rootNode, _artifactPath);
 	}
 
@@ -228,20 +228,20 @@ namespace NE {
 		return gSceneManager.GetActive()->GetECSCoordinator().GetUsedEntities();
 	}
 
-	 std::vector<uint32_t> DeserializePrefab(std::string prefabPath) {
+	 std::vector<uint32_t> DeserializePrefab(std::string /*prefabPath*/) {
 		 //auto newEntities = Serialization::JsonSceneSerializer::DeserializePrefab(*gSceneManager.GetActive(), prefabPath);
 		 //return newEntities;
 		 return std::vector<uint32_t>();
 	}
 
-	std::vector<uint32_t> DeserializePrefab(std::string prefabPath, std::string uuid) {
+	std::vector<uint32_t> DeserializePrefab(std::string /*prefabPath*/, std::string /*uuid*/) {
 		//auto newEntities = Serialization::JsonSceneSerializer::DeserializePrefab(*gSceneManager.GetActive(), prefabPath);
 		//Prefab::PrefabManager::Instantiate(uuid, newEntities);
 		//return newEntities;
 		return std::vector<uint32_t>();
 	}
 
-	std::vector<uint32_t> DeserializePrefab(std::string prefabPath, std::string uuid, Math::Vec3 pos) {
+	std::vector<uint32_t> DeserializePrefab(std::string /*prefabPath*/, std::string /*uuid*/, Math::Vec3 /*pos*/) {
 		//auto newEntities = Serialization::JsonSceneSerializer::DeserializePrefab(*gSceneManager.GetActive(), prefabPath, pos);
 		//Prefab::PrefabManager::Instantiate(uuid, newEntities);
 		//return newEntities;

--- a/NANOEngine/src/Graphics/Core/DrawQueue.cpp
+++ b/NANOEngine/src/Graphics/Core/DrawQueue.cpp
@@ -81,8 +81,8 @@ namespace NE::Graphics {
 		// Step 1: Sort by Render Queue Order (base + offset)
 		// Stable sort to maintain input order for same order items
 		std::stable_sort(m_Commands.begin(), m_Commands.end(), [](const DrawCommand& a, const DrawCommand& b) {
-			uint16_t orderA = a.material ? a.material->GetQueueOrder() : 0;
-			uint16_t orderB = b.material ? b.material->GetQueueOrder() : 0;
+			uint16_t orderA = static_cast<uint16_t>(a.material ? a.material->GetQueueOrder() : 0);
+			uint16_t orderB = static_cast<uint16_t>(b.material ? b.material->GetQueueOrder() : 0);
 			return orderA < orderB;
 			});
 

--- a/NANOEngine/src/Graphics/Core/Font.hpp
+++ b/NANOEngine/src/Graphics/Core/Font.hpp
@@ -9,18 +9,18 @@
 
 namespace NE::Graphics {
 
-	class NANOENGINE_API Font final : public Resource::IResource {
+	class  Font final : public Resource::IResource {
 	public:
-		bool Preload(NE::Resource::BinaryView blob) override;
-		void Finalize() override;
+		NANOENGINE_API bool Preload(NE::Resource::BinaryView blob) override;
+		NANOENGINE_API void Finalize() override;
 
-		static constexpr Resource::ResourceType GetStaticType() { return Resource::ResourceType::Font; }
-		Resource::ResourceType GetType() const override { return GetStaticType(); }
+		NANOENGINE_API static constexpr Resource::ResourceType GetStaticType() { return Resource::ResourceType::Font; }
+		NANOENGINE_API Resource::ResourceType GetType() const override { return GetStaticType(); }
 
-		const std::vector<uint8_t>& GetFontData() const { return m_fontData; }
-		float GetAscent100() const { return m_ascent100; }
-		float GetDescent100() const { return m_descent100; }
-		float GetLineHeight100() const { return m_lineHeight100; }
+		NANOENGINE_API const std::vector<uint8_t>& GetFontData() const { return m_fontData; }
+		NANOENGINE_API float GetAscent100() const { return m_ascent100; }
+		NANOENGINE_API float GetDescent100() const { return m_descent100; }
+		NANOENGINE_API float GetLineHeight100() const { return m_lineHeight100; }
 
 	private:
 		std::vector<uint8_t> m_fontData;

--- a/NANOEngine/src/Graphics/Core/PostProcessPipeline.cpp
+++ b/NANOEngine/src/Graphics/Core/PostProcessPipeline.cpp
@@ -1670,7 +1670,7 @@ namespace NE::Graphics {
 			m_graph->AddPass("Bloom: Upsample")
 				.Read(bloomDown0)
 				.Write(bloomTex)
-				.Execute([this](const RenderGraphContext& ctx) {
+				.Execute([this](const RenderGraphContext& /*ctx*/) {
 					if (!m_settings || !m_upSampleShader) return;
 
 					const GLboolean depthWasEnabled = glIsEnabled(GL_DEPTH_TEST);

--- a/NANOEngine/src/Graphics/Core/RenderGraph.hpp
+++ b/NANOEngine/src/Graphics/Core/RenderGraph.hpp
@@ -127,10 +127,10 @@ namespace NE::Graphics {
     //==========================================================================
     // RenderGraph - Main graph structure
     //==========================================================================
-    class NANOENGINE_API RenderGraph {
+    class RenderGraph {
     public:
         RenderGraph() = default;
-        ~RenderGraph();
+        NANOENGINE_API ~RenderGraph();
 
         // Non-copyable
         RenderGraph(const RenderGraph&) = delete;
@@ -145,49 +145,49 @@ namespace NE::Graphics {
         //----------------------------------------------------------------------
 
         // Import an existing texture (e.g., from a framebuffer attachment)
-        RenderGraphResource ImportTexture(uint32_t textureId, const std::string& name);
+        NANOENGINE_API RenderGraphResource ImportTexture(uint32_t textureId, const std::string& name);
 
         // Import an existing framebuffer
-        RenderGraphResource ImportFramebuffer(IFrameBuffer* fb, const std::string& name);
+        NANOENGINE_API RenderGraphResource ImportFramebuffer(IFrameBuffer* fb, const std::string& name);
 
         // Create a transient texture (lifetime managed by the graph)
-        RenderGraphResource CreateTexture(const TextureDesc& desc);
+        NANOENGINE_API RenderGraphResource CreateTexture(const TextureDesc& desc);
 
         //----------------------------------------------------------------------
         // Pass Registration
         //----------------------------------------------------------------------
 
         // Add a new render pass, returns builder for fluent configuration
-        RenderGraphBuilder AddPass(const std::string& name);
+        NANOENGINE_API RenderGraphBuilder AddPass(const std::string& name);
 
         //----------------------------------------------------------------------
         // Compilation & Execution
         //----------------------------------------------------------------------
 
         // Compile the graph: validate, compute execution order, allocate resources
-        void Compile();
+        NANOENGINE_API void Compile();
 
         // Execute all passes in dependency order
-        void Execute();
+        NANOENGINE_API void Execute();
 
         // Reset the graph for reuse (clears passes but keeps imported resources)
-        void Reset();
+        NANOENGINE_API void Reset();
 
         // Clear everything (passes and resources)
-        void Clear();
+        NANOENGINE_API void Clear();
 
         //----------------------------------------------------------------------
         // Resource Access (for use during pass execution)
         //----------------------------------------------------------------------
 
         // Get the OpenGL texture ID from a resource handle
-        uint32_t GetTexture(RenderGraphResource handle) const;
+        NANOENGINE_API uint32_t GetTexture(RenderGraphResource handle) const;
 
         // Get the framebuffer pointer from a resource handle
-        IFrameBuffer* GetFramebuffer(RenderGraphResource handle) const;
+        NANOENGINE_API IFrameBuffer* GetFramebuffer(RenderGraphResource handle) const;
 
         // Get the OpenGL framebuffer ID for a resource (0 if unavailable)
-        uint32_t GetFramebufferId(RenderGraphResource handle) const;
+        NANOENGINE_API uint32_t GetFramebufferId(RenderGraphResource handle) const;
 
         //----------------------------------------------------------------------
         // Query
@@ -221,11 +221,11 @@ namespace NE::Graphics {
         const std::vector<ResourceLifetime>& GetResourceLifetimes() const { return m_ResourceLifetimes; }
 
         // Get resource name by handle
-        const std::string& GetResourceName(RenderGraphResource handle) const;
+        NANOENGINE_API const std::string& GetResourceName(RenderGraphResource handle) const;
 
         // Get resource type string for display
-        static const char* GetResourceTypeString(ResourceType type);
-        static const char* GetTextureFormatString(TextureFormat format);
+        NANOENGINE_API static const char* GetResourceTypeString(ResourceType type);
+        NANOENGINE_API static const char* GetTextureFormatString(TextureFormat format);
 
     private:
         friend class RenderGraphBuilder;

--- a/NANOEngine/src/Graphics/Core/RenderGraph/TexturePool.hpp
+++ b/NANOEngine/src/Graphics/Core/RenderGraph/TexturePool.hpp
@@ -26,10 +26,10 @@ namespace NE::Graphics {
         size_t totalAllocated = 0;  // Lifetime allocation count
     };
 
-    class NANOENGINE_API TexturePool {
+    class TexturePool {
     public:
         TexturePool() = default;
-        ~TexturePool();
+        NANOENGINE_API ~TexturePool();
 
         // Non-copyable
         TexturePool(const TexturePool&) = delete;
@@ -37,16 +37,16 @@ namespace NE::Graphics {
 
         // Acquire a texture matching the description
         // Returns existing pooled texture if available, creates new otherwise
-        PooledTexture* Acquire(uint32_t width, uint32_t height, TextureFormat format);
+        NANOENGINE_API PooledTexture* Acquire(uint32_t width, uint32_t height, TextureFormat format);
 
         // Release a texture back to the pool for reuse
-        void Release(PooledTexture* texture);
+        NANOENGINE_API void Release(PooledTexture* texture);
 
         // Release all textures (marks all as available)
-        void ReleaseAll();
+        NANOENGINE_API void ReleaseAll();
 
         // Clear the pool (deletes all GPU resources)
-        void Clear();
+        NANOENGINE_API void Clear();
 
         // Get statistics
         const TexturePoolStats& GetStats() const { return m_Stats; }

--- a/NANOEngine/src/Graphics/Core/ShadowRenderer.cpp
+++ b/NANOEngine/src/Graphics/Core/ShadowRenderer.cpp
@@ -466,7 +466,7 @@ namespace NE::Graphics {
 		using NE::Math::Mat4;
 
 		const float n = std::max(0.01f, view.nearPlane);
-		const float f = std::max(n + 0.01f, view.farPlane);
+		//const float f = std::max(n + 0.01f, view.farPlane);
 
 		const float cascadeNear = (cascadeIdx == 0) ? n : light.dirCascadeSplitsVS[cascadeIdx - 1];
 		const float cascadeFar = light.dirCascadeSplitsVS[cascadeIdx];

--- a/NANOEngine/src/Physics/ContactListenerImpl.cpp
+++ b/NANOEngine/src/Physics/ContactListenerImpl.cpp
@@ -22,7 +22,7 @@ namespace NE::Physics {
     void ContactListenerImpl::OnContactAdded(
         const JPH::Body& body1,
         const JPH::Body& body2,
-        const JPH::ContactManifold& manifold,
+        const JPH::ContactManifold& /*manifold*/,
         JPH::ContactSettings&
     ) {
         if (!m_pm) return;
@@ -43,7 +43,7 @@ namespace NE::Physics {
     void ContactListenerImpl::OnContactPersisted(
         const JPH::Body& body1,
         const JPH::Body& body2,
-        const JPH::ContactManifold& manifold,
+        const JPH::ContactManifold& /*manifold*/,
         JPH::ContactSettings&
     ) {
         if (!m_pm) return;

--- a/NANOEngine/src/Physics/PhysicsManager.cpp
+++ b/NANOEngine/src/Physics/PhysicsManager.cpp
@@ -1022,15 +1022,15 @@ namespace NE::Physics {
 		}
 	}
 
-	void PhysicsManager::SetIsKinematic(uint64_t entityLUID, bool isKinematic) {
-		//auto it = m_bodies.find(entityLUID);
-		//if (it != m_bodies.end()) {
-		//	JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
-		//	JPH::BodyID bodyID = it->second;
-		//	JPH::EMotionType newMotion = isKinematic ? JPH::EMotionType::Kinematic : JPH::EMotionType::Dynamic;
-		//	bi.SetMotionType(bodyID, newMotion);
-		//}
-	}
+	//void PhysicsManager::SetIsKinematic(uint64_t entityLUID, bool isKinematic) {
+	//	//auto it = m_bodies.find(entityLUID);
+	//	//if (it != m_bodies.end()) {
+	//	//	JPH::BodyInterface& bi = m_physicsSystem->GetBodyInterface();
+	//	//	JPH::BodyID bodyID = it->second;
+	//	//	JPH::EMotionType newMotion = isKinematic ? JPH::EMotionType::Kinematic : JPH::EMotionType::Dynamic;
+	//	//	bi.SetMotionType(bodyID, newMotion);
+	//	//}
+	//}
 
 	bool PhysicsManager::CookMeshCollider(const std::vector<Math::Vec3>& vertices,
 		const std::vector<uint32_t>& indices, std::vector<uint8_t>& outBlob) {

--- a/NANOEngine/src/Scripting/ScriptAPI.cpp
+++ b/NANOEngine/src/Scripting/ScriptAPI.cpp
@@ -153,8 +153,8 @@ namespace NE {
 		}
 
 		// Context validation macro for consistent null-checking
-#define CHECK_CONTEXT_OR_RETURN(returnValue) \
-        if (!m_context || !m_context->componentManager) return returnValue
+#define CHECK_CONTEXT_OR_RETURN(...) \
+        if (!m_context || !m_context->componentManager) return __VA_ARGS__
 
 	//=========================================================================
 	// FIELD REGISTRY (PIMPL - Hide STL containers from DLL interface)
@@ -414,7 +414,7 @@ namespace NE {
 			return Vec3(m.Right());
 		}
 
-		Vec3 IScript::TF_GetUp(Entity entity) const {
+		Vec3 IScript::TF_GetUp(Entity /*entity*/) const {
 			// Up is always world up in this simple implementation
 			// For more complex scenarios, you might want to calculate it from forward and right
 			return Vec3(0.0f, 1.0f, 0.0f);
@@ -520,7 +520,7 @@ namespace NE {
 			return m_context->componentManager->GetComponent<ECS::Component::Rigidbody>(targetEntity).useGravity;
 		}
 
-		void IScript::RB_SetUseGravity(bool use, Entity entity) {
+		void IScript::RB_SetUseGravity(bool /*use*/, Entity /*entity*/) {
 			//Entity targetEntity = (entity == DEFAULT_ENTITY_PARAM) ? m_entity : entity;
 
 			//if (!Physics::PhysicsManager::EntityHasPhysicsBody(targetEntity)) return;
@@ -536,7 +536,7 @@ namespace NE {
 			//}
 		}
 
-		bool IScript::RB_IsStatic(Entity entity) const {
+		bool IScript::RB_IsStatic(Entity /*entity*/) const {
 			/*if (!m_context || !m_context->componentManager) return false;
 
 			Entity targetEntity = (entity == DEFAULT_ENTITY_PARAM) ? m_entity : entity;
@@ -548,7 +548,7 @@ namespace NE {
 			return false;
 		}
 
-		void IScript::RB_SetStatic(bool isStatic, Entity entity) {
+		void IScript::RB_SetStatic(bool /*isStatic*/, Entity /*entity*/) {
 			/*if (!m_context || !m_context->componentManager) return;
 
 			Entity targetEntity = (entity == DEFAULT_ENTITY_PARAM) ? m_entity : entity;
@@ -559,7 +559,7 @@ namespace NE {
 			}*/
 		}
 
-		void IScript::RB_LockRotation(bool lockX, bool lockY, bool lockZ, Entity entity) {
+		void IScript::RB_LockRotation(bool /*lockX*/, bool /*lockY*/, bool /*lockZ*/, Entity /*entity*/) {
 			/*Entity targetEntity = (entity == DEFAULT_ENTITY_PARAM) ? m_entity : entity;
 
 			if (!Physics::PhysicsManager::EntityHasPhysicsBody(targetEntity)) return;
@@ -782,8 +782,8 @@ namespace NE {
 				layerMask);
 		}
 
-		std::vector<RaycastHit> IScript::RaycastAll(const Vec3& origin, const Vec3& direction,
-			float maxDistance, uint32_t layerMask) const {
+		std::vector<RaycastHit> IScript::RaycastAll(const Vec3& /*origin*/, const Vec3& /*direction*/,
+			float /*maxDistance*/, uint32_t /*layerMask*/) const {
 			//std::vector<RaycastHit> results;
 
 			//if (!m_context || !m_context->componentManager) {
@@ -1336,7 +1336,7 @@ namespace NE {
 
 				return rootEntity;
 			} catch (const std::exception& e) {
-				SPD_ERROR("[PrefabRef] Exception during instantiation: {}", e.what());
+				SPD_ERROR("[PrefabRef] Exception during instantiation: " << e.what());
 				return INVALID_ENTITY;
 			} catch (...) {
 				SPD_ERROR("[PrefabRef] Unknown exception during prefab instantiation");
@@ -1913,7 +1913,7 @@ namespace NE {
 						//SPD_DEBUG("[MaterialRef] Successfully assigned material to field '{}'", name);
 						return true;
 					} catch (const std::exception& e) {
-						SPD_ERROR("[MaterialRef] setValue exception for field '{}': {}", name, e.what());
+						SPD_ERROR("[MaterialRef] setValue exception for field '" << name << "': " << e.what());
 						return false;
 					} catch (...) {
 						SPD_ERROR("[MaterialRef] setValue unknown exception for field '{}'", name);

--- a/NANOEngine/src/Scripting/ScriptingEngine.cpp
+++ b/NANOEngine/src/Scripting/ScriptingEngine.cpp
@@ -551,7 +551,7 @@ namespace NE::Scripting {
         }
     }
 
-    bool ScriptingEngine::SwapDLLs(const std::string& oldDllPath, const std::string& newDllPath) {
+    bool ScriptingEngine::SwapDLLs(const std::string& /*oldDllPath*/, const std::string& newDllPath) {
         if (IsScriptDLLLoaded()) {
             if (!UnloadScriptDLL()) {
                 SPD_ERROR("Failed to unload old DLL. Attempting to load new one anyway...");
@@ -592,10 +592,10 @@ namespace NE::Scripting {
             // Parse comma-separated script names (for multi-script support)
             std::vector<std::string> scriptNamesToRestore;
             std::stringstream ss(state.scriptName);
-            std::string scriptName;
-            while (std::getline(ss, scriptName, ',')) {
-                if (!scriptName.empty()) {
-                    scriptNamesToRestore.push_back(scriptName);
+            std::string parsedName;
+            while (std::getline(ss, parsedName, ',')) {
+                if (!parsedName.empty()) {
+                    scriptNamesToRestore.push_back(parsedName);
                 }
             }
 
@@ -688,7 +688,7 @@ namespace NE::Scripting {
         SPD_INFO("=== HOT RELOAD COMPLETE ===");
     }
 
-    void ScriptingEngine::SaveSerializedFields(NE::ECS::Component::NativeScript& nsc) {
+    void ScriptingEngine::SaveSerializedFields(NE::ECS::Component::NativeScript& /*nsc*/) {
         // This function is problematic because it relies on pointer comparison to find the entity.
         // Use the overload that takes entity ID directly instead.
         SPD_ERROR("SaveSerializedFields(nsc) called without entity ID - this may not work correctly!");
@@ -725,7 +725,7 @@ namespace NE::Scripting {
         }
     }
 
-    void ScriptingEngine::RestoreSerializedFields(NE::ECS::Component::NativeScript& nsc) {
+    void ScriptingEngine::RestoreSerializedFields(NE::ECS::Component::NativeScript& /*nsc*/) {
         // This function is problematic because it relies on pointer comparison to find the entity.
         // Use the overload that takes entity ID directly instead.
         SPD_ERROR("RestoreSerializedFields(nsc) called without entity ID - this may not work correctly!");
@@ -766,7 +766,6 @@ namespace NE::Scripting {
     }
     
     void ScriptingEngine::OnScriptComponentDestroyed(NE::ECS::Entity entity) {
-        auto& nsc = GetScene().GetECSCoordinator().GetComponentManager().GetComponent<ECS::Component::NativeScript>(entity);
         auto it = m_scriptInstances.find(entity);
         if (it != m_scriptInstances.end()) {
             for (IScript* instance : it->second) {

--- a/NANOEngine/src/pch.h
+++ b/NANOEngine/src/pch.h
@@ -24,7 +24,9 @@
 
 // Windows headers (when on Windows)
 #ifdef _WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Expose API symbols and clean up compiler warnings across the codebase. Key changes:

- Added NANOENGINE_API to many class methods and destructors (AnimationClip, Font, RenderGraph, TexturePool, RenderGraph APIs, LayerRegistry, LUIDGenerator, etc.) to properly export symbols.
- Silenced unused-parameter and unused-variable warnings by removing names, commenting out unused locals, or using /*...*/ parameter names in many cpp files (Engine, UIEventSystem, UIRenderSystem, ScriptAPI, ScriptingEngine, ContactListenerImpl, ShadowRenderer, PhysicsManager, ColliderSystem).
- Initialized UIBatchKey members with defaults and made sortingOrder an int with explicit static_casts where needed; cast sizes/indices to avoid implicit narrowing.
- Minor logic/UI fixes: AssetBrowserPanel variable renames and commented-out extension handling, thumbnail icon variable rename, AnimationPanel removed unused drawing math, DrawQueue queue order casts, PostProcess lambda param unused.
- Project and build tweaks: removed vendor\include from AdditionalIncludeDirectories in NANOEngine.vcxproj and added ExternalWarningLevel entries for some configs.
- pch.h: protect NOMINMAX define with #ifndef to avoid redefinition.
- Misc: commented-out physics SetIsKinematic implementation, adjusted logging calls to use stream-style concatenation where needed.

These changes are primarily focused on linking/ABI correctness and reducing compiler noise; no major behavioral changes are intended.