### PR TITLE
Extract LightShadowRuntime and use RenderLightRef

### DIFF
--- a/Editor/src/Panels/InspectorPanel.cpp
+++ b/Editor/src/Panels/InspectorPanel.cpp
@@ -1598,8 +1598,6 @@ namespace Editor {
 					comp.data.emplace<Light::AreaLightData>();
 					break;
 				}
-
-				comp.isDirty = true;
 			}
 		}
 

--- a/NANOEngine/src/ECS/Components/Light.hpp
+++ b/NANOEngine/src/ECS/Components/Light.hpp
@@ -97,20 +97,6 @@ namespace NE::ECS::Component {
         ShadowType shadowType = ShadowType::None;
         ShadowUpdateMode shadowUpdateMode = ShadowUpdateMode::NoneUpdate;
 
-        uint32_t shadowMapTex = 0;
-        uint32_t shadowMapFBO = 0;
-        int shadowMapRes = 0;
-        Math::Mat4 lightViewProj{};
-        int shadowIndex = -1;
-        bool shadowBaked = false;
-
-        std::array<uint32_t, DIR_CASCADES> dirShadowTex{};  // 0-init
-        std::array<uint32_t, DIR_CASCADES> dirShadowFBO{};  // 0-init
-        std::array<Math::Mat4, DIR_CASCADES> dirLightVP{};
-        std::array<float, DIR_CASCADES> dirCascadeSplitsVS{}; // view-space split depths (positive, in world units)
-        uint8_t shadowCascadeCount = 0;
-        int dirShadowRes[DIR_CASCADES] = { 0,0,0,0 };
-
         NE_REFLECT_BEGIN(Light)
             NE_REFLECT_FIELD_HIDDEN(type),
             NE_REFLECT_FIELD_HIDDEN(data),

--- a/NANOEngine/src/ECS/Systems/LightSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/LightSystem.cpp
@@ -61,7 +61,7 @@ namespace NE::ECS::Systems {
                 auto& light = m_componentManager->GetComponent<Component::Light>(entity);
                 light.position = t.worldMatrix.GetTranslation();
                 light.direction = t.worldMatrix.Forward();
-                Graphics::GraphicsManager::m_lights.push_back(&light);
+                Graphics::GraphicsManager::m_lights.push_back({ entity, &light });
 
 #ifndef PRODUCTION_BUILD
                 Graphics::LightGizmoCommand gizmoCommand{};

--- a/NANOEngine/src/Graphics/Core/GraphicsManager.cpp
+++ b/NANOEngine/src/Graphics/Core/GraphicsManager.cpp
@@ -1000,7 +1000,7 @@ namespace NE::Graphics {
     uint32_t GraphicsManager::s_ScreenHeight = 1080;
 	uint32_t GraphicsManager::s_GameViewWidth = 1920;
 	uint32_t GraphicsManager::s_GameViewHeight = 1080;
-    std::vector<ECS::Component::Light*> GraphicsManager::m_lights;
+    std::vector<RenderLightRef> GraphicsManager::m_lights;
     int GraphicsManager::drawCount = 0;
     bool GraphicsManager::enableSorting = true;
 
@@ -1200,45 +1200,51 @@ namespace NE::Graphics {
             std::vector<GLuint>     shadowTextures;
             shadowVPs.reserve(MAX_SHADOWS);
             shadowTextures.reserve(MAX_SHADOWS);
-            ECS::Component::Light* dirForSplits = nullptr;
+            RenderLightRef* dirForSplits = nullptr;
 
             int shadowCount = 0;
-            for (auto* l : m_lights) {
+            for (auto& lightRef : m_lights) {
+                auto* l = lightRef.light;
                 if (!l) continue;
-                l->shadowIndex = -1;
+
+                LightShadowRuntime* runtime = s_shadowRenderer ? s_shadowRenderer->FindRuntime(lightRef.entity) : nullptr;
+                if (runtime) {
+                    runtime->shadowIndex = -1;
+                }
 
                 if (l->shadowType == NE::ECS::Component::Light::None) continue;
+                if (!runtime) continue;
 
                 // Directional CSM
                 if (l->type == NE::ECS::Component::Light::Directional && 
-                    l->shadowCascadeCount == NE::ECS::Component::Light::DIR_CASCADES) 
+                    runtime->shadowCascadeCount == NE::ECS::Component::Light::DIR_CASCADES) 
                 {
                     if (shadowCount + NE::ECS::Component::Light::DIR_CASCADES > MAX_SHADOWS) continue;
 
-                    if (!dirForSplits) dirForSplits = l;
+                    if (!dirForSplits) dirForSplits = &lightRef;
 
-                    l->shadowIndex = shadowCount;
+                    runtime->shadowIndex = shadowCount;
                     for (int c = 0; c < NE::ECS::Component::Light::DIR_CASCADES; ++c) {
-                        shadowVPs.push_back(l->dirLightVP[c]);
-                        shadowTextures.push_back(l->dirShadowTex[c]);
+                        shadowVPs.push_back(runtime->dirLightVP[c]);
+                        shadowTextures.push_back(runtime->dirShadowTex[c]);
                         ++shadowCount;
                     }
                     continue;
                 }
 
                 // Single-map (Spot)
-                if (l->shadowMapTex != 0 && l->shadowCascadeCount == 1) {
+                if (runtime->shadowMapTex != 0 && runtime->shadowCascadeCount == 1) {
                     if (shadowCount >= MAX_SHADOWS) continue;
-                    l->shadowIndex = shadowCount;
-                    shadowVPs.push_back(l->lightViewProj);
-                    shadowTextures.push_back(l->shadowMapTex);
+                    runtime->shadowIndex = shadowCount;
+                    shadowVPs.push_back(runtime->lightViewProj);
+                    shadowTextures.push_back(runtime->shadowMapTex);
                     ++shadowCount;
                 }
             }
 
             RenderView viewForLighting = view;
             viewForLighting.projection = camProj;
-            s_clusteredLighting->BuildForView(viewForLighting, m_lights);
+            s_clusteredLighting->BuildForView(viewForLighting, *s_shadowRenderer, m_lights);
 
             // Prepare instance data buffer and batching variables
             std::vector<InstanceData> instanceData;
@@ -1290,11 +1296,14 @@ namespace NE::Graphics {
                 float dirSplits[NE::ECS::Component::Light::DIR_CASCADES] = {};
 
                 if (dirForSplits) {
+                    const LightShadowRuntime* dirRuntime = s_shadowRenderer ? s_shadowRenderer->FindRuntime(dirForSplits->entity) : nullptr;
                     // Directional cascade splits are derived from the active view, so one upload
                     // is shared across directional lights in the current renderer design.
-                    dirCascadeCount = dirForSplits->shadowCascadeCount;
-                    for (int c = 0; c < NE::ECS::Component::Light::DIR_CASCADES; ++c)
-                        dirSplits[c] = dirForSplits->dirCascadeSplitsVS[c];
+                    if (dirRuntime) {
+                        dirCascadeCount = dirRuntime->shadowCascadeCount;
+                        for (int c = 0; c < NE::ECS::Component::Light::DIR_CASCADES; ++c)
+                            dirSplits[c] = dirRuntime->dirCascadeSplitsVS[c];
+                    }
                 }
 
                 shader->SetUniformInt("i_DirCascadeCount", dirCascadeCount);
@@ -1918,6 +1927,10 @@ namespace NE::Graphics {
             s_PostPipeline->Shutdown();
             s_PostPipeline.reset();
         }
+        if (s_shadowRenderer) {
+            s_shadowRenderer->Shutdown();
+            s_shadowRenderer.reset();
+        }
 		s_RenderViewManager->Shutdown();
         s_skybox.reset();
         s_CommandBuffer.reset();
@@ -1932,6 +1945,7 @@ namespace NE::Graphics {
         s_DecalGizmoMaterial.reset();
         s_DecalCubeMesh.reset();
         s_DecalQueue.clear();
+        m_lights.clear();
         s_NormalPrepassShader.reset();
 #ifndef PRODUCTION_BUILD
         s_EditorDebugViewShader.reset();

--- a/NANOEngine/src/Graphics/Core/GraphicsManager.hpp
+++ b/NANOEngine/src/Graphics/Core/GraphicsManager.hpp
@@ -11,6 +11,7 @@
 #include "DecalCommand.hpp"
 #include "DecalGizmoCommand.hpp"
 #include "DrawQueue.hpp"
+#include "LightShadowRuntime.hpp"
 #include "RenderViewManager.hpp"
 #include "RenderSettings.hpp"
 #include "PostProcessingSettings.hpp"
@@ -146,7 +147,7 @@ namespace NE::Graphics {
         static void ClearSelectedEntities();
 
         // lights
-        static std::vector<ECS::Component::Light*> m_lights;
+        static std::vector<RenderLightRef> m_lights;
 
         // Draw Count Profiling
         static int drawCount;

--- a/NANOEngine/src/Graphics/Core/LightShadowRuntime.hpp
+++ b/NANOEngine/src/Graphics/Core/LightShadowRuntime.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "ECS/Core/Entity.hpp"
+#include "ECS/Components/Light.hpp"
+#include "Math/Mat4.hpp"
+
+namespace NE::Graphics {
+    struct RenderLightRef {
+        ECS::Entity entity = ECS::NO_ENTITY;
+        ECS::Component::Light* light = nullptr;
+    };
+
+    struct LightShadowRuntime {
+        static constexpr int DIR_CASCADES = ECS::Component::Light::DIR_CASCADES;
+
+        uint32_t shadowMapTex = 0;
+        uint32_t shadowMapFBO = 0;
+        int shadowMapRes = 0;
+        Math::Mat4 lightViewProj{};
+        int shadowIndex = -1;
+        bool shadowBaked = false;
+
+        std::array<uint32_t, DIR_CASCADES> dirShadowTex{};
+        std::array<uint32_t, DIR_CASCADES> dirShadowFBO{};
+        std::array<Math::Mat4, DIR_CASCADES> dirLightVP{};
+        std::array<float, DIR_CASCADES> dirCascadeSplitsVS{};
+        uint8_t shadowCascadeCount = 0;
+        std::array<int, DIR_CASCADES> dirShadowRes{};
+    };
+}

--- a/NANOEngine/src/Graphics/Core/ShadowRenderer.cpp
+++ b/NANOEngine/src/Graphics/Core/ShadowRenderer.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
+#include <unordered_set>
 
 #include <glad/glad.h>
 
@@ -156,6 +157,21 @@ namespace NE::Graphics {
 			return dirs;
 		}
 
+		inline void DeleteTexture(uint32_t& id) {
+			if (id != 0) {
+				GLuint glId = id;
+				glDeleteTextures(1, &glId);
+				id = 0;
+			}
+		}
+
+		inline void DeleteFramebuffer(uint32_t& id) {
+			if (id != 0) {
+				GLuint glId = id;
+				glDeleteFramebuffers(1, &glId);
+				id = 0;
+			}
+		}
 	}
 
 	void ShadowRenderer::Init() {
@@ -166,15 +182,22 @@ namespace NE::Graphics {
 	}
 
 	void ShadowRenderer::Update(const RenderView& view,
-		std::vector<ECS::Component::Light*>& lights,
+		const std::vector<RenderLightRef>& lights,
 		const std::vector<DrawCommand>& commands
 	) {
 #ifndef PRODUCTION_BUILD
 		NE_PROFILE_FUNCTION();
 #endif
+		PruneUnusedRuntimes(lights);
+
 		if (lights.empty() || commands.empty()) return;
 
-		for (auto& light : lights) {
+		for (const auto& lightRef : lights) {
+			ECS::Component::Light* light = lightRef.light;
+			if (!light) continue;
+
+			LightShadowRuntime& runtime = GetOrCreateRuntime(lightRef.entity);
+
 			if (light->shadowType == ECS::Component::Light::ShadowType::None ||
 				light->type == ECS::Component::Light::Type::Point)
 				continue;
@@ -184,67 +207,119 @@ namespace NE::Graphics {
 				continue;
 
 			case ECS::Component::Light::ShadowUpdateMode::StaticBake:
-				if (light->shadowBaked)
+				if (runtime.shadowBaked)
 					continue;
 				break;
 
 			case ECS::Component::Light::ShadowUpdateMode::Realtime:
+				runtime.shadowBaked = false;
 				break;
 			}
 
 			if (light->type == ECS::Component::Light::Directional) {
-				EnsureResources2D(*light);
+				EnsureResources2D(*light, runtime);
 
-				ComputeDirectionalSplits(view, *light);
+				ComputeDirectionalSplits(view, runtime);
 				for (int c = 0; c < ECS::Component::Light::DIR_CASCADES; ++c) {
-					Math::Mat4 vp = BuildDirectionalCascadeVP(view, *light, c);
-					light->dirLightVP[c] = vp;
-					RenderDepthDirectionalCascade(*light, c, vp, commands);
+					Math::Mat4 vp = BuildDirectionalCascadeVP(view, *light, runtime, c);
+					runtime.dirLightVP[c] = vp;
+					RenderDepthDirectionalCascade(runtime, c, vp, commands);
 				}
 
-				light->shadowCascadeCount = ECS::Component::Light::DIR_CASCADES;
+				runtime.shadowCascadeCount = ECS::Component::Light::DIR_CASCADES;
 
 				if (light->shadowUpdateMode == ECS::Component::Light::ShadowUpdateMode::StaticBake)
-					light->shadowBaked = true;
+					runtime.shadowBaked = true;
 
 				continue;
 			}
 
-			EnsureResources2D(*light);
+			EnsureResources2D(*light, runtime);
 
 			Math::Mat4 lightVP = BuildLightVP(*light);
-			light->lightViewProj = lightVP;
-			light->shadowCascadeCount = 1;
-			RenderDepth(*light, lightVP, commands);
+			runtime.lightViewProj = lightVP;
+			runtime.shadowCascadeCount = 1;
+			RenderDepth(runtime, lightVP, commands);
 
 			if (light->shadowUpdateMode == ECS::Component::Light::ShadowUpdateMode::StaticBake)
-				light->shadowBaked = true;
+				runtime.shadowBaked = true;
 		}
 	}
 
+	LightShadowRuntime* ShadowRenderer::FindRuntime(ECS::Entity entity) {
+		auto it = m_lightShadowRuntime.find(entity);
+		return it != m_lightShadowRuntime.end() ? &it->second : nullptr;
+	}
+
+	const LightShadowRuntime* ShadowRenderer::FindRuntime(ECS::Entity entity) const {
+		auto it = m_lightShadowRuntime.find(entity);
+		return it != m_lightShadowRuntime.end() ? &it->second : nullptr;
+	}
+
 	void  ShadowRenderer::Shutdown() {
+		for (auto& [_, runtime] : m_lightShadowRuntime) {
+			ReleaseRuntimeResources(runtime);
+		}
+		m_lightShadowRuntime.clear();
 		m_shadowShader.reset();
 	}
 
-	void ShadowRenderer::EnsureResources2D(ECS::Component::Light& light) {
+	LightShadowRuntime& ShadowRenderer::GetOrCreateRuntime(ECS::Entity entity) {
+		return m_lightShadowRuntime[entity];
+	}
+
+	void ShadowRenderer::PruneUnusedRuntimes(const std::vector<RenderLightRef>& lights) {
+		std::unordered_set<ECS::Entity> activeLights;
+		activeLights.reserve(lights.size());
+
+		for (const auto& lightRef : lights) {
+			if (lightRef.light) {
+				activeLights.insert(lightRef.entity);
+			}
+		}
+
+		for (auto it = m_lightShadowRuntime.begin(); it != m_lightShadowRuntime.end();) {
+			if (activeLights.find(it->first) != activeLights.end()) {
+				++it;
+				continue;
+			}
+
+			ReleaseRuntimeResources(it->second);
+			it = m_lightShadowRuntime.erase(it);
+		}
+	}
+
+	void ShadowRenderer::ReleaseRuntimeResources(LightShadowRuntime& runtime) {
+		DeleteTexture(runtime.shadowMapTex);
+		DeleteFramebuffer(runtime.shadowMapFBO);
+
+		for (int c = 0; c < LightShadowRuntime::DIR_CASCADES; ++c) {
+			DeleteTexture(runtime.dirShadowTex[c]);
+			DeleteFramebuffer(runtime.dirShadowFBO[c]);
+		}
+
+		runtime = LightShadowRuntime{};
+	}
+
+	void ShadowRenderer::EnsureResources2D(const ECS::Component::Light& light, LightShadowRuntime& runtime) {
 		if (light.type == ECS::Component::Light::Directional) {
 			for (int c = 0; c < ECS::Component::Light::DIR_CASCADES; ++c) {
-				if (light.dirShadowTex[c] == 0)
-					glGenTextures(1, &light.dirShadowTex[c]);
+				if (runtime.dirShadowTex[c] == 0)
+					glGenTextures(1, &runtime.dirShadowTex[c]);
 
-				if (light.dirShadowFBO[c] == 0)
-					glGenFramebuffers(1, &light.dirShadowFBO[c]);
+				if (runtime.dirShadowFBO[c] == 0)
+					glGenFramebuffers(1, &runtime.dirShadowFBO[c]);
 
-				bool needsAlloc = (light.dirShadowRes[c] != m_shadowRes);
+				bool needsAlloc = (runtime.dirShadowRes[c] != m_shadowRes);
 
-				glBindTexture(GL_TEXTURE_2D, light.dirShadowTex[c]);
+				glBindTexture(GL_TEXTURE_2D, runtime.dirShadowTex[c]);
 
 				if (needsAlloc) {
 					glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24,
 						m_shadowRes, m_shadowRes, 0,
 						GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
 
-					light.dirShadowRes[c] = m_shadowRes;
+					runtime.dirShadowRes[c] = m_shadowRes;
 
 					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -257,9 +332,9 @@ namespace NE::Graphics {
 
 				glBindTexture(GL_TEXTURE_2D, 0);
 
-				glBindFramebuffer(GL_FRAMEBUFFER, light.dirShadowFBO[c]);
+				glBindFramebuffer(GL_FRAMEBUFFER, runtime.dirShadowFBO[c]);
 				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-					GL_TEXTURE_2D, light.dirShadowTex[c], 0);
+					GL_TEXTURE_2D, runtime.dirShadowTex[c], 0);
 
 				glDrawBuffer(GL_NONE);
 				glReadBuffer(GL_NONE);
@@ -275,22 +350,22 @@ namespace NE::Graphics {
 			return;
 		}
 
-		if (light.shadowMapTex == 0)
-			glGenTextures(1, &light.shadowMapTex);
+		if (runtime.shadowMapTex == 0)
+			glGenTextures(1, &runtime.shadowMapTex);
 
-		if (light.shadowMapFBO == 0)
-			glGenFramebuffers(1, &light.shadowMapFBO);
+		if (runtime.shadowMapFBO == 0)
+			glGenFramebuffers(1, &runtime.shadowMapFBO);
 
-		const bool needsAlloc = (light.shadowMapRes != m_shadowRes);
+		const bool needsAlloc = (runtime.shadowMapRes != m_shadowRes);
 
-		glBindTexture(GL_TEXTURE_2D, light.shadowMapTex);
+		glBindTexture(GL_TEXTURE_2D, runtime.shadowMapTex);
 
 		if (needsAlloc) {
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24,
 				m_shadowRes, m_shadowRes, 0,
 				GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
 
-			light.shadowMapRes = m_shadowRes;
+			runtime.shadowMapRes = m_shadowRes;
 
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -303,9 +378,9 @@ namespace NE::Graphics {
 
 		glBindTexture(GL_TEXTURE_2D, 0);
 
-		glBindFramebuffer(GL_FRAMEBUFFER, light.shadowMapFBO);
+		glBindFramebuffer(GL_FRAMEBUFFER, runtime.shadowMapFBO);
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-			GL_TEXTURE_2D, light.shadowMapTex, 0);
+			GL_TEXTURE_2D, runtime.shadowMapTex, 0);
 		glDrawBuffer(GL_NONE);
 		glReadBuffer(GL_NONE);
 
@@ -353,10 +428,10 @@ namespace NE::Graphics {
 		}
 	}
 
-	void ShadowRenderer::RenderDepth(ECS::Component::Light& light, const Math::Mat4& lightVP,
+	void ShadowRenderer::RenderDepth(const LightShadowRuntime& runtime, const Math::Mat4& lightVP,
 		const std::vector<DrawCommand>& commands
 	) {
-		glBindFramebuffer(GL_FRAMEBUFFER, light.shadowMapFBO);
+		glBindFramebuffer(GL_FRAMEBUFFER, runtime.shadowMapFBO);
 
 		glViewport(0, 0, m_shadowRes, m_shadowRes);
 
@@ -393,12 +468,12 @@ namespace NE::Graphics {
 	}
 
 	void ShadowRenderer::RenderDepthDirectionalCascade(
-		ECS::Component::Light& light,
+		const LightShadowRuntime& runtime,
 		int cascadeIdx,
 		const NE::Math::Mat4& lightVP,
 		const std::vector<DrawCommand>& commands
 	) {
-		GLuint fbo = light.dirShadowFBO[cascadeIdx];
+		GLuint fbo = runtime.dirShadowFBO[cascadeIdx];
 		glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 
 		glViewport(0, 0, m_shadowRes, m_shadowRes);
@@ -436,7 +511,7 @@ namespace NE::Graphics {
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	}
 
-	void ShadowRenderer::ComputeDirectionalSplits(const RenderView& view, ECS::Component::Light& light) {
+	void ShadowRenderer::ComputeDirectionalSplits(const RenderView& view, LightShadowRuntime& runtime) {
 		constexpr int C = ECS::Component::Light::DIR_CASCADES;
 
 		const float n = std::max(0.01f, view.nearPlane);
@@ -453,21 +528,22 @@ namespace NE::Graphics {
 
 			float split = uniSplit * (1.0f - lambda) + logSplit * lambda;
 
-			light.dirCascadeSplitsVS[i] = split;
+			runtime.dirCascadeSplitsVS[i] = split;
 		}
 	}
 
 	NE::Math::Mat4 ShadowRenderer::BuildDirectionalCascadeVP(
 		const RenderView& view,
 		const ECS::Component::Light& light,
+		const LightShadowRuntime& runtime,
 		int cascadeIdx
 	) {
 		using NE::Math::Vec3;
 		using NE::Math::Mat4;
 
 		const float n = std::max(0.01f, view.nearPlane);
-		const float cascadeNear = (cascadeIdx == 0) ? n : light.dirCascadeSplitsVS[cascadeIdx - 1];
-		const float cascadeFar = light.dirCascadeSplitsVS[cascadeIdx];
+		const float cascadeNear = (cascadeIdx == 0) ? n : runtime.dirCascadeSplitsVS[cascadeIdx - 1];
+		const float cascadeFar = runtime.dirCascadeSplitsVS[cascadeIdx];
 
 		Mat4 invProj = view.projection.Inverse();
 		Mat4 invView = view.view.Inverse();

--- a/NANOEngine/src/Graphics/Core/ShadowRenderer.hpp
+++ b/NANOEngine/src/Graphics/Core/ShadowRenderer.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
+#include <unordered_map>
 #include <vector>
 #include <memory>
 
+#include "LightShadowRuntime.hpp"
+
 namespace NE {
-	namespace ECS {
-		namespace Component {
-			struct Light;
-		}
-	}
 	namespace Graphics {
 		struct RenderView;
 		struct DrawCommand;
@@ -27,25 +25,31 @@ namespace NE::Graphics {
 	public:
 		void Init();
 		void Update(const RenderView& view,
-			std::vector<ECS::Component::Light*>& lights,
+			const std::vector<RenderLightRef>& lights,
 			const std::vector<DrawCommand>& commands);
+		LightShadowRuntime* FindRuntime(ECS::Entity entity);
+		const LightShadowRuntime* FindRuntime(ECS::Entity entity) const;
 
 		void Shutdown();
 
 	private:
-		void EnsureResources2D(ECS::Component::Light& light);
+		LightShadowRuntime& GetOrCreateRuntime(ECS::Entity entity);
+		void PruneUnusedRuntimes(const std::vector<RenderLightRef>& lights);
+		void ReleaseRuntimeResources(LightShadowRuntime& runtime);
+		void EnsureResources2D(const ECS::Component::Light& light, LightShadowRuntime& runtime);
 		Math::Mat4 BuildLightVP(const ECS::Component::Light& light);
-		void RenderDepth(ECS::Component::Light& light,
+		void RenderDepth(const LightShadowRuntime& runtime,
 			const Math::Mat4& lightVP,
 			const std::vector<DrawCommand>& commands);
 
-		void RenderDepthDirectionalCascade(ECS::Component::Light& light, int cascadeIdx, const NE::Math::Mat4& lightVP, const std::vector<DrawCommand>& commands);
+		void RenderDepthDirectionalCascade(const LightShadowRuntime& runtime, int cascadeIdx, const NE::Math::Mat4& lightVP, const std::vector<DrawCommand>& commands);
 
-		void ComputeDirectionalSplits(const RenderView& view, ECS::Component::Light& light);
+		void ComputeDirectionalSplits(const RenderView& view, LightShadowRuntime& runtime);
 
-		NE::Math::Mat4 BuildDirectionalCascadeVP(const RenderView& view, const ECS::Component::Light& light, int cascadeIdx);
+		NE::Math::Mat4 BuildDirectionalCascadeVP(const RenderView& view, const ECS::Component::Light& light, const LightShadowRuntime& runtime, int cascadeIdx);
 
 		std::shared_ptr<OpenGL::GLShader> m_shadowShader;
+		std::unordered_map<ECS::Entity, LightShadowRuntime> m_lightShadowRuntime;
 		int m_shadowRes = 2048;
 		float m_directionalShadowDistance = 60.0f;
 	};

--- a/NANOEngine/src/Graphics/Interfaces/IClusteredLighting.hpp
+++ b/NANOEngine/src/Graphics/Interfaces/IClusteredLighting.hpp
@@ -1,15 +1,13 @@
 #pragma once
 #include <vector>
 
+#include "../Core/LightShadowRuntime.hpp"
+
 // Forward declarations
 namespace NE {
-	namespace ECS {
-		namespace Component {
-			struct Light;
-		}
-	}
 	namespace Graphics {
 		struct RenderView;
+		class ShadowRenderer;
 	}
 }
 
@@ -19,7 +17,7 @@ namespace NE::Graphics {
 		virtual ~IClusteredLighting() = default;
 
 		// Per view per frame
-		virtual void BuildForView(const Graphics::RenderView& view, const std::vector<ECS::Component::Light*>& lights) = 0;
+		virtual void BuildForView(const Graphics::RenderView& view, const ShadowRenderer& shadowRenderer, const std::vector<RenderLightRef>& lights) = 0;
 
 		// Called before drawing geometry (so forward shaders can read SSBOs/UBOs)
 		virtual void BindForDraw() = 0;

--- a/NANOEngine/src/Graphics/OpenGL/GLClusteredLighting.cpp
+++ b/NANOEngine/src/Graphics/OpenGL/GLClusteredLighting.cpp
@@ -2,6 +2,7 @@
 #include "GLClusteredLighting.hpp"
 
 #include "../Core/RenderViewManager.hpp"
+#include "../Core/ShadowRenderer.hpp"
 #include "../../ECS/Components/Light.hpp"
 #include "ResourceManagement/ResourceManager.hpp"
 #include "../Interfaces/IShader.hpp"
@@ -122,7 +123,7 @@ namespace NE::Graphics::OpenGL {
         }
     }
 
-	void GLClusteredLighting::BuildForView(const Graphics::RenderView& view, const std::vector<ECS::Component::Light*>& lights)
+	void GLClusteredLighting::BuildForView(const Graphics::RenderView& view, const ShadowRenderer& shadowRenderer, const std::vector<RenderLightRef>& lights)
 	{
         if (!m_countShader || !m_fillShader) {
             return;
@@ -135,7 +136,7 @@ namespace NE::Graphics::OpenGL {
             m_numLightsThisView = maxLights;
         }
 
-        UploadLights(view, lights);
+        UploadLights(view, shadowRenderer, lights);
 
         const int numClusters = clustersX * clustersY * clustersZ;
 		// Early out if no lights
@@ -235,7 +236,7 @@ namespace NE::Graphics::OpenGL {
         glBindBufferBase(GL_UNIFORM_BUFFER, 3, m_clusterParamsUBO);
 	}
 
-    void GLClusteredLighting::UploadLights(const Graphics::RenderView& view, const std::vector<ECS::Component::Light*>& lights)
+    void GLClusteredLighting::UploadLights(const Graphics::RenderView& view, const ShadowRenderer& shadowRenderer, const std::vector<RenderLightRef>& lights)
     {
         using NE::Math::Mat4;
         using NE::Math::Vec3;
@@ -244,13 +245,18 @@ namespace NE::Graphics::OpenGL {
         m_gpuLightsCPU.clear();
         m_gpuLightsCPU.reserve(m_numLightsThisView);
 
-
-        auto pushLight = [&](const ECS::Component::Light* src,
+        auto pushLight = [&](const RenderLightRef& lightRef,
             float intensity,
             float radius,
             float innerCos,
             float outerCos)
             {
+                const ECS::Component::Light* src = lightRef.light;
+                if (!src) {
+                    return;
+                }
+
+                const LightShadowRuntime* runtime = shadowRenderer.FindRuntime(lightRef.entity);
                 GPULightCPU dst{};
 
                 dst.position[0] = src->position.x;
@@ -266,7 +272,7 @@ namespace NE::Graphics::OpenGL {
                 dst.params[0] = innerCos;
                 dst.params[1] = outerCos;
                 dst.params[2] = radius; // range/radius
-                dst.params[3] = (float)src->shadowIndex;
+                dst.params[3] = runtime ? static_cast<float>(runtime->shadowIndex) : -1.0f;
 
                 auto dir = src->direction.Normalized();
                 dst.direction[0] = dir.x;
@@ -278,7 +284,11 @@ namespace NE::Graphics::OpenGL {
         };
 
 		for (int i = 0; i < m_numLightsThisView; ++i) {
-			const auto* src = lights[i];
+			const auto& lightRef = lights[i];
+			const auto* src = lightRef.light;
+            if (!src) {
+                continue;
+            }
             // Extract per-type values from variant
             bool keep = true;
 
@@ -319,7 +329,7 @@ namespace NE::Graphics::OpenGL {
 
             if (!keep) continue;
 
-            pushLight(src, intensity, radius, innerCos, outerCos);
+            pushLight(lightRef, intensity, radius, innerCos, outerCos);
 
             if (static_cast<int>(m_gpuLightsCPU.size()) >= maxLights)
                 break;

--- a/NANOEngine/src/Graphics/OpenGL/GLClusteredLighting.hpp
+++ b/NANOEngine/src/Graphics/OpenGL/GLClusteredLighting.hpp
@@ -9,13 +9,9 @@
 
 // Forward declarations
 namespace NE {
-    namespace ECS {
-        namespace Component {
-            struct Light;
-		}
-    }
     namespace Graphics {
 		struct RenderView;
+        class ShadowRenderer;
         namespace OpenGL {
             class GLShader;
         }
@@ -33,18 +29,18 @@ namespace NE::Graphics::OpenGL {
 
     class GLClusteredLighting final : public IClusteredLighting {
     public:
-		GLClusteredLighting(
+        GLClusteredLighting(
             int cX = CLUSTERED_LIGHTING_SIZE_X, int cY = CLUSTERED_LIGHTING_SIZE_Y, int cZ = CLUSTERED_LIGHTING_SIZE_Z,
 			int maxLights = MAX_LIGHTS_PER_VIEW, int avgClustersPerLight = AVERAGE_CLUSTERS_PER_LIGHT
         );
 		~GLClusteredLighting();
 
-        void BuildForView(const Graphics::RenderView& view, const std::vector<ECS::Component::Light*>& lights) override;
+        void BuildForView(const Graphics::RenderView& view, const ShadowRenderer& shadowRenderer, const std::vector<RenderLightRef>& lights) override;
         void BindForDraw() override;
 
     private:
 
-        void UploadLights(const Graphics::RenderView& view, const std::vector<ECS::Component::Light*>& lights);
+        void UploadLights(const Graphics::RenderView& view, const ShadowRenderer& shadowRenderer, const std::vector<RenderLightRef>& lights);
 
 		bool EnsureBufferCapacity(uint32_t required);
 


### PR DESCRIPTION
Introduce LightShadowRuntime and RenderLightRef to separate GL/runtime shadow data from the ECS Light component. Removed shadow-related fields from Light (shadow maps, FBOs, VP matrices, cascade data) and moved them into Graphics/Core/LightShadowRuntime.hpp. ShadowRenderer now manages per-entity runtimes (unordered_map), lifecycle (GetOrCreateRuntime, FindRuntime, PruneUnusedRuntimes, ReleaseRuntimeResources), and resource allocation/deletion; its Update/Render methods were adapted to use runtimes. GraphicsManager and GLClusteredLighting APIs were updated to use RenderLightRef lists and to pass the ShadowRenderer where needed. LightSystem now pushes RenderLightRef entries (entity + light ptr). Misc: cleared m_lights on shutdown, removed a redundant comp.isDirty set in the editor, and adjusted clustering/shadow data uploads to read runtime shadow indices and splits. This decouples ECS data from GL resources and centralizes shadow resource management.