### PR TITLE
Add chromatic aberration scripting API

### DIFF
--- a/NANOEngine/include/ScriptSDK/ScriptAPI.h
+++ b/NANOEngine/include/ScriptSDK/ScriptAPI.h
@@ -1573,6 +1573,15 @@ namespace Scripting {
     SCRIPT_API float GetAmbientIntensity();
     SCRIPT_API void SetAmbientIntensity(float intensity);
 
+    // Chromatic Aberration Settings
+	SCRIPT_API void ToggleChromaticAberration(bool _enabled);
+    // Default Value (1.0f)
+	SCRIPT_API void SetChromaticAberrationStrength(float _strength);
+    // Default Value (0.6f)
+	SCRIPT_API void SetChromaticAberrationRadius(float _radius);
+    // Default Value (2.0f)
+	SCRIPT_API void SetChromaticAberrationFalloff(float _falloff);
+
     // Fog Settings
     SCRIPT_API bool IsFogEnabled();
     SCRIPT_API void SetFogEnabled(bool enabled);

--- a/NANOEngine/src/Scripting/ScriptAPI.cpp
+++ b/NANOEngine/src/Scripting/ScriptAPI.cpp
@@ -44,6 +44,7 @@
 #include "../EditorInterface/RendererExports.hpp"  // For RenderSettings access
 #include "../EditorInterface/AudioExports.hpp"  
 #include "../Graphics/Core/RenderSettings.hpp"  // For RenderSettings struct
+#include "Graphics/Core/PostProcessingSettings.hpp"
 
 #include <sstream>
 #include <unordered_map>
@@ -4216,6 +4217,27 @@ namespace NE {
 		void SetAmbientIntensity(float intensity) {
 			auto& settings = Renderer::Command::GetRenderSettings();
 			settings.ambientIntensity = intensity;
+		}
+
+		// Chromatic Aberration Settings
+		void ToggleChromaticAberration(bool _enabled) {
+			auto& settings = Renderer::Command::GetPostProcessingSettings();
+			settings.chromaticAberrationSettings.enabled = _enabled;
+		}
+
+		void SetChromaticAberrationStrength(float _strength) {
+			auto& settings = Renderer::Command::GetPostProcessingSettings();
+			settings.chromaticAberrationSettings.strengthPx = _strength;
+		}
+
+		void SetChromaticAberrationRadius(float _radius) {
+			auto& settings = Renderer::Command::GetPostProcessingSettings();
+			settings.chromaticAberrationSettings.startRadius = _radius;
+		}
+
+		void SetChromaticAberrationFalloff(float _falloff) {
+			auto& settings = Renderer::Command::GetPostProcessingSettings();
+			settings.chromaticAberrationSettings.falloffExponent = _falloff;
 		}
 
 		// Fog Settings


### PR DESCRIPTION
Expose chromatic aberration controls to the scripting API by adding four new functions (ToggleChromaticAberration, SetChromaticAberrationStrength, SetChromaticAberrationRadius, SetChromaticAberrationFalloff) in the ScriptAPI header and implementing them in the CPP. Also include Graphics/Core/PostProcessingSettings.hpp and update Renderer::Command::GetPostProcessingSettings() fields (enabled, strengthPx, startRadius, falloffExponent). Header documents default values for strength (1.0), radius (0.6) and falloff (2.0).