### PR TITLE
Split StopAndClearSounds from Shutdown

### DIFF
--- a/NANOEngine/src/ECS/Systems/AudioSystem.cpp
+++ b/NANOEngine/src/ECS/Systems/AudioSystem.cpp
@@ -44,20 +44,31 @@ namespace NE::ECS::Systems {
 				SPD_INFO("AudioEngine destructor (already shut down: " << (system == nullptr) << ")");
 			}
 
-			void Shutdown()
+			// Call during scene transitions: stops all sounds and clears cache but keeps
+			// the Core system alive so subsequent AudioSystem instances can reuse it.
+			void StopAndClearSounds()
 			{
 				if (!system) return;
-				SPD_INFO("AudioEngine::Shutdown - releasing sounds and closing FMOD core");
+				SPD_INFO("AudioEngine::StopAndClearSounds - releasing sounds (core stays alive)");
 				for (auto& [path, sound] : loadedClips) {
 					sound->release();
 				}
 				loadedClips.clear();
+			}
+
+			// Full teardown - only call once at true process exit (not on scene transitions).
+			void Shutdown()
+			{
+				if (!system) return;
+				SPD_INFO("AudioEngine::Shutdown - closing FMOD core");
+				StopAndClearSounds();
 				system->close();
 				system->release();
 				system = nullptr;
 			}
 
 			FMOD::Sound* LoadSound(const std::string& filepath, bool loop = false, bool is3D = false) {
+				if (!system) return nullptr;
 				std::string cacheKey = filepath + (is3D ? "|3D" : "|2D");
 				if (loadedClips.find(cacheKey) != loadedClips.end()) {
 					return loadedClips[cacheKey];
@@ -570,7 +581,10 @@ namespace NE::ECS::Systems {
 		}
 		m_entityInstances.clear();
 
-		GetAudioEngine().Shutdown();
+		// Release sounds but keep the Core alive — the Core is process-wide and must
+		// survive scene transitions. Calling Shutdown() here would null the Core and
+		// crash any subsequent AudioSystem that tries to load legacy audio files.
+		GetAudioEngine().StopAndClearSounds();
 		CleanupStudioSystem();
 		SPD_INFO("AudioSystem shutdown");
 	}


### PR DESCRIPTION
Introduce StopAndClearSounds() to release loaded sounds and clear the clip cache while keeping the FMOD core alive, and make Shutdown() a full teardown that closes and releases the core (it now calls StopAndClearSounds()). Add a null-check in LoadSound() to avoid dereferencing a closed core. Replace a scene-transition call to Shutdown() with StopAndClearSounds() to prevent nulling the process-wide audio core and subsequent crashes, and update log messages accordingly.